### PR TITLE
Remove the Monero build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,8 @@ jobs:
 
       - name: Monero cache
         id: cache-monerod
-        with: actions/cache@v3
+        uses: actions/cache@v3
+        with:
           path: monerod
           key: monerod-${{ runner.os }}-${{ runner.arch }}-v0.17.3.2
 
@@ -143,7 +144,8 @@ jobs:
           sudo apt install build-essential libboost-all-dev
 
       - name: Monero cache
-        with: actions/cache@v3
+        uses: actions/cache@v3
+        with:
           path: monerod
           key: monerod-${{ runner.os }}-${{ runner.arch }}-v0.17.3.2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,27 @@ jobs:
           sudo apt update
           sudo apt install build-essential libboost-all-dev
 
+      - name: Monero cache
+        id: cache-monerod
+        with: actions/cache@v3
+          path: monerod
+          key: monerod-${{ runner.os }}-${{ runner.arch }}-v0.17.3.2
+
+      - name: Download the Monero Daemon
+        if: steps.cache-monerod.cache-hit != 'true'
+        # Calculates OS/ARCH to demonstrate it, yet then locks to linux-x64 due
+        # to the contained folder not following the same naming scheme and
+        # requiring further expansion not worth doing right now
+        run: |
+          RUNNER_OS=${{ runner.os }}
+          RUNNER_ARCH=${{ runner.arch }}
+          OS_ARCH=${RUNNER_OS,,}-${RUNNER_ARCH,,}
+          OS_ARCH=linux-x64
+
+          wget https://downloads.getmonero.org/cli/monero-$OS_ARCH-v0.17.3.2.tar.bz2
+          tar -xvf monero-$OS_ARCH-v0.17.3.2.tar.bz2
+          mv monero-x86_64-linux-gnu-v0.17.3.2/monerod monerod
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -116,11 +137,18 @@ jobs:
         with:
           version: nightly
 
-      - name: Monero Regtest Daemon
+      - name: Install Monero Dependencies
         run: |
-          wget https://downloads.getmonero.org/cli/monero-linux-x64-v0.17.3.2.tar.bz2
-          tar -xvf monero-linux-x64-v0.17.3.2.tar.bz2
-          ./monero-x86_64-linux-gnu-v0.17.3.2/monerod --regtest --offline --fixed-difficulty=1 --detach
+          sudo apt update
+          sudo apt install build-essential libboost-all-dev
+
+      - name: Monero cache
+        with: actions/cache@v3
+          path: monerod
+          key: monerod-${{ runner.os }}-${{ runner.arch }}-v0.17.3.2
+
+      - name: Monero Regtest Daemon
+        run: ./monerod --regtest --offline --fixed-difficulty=1 --detach
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,27 +8,29 @@ on:
 
 jobs:
   monero-daemon:
-    - name: Monero cache
-      id: cache-monerod
-      uses: actions/cache@v3
-      with:
-        path: monerod
-        key: monerod-${{ runner.os }}-${{ runner.arch }}-v0.17.3.2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Monero cache
+        id: cache-monerod
+        uses: actions/cache@v3
+        with:
+          path: monerod
+          key: monerod-${{ runner.os }}-${{ runner.arch }}-v0.17.3.2
 
-    - name: Download the Monero Daemon
-      if: steps.cache-monerod.cache-hit != 'true'
-      # Calculates OS/ARCH to demonstrate it, yet then locks to linux-x64 due
-      # to the contained folder not following the same naming scheme and
-      # requiring further expansion not worth doing right now
-      run: |
-        RUNNER_OS=${{ runner.os }}
-        RUNNER_ARCH=${{ runner.arch }}
-        OS_ARCH=${RUNNER_OS,,}-${RUNNER_ARCH,,}
-        OS_ARCH=linux-x64
+      - name: Download the Monero Daemon
+        if: steps.cache-monerod.cache-hit != 'true'
+        # Calculates OS/ARCH to demonstrate it, yet then locks to linux-x64 due
+        # to the contained folder not following the same naming scheme and
+        # requiring further expansion not worth doing right now
+        run: |
+          RUNNER_OS=${{ runner.os }}
+          RUNNER_ARCH=${{ runner.arch }}
+          OS_ARCH=${RUNNER_OS,,}-${RUNNER_ARCH,,}
+          OS_ARCH=linux-x64
 
-        wget https://downloads.getmonero.org/cli/monero-$OS_ARCH-v0.17.3.2.tar.bz2
-        tar -xvf monero-$OS_ARCH-v0.17.3.2.tar.bz2
-        mv monero-x86_64-linux-gnu-v0.17.3.2/monerod monerod
+          wget https://downloads.getmonero.org/cli/monero-$OS_ARCH-v0.17.3.2.tar.bz2
+          tar -xvf monero-$OS_ARCH-v0.17.3.2.tar.bz2
+          mv monero-x86_64-linux-gnu-v0.17.3.2/monerod monerod
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Monero Dependencies
         run: |
           sudo apt update
-          sudo apt install build-essential libboost-all-dev
+          sudo apt install build-essential libboost-all-dev libsodium-dev
 
       - name: Monero cache
         id: cache-monerod
@@ -89,7 +89,7 @@ jobs:
       - name: Install Monero Dependencies
         run: |
           sudo apt update
-          sudo apt install build-essential libboost-all-dev
+          sudo apt install build-essential libboost-all-dev libsodium-dev
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -141,7 +141,7 @@ jobs:
       - name: Install Monero Dependencies
         run: |
           sudo apt update
-          sudo apt install build-essential libboost-all-dev
+          sudo apt install build-essential libboost-all-dev libsodium-dev
 
       - name: Monero cache
         uses: actions/cache@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,12 +46,17 @@ jobs:
       - name: Monero cache
         uses: actions/cache@v3
         with:
-          path: |
-            ./coins/monero/c/.build
-            ./coins/monero/c/monero/build
+          path: ./coins/monero/c/monero/build
           # Hash src, as theoretically, a different version of Monero warranting
           # a rebuild would've changed *something* under src
           key: ${{ runner.os }}-${{ hashFiles('./coins/monero/c/monero/src') }}
+
+      # We could download a Monero binary here instead
+      - name: Build Monero
+        run: |
+          cd coins/monero/c/monero
+          make
+          cd ../../../..
 
       - name: Cargo/Rust cache
         uses: actions/cache@v3
@@ -101,15 +106,6 @@ jobs:
           profile: minimal
           target: wasm32-unknown-unknown
 
-      # Grab the Monero cache since it'll be unaffected by Rust versioning
-      - name: Monero cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ./coins/monero/c/.build
-            ./coins/monero/c/monero/build
-          key: ${{ runner.os }}-${{ hashFiles('./coins/monero/c/monero/src') }}
-
       # Define a separate cache for nightly Rust
       - name: Cargo/Rust nightly cache
         uses: actions/cache@v3
@@ -141,7 +137,7 @@ jobs:
         with:
           version: nightly
 
-      - name: Install Monero Dependencies
+      - name: Install Monero Runtime Dependencies
         run: |
           sudo apt update
           sudo apt install libboost-all-dev libssl-dev libzmq3-dev libpgm-dev \
@@ -164,9 +160,7 @@ jobs:
       - name: Monero cache
         uses: actions/cache@v3
         with:
-          path: |
-            ./coins/monero/c/.build
-            ./coins/monero/c/monero/build
+          path: ./coins/monero/c/monero/build
           key: ${{ runner.os }}-${{ hashFiles('./coins/monero/c/monero/src') }}
 
       - name: Cargo/Rust cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
           key: monerod-${{ runner.os }}-${{ runner.arch }}-v0.17.3.2
 
       - name: Download the Monero Daemon
-        if: steps.cache-monerod.cache-hit != 'true'
+        if: steps.cache-monerod.outputs.cache-hit != 'true'
         # Calculates OS/ARCH to demonstrate it, yet then locks to linux-x64 due
         # to the contained folder not following the same naming scheme and
         # requiring further expansion not worth doing right now

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,29 @@ on:
   pull_request:
 
 jobs:
+  monero-daemon:
+    - name: Monero cache
+      id: cache-monerod
+      uses: actions/cache@v3
+      with:
+        path: monerod
+        key: monerod-${{ runner.os }}-${{ runner.arch }}-v0.17.3.2
+
+    - name: Download the Monero Daemon
+      if: steps.cache-monerod.cache-hit != 'true'
+      # Calculates OS/ARCH to demonstrate it, yet then locks to linux-x64 due
+      # to the contained folder not following the same naming scheme and
+      # requiring further expansion not worth doing right now
+      run: |
+        RUNNER_OS=${{ runner.os }}
+        RUNNER_ARCH=${{ runner.arch }}
+        OS_ARCH=${RUNNER_OS,,}-${RUNNER_ARCH,,}
+        OS_ARCH=linux-x64
+
+        wget https://downloads.getmonero.org/cli/monero-$OS_ARCH-v0.17.3.2.tar.bz2
+        tar -xvf monero-$OS_ARCH-v0.17.3.2.tar.bz2
+        mv monero-x86_64-linux-gnu-v0.17.3.2/monerod monerod
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -24,28 +47,6 @@ jobs:
         run: |
           sudo apt update
           sudo apt install build-essential libboost-all-dev libsodium-dev
-
-      - name: Monero cache
-        id: cache-monerod
-        uses: actions/cache@v3
-        with:
-          path: monerod
-          key: monerod-${{ runner.os }}-${{ runner.arch }}-v0.17.3.2
-
-      - name: Download the Monero Daemon
-        if: steps.cache-monerod.cache-hit != 'true'
-        # Calculates OS/ARCH to demonstrate it, yet then locks to linux-x64 due
-        # to the contained folder not following the same naming scheme and
-        # requiring further expansion not worth doing right now
-        run: |
-          RUNNER_OS=${{ runner.os }}
-          RUNNER_ARCH=${{ runner.arch }}
-          OS_ARCH=${RUNNER_OS,,}-${RUNNER_ARCH,,}
-          OS_ARCH=linux-x64
-
-          wget https://downloads.getmonero.org/cli/monero-$OS_ARCH-v0.17.3.2.tar.bz2
-          tar -xvf monero-$OS_ARCH-v0.17.3.2.tar.bz2
-          mv monero-x86_64-linux-gnu-v0.17.3.2/monerod monerod
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -121,7 +122,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [monero-daemon, build]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,9 +23,7 @@ jobs:
       - name: Install Monero Dependencies
         run: |
           sudo apt update
-          sudo apt install build-essential cmake pkg-config libboost-all-dev \
-                           libssl-dev libzmq3-dev libpgm-dev libunbound-dev \
-                           libsodium-dev ccache
+          sudo apt install build-essential libboost-all-dev
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -40,23 +38,6 @@ jobs:
           toolchain: nightly
           profile: minimal
           target: wasm32-unknown-unknown
-
-      # Cache everything, not only for performance, yet to export these to the
-      # following jobs
-      - name: Monero cache
-        uses: actions/cache@v3
-        with:
-          path: ./coins/monero/c/monero/build
-          # Hash src, as theoretically, a different version of Monero warranting
-          # a rebuild would've changed *something* under src
-          key: ${{ runner.os }}-${{ hashFiles('./coins/monero/c/monero/src') }}
-
-      # We could download a Monero binary here instead
-      - name: Build Monero
-        run: |
-          cd coins/monero/c/monero
-          make
-          cd ../../../..
 
       - name: Cargo/Rust cache
         uses: actions/cache@v3
@@ -86,9 +67,7 @@ jobs:
       - name: Install Monero Dependencies
         run: |
           sudo apt update
-          sudo apt install build-essential cmake pkg-config libboost-all-dev \
-                           libssl-dev libzmq3-dev libpgm-dev libunbound-dev \
-                           libsodium-dev ccache
+          sudo apt install build-essential libboost-all-dev
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -137,11 +116,11 @@ jobs:
         with:
           version: nightly
 
-      - name: Install Monero Runtime Dependencies
+      - name: Monero Regtest Daemon
         run: |
-          sudo apt update
-          sudo apt install libboost-all-dev libssl-dev libzmq3-dev libpgm-dev \
-                           libunbound-dev libsodium-dev
+          wget https://downloads.getmonero.org/cli/monero-linux-x64-v0.17.3.2.tar.bz2
+          tar -xvf monero-linux-x64-v0.17.3.2.tar.bz2
+          ./monero-x86_64-linux-gnu-v0.17.3.2/monerod --regtest --offline --fixed-difficulty=1 --detach
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -157,12 +136,6 @@ jobs:
           profile: minimal
           target: wasm32-unknown-unknown
 
-      - name: Monero cache
-        uses: actions/cache@v3
-        with:
-          path: ./coins/monero/c/monero/build
-          key: ${{ runner.os }}-${{ hashFiles('./coins/monero/c/monero/src') }}
-
       - name: Cargo/Rust cache
         uses: actions/cache@v3
         with:
@@ -170,9 +143,6 @@ jobs:
             ~/.cargo
             ./target
           key: ${{ runner.os }}-cargo-rust
-
-      - name: Monero Regtest Daemon
-        run: ./coins/monero/c/monero/build/release/bin/monerod --regtest --offline --fixed-difficulty=1 --detach
 
       - name: Run tests
         run: cargo test --all-features

--- a/coins/monero/build.rs
+++ b/coins/monero/build.rs
@@ -1,4 +1,4 @@
-use std::{env, path::Path, process::Command};
+use std::process::Command;
 
 fn main() {
   if !Command::new("git")
@@ -8,71 +8,6 @@ fn main() {
     .success()
   {
     panic!("git failed to init submodules");
-  }
-
-  if !Command::new("mkdir")
-    .args(&["-p", ".build"])
-    .current_dir(&Path::new("c"))
-    .status()
-    .unwrap()
-    .success()
-  {
-    panic!("failed to create a directory to track build progress");
-  }
-
-  let out_dir = &env::var("OUT_DIR").unwrap();
-
-  // Use a file to signal if Monero was already built, as that should never be rebuilt
-  // If the signaling file was deleted, run this script again to rebuild Monero though
-  println!("cargo:rerun-if-changed=c/.build/monero");
-  if !Path::new("c/.build/monero").exists() {
-    if !Command::new("mkdir")
-      .args(&["-p", "build/release"])
-      .current_dir(&Path::new("c/monero"))
-      .status()
-      .unwrap()
-      .success()
-    {
-      panic!("failed to mkdir");
-    }
-
-    if !Command::new("cmake")
-      .args(&[
-        "-D",
-        &format!("ARCH={}", &env::var("ARCH").unwrap_or_else(|_| "native".to_string())),
-        "-D",
-        "BUILD_TESTS=OFF",
-        "-D",
-        "CMAKE_BUILD_TYPE=Release",
-        "../..",
-      ])
-      .current_dir(&Path::new("c/monero/build/release"))
-      .status()
-      .unwrap()
-      .success()
-    {
-      panic!("failed to call cmake. Please check your dependencies");
-    }
-
-    if !Command::new("make")
-      .arg(format!("-j{}", &env::var("THREADS").unwrap_or_else(|_| "2".to_string())))
-      .current_dir(&Path::new("c/monero/build/release"))
-      .status()
-      .unwrap()
-      .success()
-    {
-      panic!("make failed to build Monero. Please check your dependencies");
-    }
-
-    if !Command::new("touch")
-      .arg("monero")
-      .current_dir(&Path::new("c/.build"))
-      .status()
-      .unwrap()
-      .success()
-    {
-      panic!("failed to create a file to label Monero as built");
-    }
   }
 
   println!("cargo:rerun-if-changed=c/wrapper.cpp");
@@ -101,9 +36,6 @@ fn main() {
     .file("c/monero/src/crypto/keccak.c")
     .file("c/monero/src/crypto/hash.c")
 
-    .include("c/monero/src/device")
-    .file("c/monero/src/device/device_default.cpp")
-
     .include("c/monero/src/ringct")
     .file("c/monero/src/ringct/rctCryptoOps.c")
     .file("c/monero/src/ringct/rctTypes.cpp")
@@ -115,7 +47,6 @@ fn main() {
     .file("c/wrapper.cpp")
     .compile("wrapper");
 
-  println!("cargo:rustc-link-search={}", out_dir);
   println!("cargo:rustc-link-lib=wrapper");
   println!("cargo:rustc-link-lib=stdc++");
 }

--- a/coins/monero/c/wrapper.cpp
+++ b/coins/monero/c/wrapper.cpp
@@ -1,7 +1,5 @@
 #include <mutex>
 
-#include "device/device_default.hpp"
-
 #include "ringct/bulletproofs.h"
 #include "ringct/rctSigs.h"
 


### PR DESCRIPTION
The Monero codebase is still downloaded and built against. It's no longer independently built.

The CI now downloads monerod to reduce OS dependencies and shrink the cache.