### PR TITLE
Implement Bulletproofs in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4581,6 +4581,7 @@ dependencies = [
  "modular-frost",
  "monero",
  "monero-epee-bin-serde",
+ "multiexp",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,22 @@ members = [
   "contracts/multisig",
 ]
 
+# Always compile Monero (and a variety of dependencies) with optimizations due
+# to the unoptimized performance of Bulletproofs
+[profile.dev.package]
+subtle = { opt-level = 3 }
+curve25519-dalek = { opt-level = 3 }
+
+ff = { opt-level = 3 }
+group = { opt-level = 3 }
+
+crypto-bigint = { opt-level = 3 }
+dalek-ff-group = { opt-level = 3 }
+
+multiexp = { opt-level = 3 }
+
+monero-serai = { opt-level = 3 }
+
 [profile.release]
 panic = "unwind"
 

--- a/coins/monero/Cargo.toml
+++ b/coins/monero/Cargo.toml
@@ -28,6 +28,7 @@ curve25519-dalek = { version = "3", features = ["std"] }
 
 group = { version = "0.12" }
 dalek-ff-group = { path = "../../crypto/dalek-ff-group" }
+multiexp = { path = "../../crypto/multiexp" }
 
 transcript = { package = "flexible-transcript", path = "../../crypto/transcript", features = ["recommended"], optional = true }
 frost = { package = "modular-frost", path = "../../crypto/frost", features = ["ed25519"], optional = true }

--- a/coins/monero/src/ringct/bulletproofs/core.rs
+++ b/coins/monero/src/ringct/bulletproofs/core.rs
@@ -40,7 +40,7 @@ lazy_static! {
   static ref H: EdwardsPoint = EdwardsPoint(*DALEK_H);
 
   pub(crate) static ref ONE_N: ScalarVector = ScalarVector(vec![Scalar::one(); MAX_N]);
-  pub(crate) static ref TWO_N: ScalarVector = ScalarVector(vec![Scalar::from(2u8); MAX_N]);
+  pub(crate) static ref TWO_N: ScalarVector = vector_powers(Scalar::from(2u8), MAX_N);
   pub(crate) static ref IP12: Scalar = inner_product(&*ONE_N, &*TWO_N);
 
   static ref H_i: Vec<EdwardsPoint> = (0 .. MAX_MN).map(|g| generator(g * 2)).collect();
@@ -198,18 +198,22 @@ pub(crate) fn prove<R: RngCore + CryptoRng>(rng: &mut R, commitments: &[Commitme
 
     let aL = a_prime.slice(.. n_prime);
     let aR = a_prime.slice(n_prime ..);
+    assert_eq!(aL.len(), aR.len());
 
     let bL = b_prime.slice(.. n_prime);
     let bR = b_prime.slice(n_prime ..);
+    assert_eq!(bL.len(), bR.len());
 
     let cL = inner_product(&aL, &bR);
     let cR = inner_product(&aR, &bL);
 
     let G_L = G_prime[.. n_prime].to_vec();
     let G_R = G_prime[n_prime ..].to_vec();
+    assert_eq!(G_L.len(), G_R.len());
 
     let H_L = H_prime[.. n_prime].to_vec();
     let H_R = H_prime[n_prime ..].to_vec();
+    assert_eq!(H_L.len(), H_R.len());
 
     let mut L_i_s = aL.0.iter().cloned().zip(G_R.iter().cloned()).chain(
       bR.0.iter().cloned().zip(H_L.iter().cloned())

--- a/coins/monero/src/ringct/bulletproofs/core.rs
+++ b/coins/monero/src/ringct/bulletproofs/core.rs
@@ -244,7 +244,10 @@ pub(crate) fn prove<R: RngCore + CryptoRng>(rng: &mut R, commitments: &[Commitme
   assert_eq!(a_prime.len(), n_prime);
   assert_eq!(b_prime.len(), n_prime);
 
-  let yinvpow = vector_powers(y.invert().unwrap(), MN);
+  let yinv = y.invert().unwrap();
+  let yinvpow = vector_powers(yinv, MN);
+  debug_assert_eq!(yinvpow[0], Scalar::one());
+  debug_assert_eq!(yinvpow[1], yinv);
 
   let mut L = Vec::with_capacity(logMN);
   let mut R = Vec::with_capacity(logMN);

--- a/coins/monero/src/ringct/bulletproofs/core.rs
+++ b/coins/monero/src/ringct/bulletproofs/core.rs
@@ -49,7 +49,7 @@ lazy_static! {
   static ref H: EdwardsPoint = EdwardsPoint(*DALEK_H);
   pub(crate) static ref ONE_N: ScalarVector = ScalarVector(vec![Scalar::one(); MAX_N]);
   pub(crate) static ref TWO_N: ScalarVector = ScalarVector::powers(Scalar::from(2u8), MAX_N);
-  pub(crate) static ref IP12: Scalar = inner_product(&*ONE_N, &*TWO_N);
+  pub(crate) static ref IP12: Scalar = inner_product(&ONE_N, &TWO_N);
   static ref H_i: Vec<EdwardsPoint> = (0 .. MAX_MN).map(|g| generator(g * 2)).collect();
   static ref G_i: Vec<EdwardsPoint> = (0 .. MAX_MN).map(|g| generator((g * 2) + 1)).collect();
 }

--- a/coins/monero/src/ringct/bulletproofs/core.rs
+++ b/coins/monero/src/ringct/bulletproofs/core.rs
@@ -1,0 +1,295 @@
+// Required to be for this entire file, which isn't an issue, as it wouldn't bind to the static
+#![allow(non_upper_case_globals)]
+
+use lazy_static::lazy_static;
+use rand_core::{RngCore, CryptoRng};
+
+use group::{ff::Field, Group};
+use dalek_ff_group::{Scalar, EdwardsPoint};
+
+use multiexp::multiexp;
+
+use crate::{
+  H as DALEK_H, Commitment, random_scalar as dalek_random, hash, hash_to_scalar as dalek_hash,
+  ringct::{hash_to_point::raw_hash_to_point, bulletproofs::{scalar_vector::*, Bulletproofs}},
+  serialize::write_varint
+};
+
+pub(crate) const MAX_M: usize = 16;
+pub(crate) const MAX_N: usize = 64;
+const MAX_MN: usize = MAX_M * MAX_N;
+
+// Wrap random_scalar and hash_to_scalar into dalek_ff_group
+fn random_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Scalar {
+  Scalar(dalek_random(rng))
+}
+
+fn hash_to_scalar(data: &[u8]) -> Scalar {
+  Scalar(dalek_hash(data))
+}
+
+fn generator(i: usize) -> EdwardsPoint {
+  let mut transcript = (*H).compress().to_bytes().to_vec();
+  transcript.extend(b"bulletproof");
+  write_varint(&i.try_into().unwrap(), &mut transcript).unwrap();
+  EdwardsPoint(raw_hash_to_point(hash(&transcript)))
+}
+
+lazy_static! {
+  static ref INV_EIGHT: Scalar = Scalar::from(8u8).invert().unwrap();
+  static ref H: EdwardsPoint = EdwardsPoint(*DALEK_H);
+
+  pub(crate) static ref ONE_N: ScalarVector = ScalarVector(vec![Scalar::one(); MAX_N]);
+  pub(crate) static ref TWO_N: ScalarVector = ScalarVector(vec![Scalar::from(2u8); MAX_N]);
+  pub(crate) static ref IP12: Scalar = inner_product(&*ONE_N, &*TWO_N);
+
+  static ref H_i: Vec<EdwardsPoint> = (0 .. MAX_MN).map(|g| generator(g * 2)).collect();
+  static ref G_i: Vec<EdwardsPoint> = (0 .. MAX_MN).map(|g| generator((g * 2) + 1)).collect();
+}
+
+pub(crate) fn vector_exponent(a: &ScalarVector, b: &ScalarVector) -> EdwardsPoint {
+  assert_eq!(a.len(), b.len());
+  (a * &G_i[.. a.len()]) + (b * &H_i[.. b.len()])
+}
+
+fn LR_single(
+  size: usize,
+  A: &[EdwardsPoint], B: &[EdwardsPoint],
+  a: &ScalarVector, b: &ScalarVector,
+  Abo: usize, Bao: usize,
+  scale: Option<&ScalarVector>,
+  extra: Scalar,
+) -> EdwardsPoint {
+  let mut variables = Vec::with_capacity((2 * size) + 1);
+  for i in 0 .. size {
+    variables.push((a[Bao + i] * *INV_EIGHT, A[Abo + i]));
+    variables.push((b[Abo + i] * *INV_EIGHT, B[Bao + i]));
+    if let Some(scale) = scale {
+      variables[(i * 2) + 1].0 *= scale[Bao + i];
+    }
+  }
+  variables.push((extra * *INV_EIGHT, *H));
+  multiexp(&variables)
+}
+
+fn LR(
+  n_prime: usize,
+  G_prime: &[EdwardsPoint], H_prime: &[EdwardsPoint],
+  a_prime: &ScalarVector, b_prime: &ScalarVector,
+  scale: Option<&ScalarVector>,
+  extra: (Scalar, Scalar, Scalar),
+) -> (EdwardsPoint, EdwardsPoint) {
+  let n_prime_2 = n_prime * 2;
+  assert!(n_prime_2 <= G_prime.len());
+  assert!(n_prime_2 <= H_prime.len());
+  assert!(n_prime_2 <= a_prime.len());
+  assert!(n_prime_2 <= b_prime.len());
+  assert!(n_prime_2 <= MAX_MN);
+
+  let L = LR_single(
+    n_prime,
+    G_prime, H_prime,
+    a_prime, b_prime,
+    n_prime, 0,
+    scale,
+    extra.0 * extra.2,
+  );
+
+  let R = LR_single(
+    n_prime,
+    G_prime, H_prime,
+    a_prime, b_prime,
+    0, n_prime,
+    scale,
+    extra.1 * extra.2,
+  );
+
+  (L, R)
+}
+
+fn hash_cache(cache: &mut Scalar, mash: &[[u8; 32]]) -> Scalar {
+  let slice = &[cache.to_bytes().as_ref(), mash.iter().cloned().flatten().collect::<Vec<_>>().as_ref()].concat();
+  *cache = hash_to_scalar(slice);
+  *cache
+}
+
+pub(crate) fn prove<R: RngCore + CryptoRng>(rng: &mut R, commitments: &[Commitment]) -> Bulletproofs {
+  let sv = ScalarVector(commitments.iter().cloned().map(|c| Scalar::from(c.amount)).collect());
+  let gamma = ScalarVector(commitments.iter().cloned().map(|c| Scalar(c.mask)).collect());
+
+  let logN = 6;
+  let N = 1 << logN;
+
+  let mut logM = 0;
+  let mut M;
+  while {
+    M = 1 << logM;
+    (M <= MAX_M) && (M < sv.len())
+  } {
+    logM += 1;
+  }
+
+  let logMN = logM + logN;
+  let MN = M * N;
+
+  let mut aL = ScalarVector(vec![Scalar::zero(); MN]);
+  let mut aL8 = ScalarVector(vec![Scalar::zero(); MN]);
+  let mut aR = ScalarVector(vec![Scalar::zero(); MN]);
+  let mut aR8 = ScalarVector(vec![Scalar::zero(); MN]);
+
+  for j in 0 .. M {
+    for i in (0 .. N).rev() {
+      if (j < sv.len()) && ((sv[j][i / 8] & (1u8 << (i % 8))) != 0) {
+        aL.0[(j * N) + i] = Scalar::one();
+        aL8.0[(j * N) + i] = *INV_EIGHT;
+      } else {
+        aR.0[(j * N) + i] = -Scalar::one();
+        aR8.0[(j * N) + i] = -*INV_EIGHT;
+      }
+    }
+  }
+
+  {
+    for j in 0 .. M {
+      let mut test_aL = 0;
+      let mut test_aR = 0;
+      for i in 0 .. N {
+        if aL[(j * N) + i] == Scalar::one() {
+          test_aL += 1 << i;
+        }
+        if aR[(j * N) + i] == Scalar::zero() {
+          test_aR += 1 << i;
+        }
+      }
+      let mut test = 0;
+      if j < sv.len() {
+        for n in 0 .. 8 {
+          test |= u64::from(sv[j][n]) << (8 * n);
+        }
+      }
+      debug_assert_eq!(test_aL, test);
+      debug_assert_eq!(test_aR, test);
+    }
+  }
+
+  // Commitments * INV_EIGHT
+  let V = commitments.iter().map(|c| EdwardsPoint(c.calculate()) * *INV_EIGHT).collect::<Vec<_>>();
+  let mut cache = hash_to_scalar(&V.iter().map(|V| V.compress().to_bytes()).flatten().collect::<Vec<_>>());
+
+  let alpha = random_scalar(&mut *rng);
+  let A = vector_exponent(&aL8, &aR8) + (EdwardsPoint::generator() * (alpha * *INV_EIGHT));
+
+  let sL = ScalarVector((0 .. MN).map(|_| random_scalar(&mut *rng)).collect::<Vec<_>>());
+  let sR = ScalarVector((0 .. MN).map(|_| random_scalar(&mut *rng)).collect::<Vec<_>>());
+  let rho = random_scalar(&mut *rng);
+  let S = (vector_exponent(&sL, &sR) + (EdwardsPoint::generator() * rho)) * *INV_EIGHT;
+
+  let y = hash_cache(&mut cache, &[A.compress().to_bytes(), S.compress().to_bytes()]);
+  assert!(y != Scalar::zero());
+  let mut cache = hash_to_scalar(&y.to_bytes());
+  let z = cache;
+  assert!(z != Scalar::zero());
+
+  let l0 = &aL - z;
+  let l1 = sL;
+
+  let mut zero_twos = Vec::with_capacity(MN);
+  let zpow = vector_powers(z, M + 2);
+  for j in 0 .. M {
+    for i in 0 .. N {
+      zero_twos.push(zpow[j + 2] * TWO_N[i]);
+    }
+  }
+
+  let yMN = vector_powers(y, MN);
+  let r0 = (&(aR + z) * &yMN) + ScalarVector(zero_twos);
+  let r1 = yMN * sR;
+
+  let t1 = inner_product(&l0, &r1) + inner_product(&l1, &r0);
+  let t2 = inner_product(&l1, &r1);
+
+  let tau1 = random_scalar(&mut *rng);
+  let tau2 = random_scalar(&mut *rng);
+
+  let T1 = multiexp(&[(t1, *H), (tau1, EdwardsPoint::generator())]) * *INV_EIGHT;
+  let T2 = multiexp(&[(t2, *H), (tau2, EdwardsPoint::generator())]) * *INV_EIGHT;
+
+  let x = hash_cache(&mut cache, &[z.to_bytes(), T1.compress().to_bytes(), T2.compress().to_bytes()]);
+  assert!(x != Scalar::zero());
+
+  let mut taux = (tau2 * (x * x)) + (tau1 * x);
+  for i in 1 ..= sv.len() {
+    taux += zpow[i + 1] * gamma[i - 1];
+  }
+  let mu = (x * rho) + alpha;
+
+  let l = &l0 + &(l1 * x);
+  let r = &r0 + &(r1 * x);
+
+  let t = inner_product(&l, &r);
+
+  {
+    let t0 = inner_product(&l0, &r0);
+    assert_eq!((t2 * x * x) + ((t1 * x) + t0), t);
+  }
+
+  let x_ip = hash_cache(&mut cache, &[x.to_bytes(), taux.to_bytes(), mu.to_bytes(), t.to_bytes()]);
+  assert!(x_ip != Scalar::zero());
+
+  let mut n_prime = MN;
+  let mut G_prime = G_i[.. n_prime].to_vec();
+  let mut H_prime = H_i[.. n_prime].to_vec();
+  let mut a_prime = l.clone();
+  let mut b_prime = r.clone();
+  assert_eq!(a_prime.len(), n_prime);
+  assert_eq!(b_prime.len(), n_prime);
+
+  let yinvpow = vector_powers(y.invert().unwrap(), MN);
+
+  let mut L = Vec::with_capacity(logMN);
+  let mut R = Vec::with_capacity(logMN);
+
+  let mut scale = Some(&yinvpow);
+  while n_prime > 1 {
+    n_prime /= 2;
+
+    let cL = inner_product(&a_prime.slice(.. n_prime), &b_prime.slice(n_prime ..));
+    let cR = inner_product(&a_prime.slice(n_prime ..), &b_prime.slice(.. n_prime));
+
+    let (L_i, R_i) = LR(n_prime, &G_prime, &H_prime, &a_prime, &b_prime, scale, (cL, cR, x_ip));
+    L.push(L_i);
+    R.push(R_i);
+
+    let w = hash_cache(&mut cache, &[L_i.compress().to_bytes(), R_i.compress().to_bytes()]);
+    assert!(w != Scalar::zero());
+
+    let winv = w.invert().unwrap();
+    if n_prime > 1 {
+      hadamard_fold(&mut G_prime, winv, w, None);
+      hadamard_fold(&mut H_prime, w, winv, scale);
+    }
+
+    a_prime = (a_prime.slice(.. n_prime) * w) + (a_prime.slice(n_prime ..) * winv);
+    b_prime = (b_prime.slice(.. n_prime) * winv) + (b_prime.slice(n_prime ..) * w);
+
+    scale = None;
+  }
+  assert_eq!(L.len(), logMN);
+  assert_eq!(R.len(), logMN);
+  assert_eq!(a_prime.len(), 1);
+  assert_eq!(b_prime.len(), 1);
+
+  Bulletproofs {
+    A: *A,
+    S: *S,
+    T1: *T1,
+    T2: *T2,
+    taux: *taux,
+    mu: *mu,
+    L: L.drain(..).map(|L| *L).collect(),
+    R: R.drain(..).map(|R| *R).collect(),
+    a: *a_prime[0],
+    b: *b_prime[0],
+    t: *t
+  }
+}

--- a/coins/monero/src/ringct/bulletproofs/mod.rs
+++ b/coins/monero/src/ringct/bulletproofs/mod.rs
@@ -9,7 +9,7 @@ use crate::{Commitment, wallet::TransactionError, serialize::*};
 pub(crate) mod scalar_vector;
 
 mod core;
-pub(crate) use self::core::{MAX_M, c_generator, generator};
+pub(crate) use self::core::MAX_M;
 use self::core::prove;
 
 pub(crate) const MAX_OUTPUTS: usize = MAX_M;

--- a/coins/monero/src/ringct/bulletproofs/scalar_vector.rs
+++ b/coins/monero/src/ringct/bulletproofs/scalar_vector.rs
@@ -1,7 +1,5 @@
 use core::{ops::{Add, Sub, Mul, Index}, slice::SliceIndex};
 
-use lazy_static::lazy_static;
-
 use group::ff::Field;
 use dalek_ff_group::{Scalar, EdwardsPoint};
 
@@ -89,16 +87,12 @@ pub(crate) fn vector_powers(x: Scalar, n: usize) -> ScalarVector {
   ScalarVector(res)
 }
 
-pub(crate) fn hadamard_fold(v: &mut Vec<EdwardsPoint>, a: Scalar, b: Scalar, scale: Option<&ScalarVector>) {
+pub(crate) fn hadamard_fold(v: &mut Vec<EdwardsPoint>, a: Scalar, b: Scalar) {
   let half = v.len() / 2;
   assert_eq!(half * 2, v.len());
 
   for n in 0 .. half {
-    v[n] = multiexp(&[
-      (a * scale.map(|s| s[n]).unwrap_or_else(Scalar::one), v[n]),
-      (b * scale.map(|s| s[half + n]).unwrap_or_else(Scalar::one), v[half + n])
-    ]);
+    v[n] = multiexp(&[(a, v[n]), (b, v[half + n])]);
   }
-
   v.truncate(half);
 }

--- a/coins/monero/src/ringct/bulletproofs/scalar_vector.rs
+++ b/coins/monero/src/ringct/bulletproofs/scalar_vector.rs
@@ -38,7 +38,7 @@ macro_rules! math_op {
         ScalarVector(self.0.iter().zip(b.0.iter()).map($f).collect())
       }
     }
-  }
+  };
 }
 math_op!(Add, add, |(a, b): (&Scalar, &Scalar)| *a + *b);
 math_op!(Sub, sub, |(a, b): (&Scalar, &Scalar)| *a - *b);
@@ -92,7 +92,12 @@ impl Mul<&[EdwardsPoint]> for &ScalarVector {
   }
 }
 
-pub(crate) fn hadamard_fold(l: &[EdwardsPoint], r: &[EdwardsPoint], a: Scalar, b: Scalar) -> Vec<EdwardsPoint> {
+pub(crate) fn hadamard_fold(
+  l: &[EdwardsPoint],
+  r: &[EdwardsPoint],
+  a: Scalar,
+  b: Scalar,
+) -> Vec<EdwardsPoint> {
   let mut res = Vec::with_capacity(l.len() / 2);
   for i in 0 .. l.len() {
     res.push(multiexp(&[(a, l[i]), (b, r[i])]));

--- a/coins/monero/src/ringct/bulletproofs/scalar_vector.rs
+++ b/coins/monero/src/ringct/bulletproofs/scalar_vector.rs
@@ -1,0 +1,104 @@
+use core::{ops::{Add, Sub, Mul, Index}, slice::SliceIndex};
+
+use lazy_static::lazy_static;
+
+use group::ff::Field;
+use dalek_ff_group::{Scalar, EdwardsPoint};
+
+use multiexp::multiexp;
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub(crate) struct ScalarVector(pub(crate) Vec<Scalar>);
+macro_rules! math_op {
+  ($Op: ident, $op: ident, $f: expr) => {
+    impl $Op<Scalar> for ScalarVector {
+      type Output = ScalarVector;
+      fn $op(self, b: Scalar) -> ScalarVector {
+        ScalarVector(self.0.iter().map(|a| $f((a, &b))).collect())
+      }
+    }
+
+    impl $Op<Scalar> for &ScalarVector {
+      type Output = ScalarVector;
+      fn $op(self, b: Scalar) -> ScalarVector {
+        ScalarVector(self.0.iter().map(|a| $f((a, &b))).collect())
+      }
+    }
+
+    impl $Op<ScalarVector> for ScalarVector {
+      type Output = ScalarVector;
+      fn $op(self, b: ScalarVector) -> ScalarVector {
+        assert_eq!(self.len(), b.len());
+        ScalarVector(self.0.iter().zip(b.0.iter()).map($f).collect())
+      }
+    }
+
+    impl $Op<&ScalarVector> for &ScalarVector {
+      type Output = ScalarVector;
+      fn $op(self, b: &ScalarVector) -> ScalarVector {
+        assert_eq!(self.len(), b.len());
+        ScalarVector(self.0.iter().zip(b.0.iter()).map($f).collect())
+      }
+    }
+  }
+}
+math_op!(Add, add, |(a, b): (&Scalar, &Scalar)| *a + *b);
+math_op!(Sub, sub, |(a, b): (&Scalar, &Scalar)| *a - *b);
+math_op!(Mul, mul, |(a, b): (&Scalar, &Scalar)| *a * *b);
+
+impl Mul<&[EdwardsPoint]> for &ScalarVector {
+  type Output = EdwardsPoint;
+  fn mul(self, b: &[EdwardsPoint]) -> EdwardsPoint {
+    assert_eq!(self.len(), b.len());
+    multiexp(&self.0.iter().cloned().zip(b.iter().cloned()).collect::<Vec<_>>())
+  }
+}
+
+impl ScalarVector {
+  pub(crate) fn len(&self) -> usize {
+    self.0.len()
+  }
+
+  pub(crate) fn slice<Idx: SliceIndex<[Scalar], Output = [Scalar]>>(&self, index: Idx) -> ScalarVector {
+    ScalarVector((&self.0[index]).to_vec())
+  }
+}
+
+impl Index<usize> for ScalarVector {
+  type Output = Scalar;
+  fn index(&self, index: usize) -> &Scalar {
+    &self.0[index]
+  }
+}
+
+pub(crate) fn inner_product(a: &ScalarVector, b: &ScalarVector) -> Scalar {
+  (a * b).0.drain(..).sum()
+}
+
+pub(crate) fn vector_powers(x: Scalar, n: usize) -> ScalarVector {
+  let mut res = Vec::with_capacity(n);
+  if n == 0 {
+    return ScalarVector(res);
+  }
+
+  res.push(Scalar::one());
+  for i in 1 .. n {
+    res.push(res[i - 1] * x);
+  }
+
+  ScalarVector(res)
+}
+
+pub(crate) fn hadamard_fold(v: &mut Vec<EdwardsPoint>, a: Scalar, b: Scalar, scale: Option<&ScalarVector>) {
+  let half = v.len() / 2;
+  assert_eq!(half * 2, v.len());
+
+  for n in 0 .. half {
+    v[n] = multiexp(&[
+      (a * scale.map(|s| s[n]).unwrap_or_else(Scalar::one), v[n]),
+      (b * scale.map(|s| s[half + n]).unwrap_or_else(Scalar::one), v[half + n])
+    ]);
+  }
+
+  v.truncate(half);
+}

--- a/coins/monero/src/tests/hash_to_point.rs
+++ b/coins/monero/src/tests/hash_to_point.rs
@@ -11,6 +11,6 @@ use crate::{
 fn hash_to_point() {
   for _ in 0 .. 50 {
     let point = &random_scalar(&mut OsRng) * &ED25519_BASEPOINT_TABLE;
-    assert_eq!(rust_hash_to_point(point), c_hash_to_point(point));
+    assert_eq!(rust_hash_to_point(point.compress().to_bytes()), c_hash_to_point(point));
   }
 }

--- a/crypto/dalek-ff-group/src/lib.rs
+++ b/crypto/dalek-ff-group/src/lib.rs
@@ -264,6 +264,12 @@ impl PrimeFieldBits for Scalar {
   }
 }
 
+impl Sum<Scalar> for Scalar {
+  fn sum<I: Iterator<Item = Scalar>>(iter: I) -> Scalar {
+    Self(DScalar::sum(iter))
+  }
+}
+
 macro_rules! dalek_group {
   (
     $Point: ident,


### PR DESCRIPTION
Closes #31.

8% performance hit compared to using the existing C implementation, with a ~40ms delay on the first proof (equivalent to 1 2-output Bulletproof under release) due to generating the generators.