### PR TITLE
Bulletproofs+

### DIFF
--- a/.github/actions/monero/action.yml
+++ b/.github/actions/monero/action.yml
@@ -9,7 +9,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: monerod
-        key: monerod-${{ runner.os }}-${{ runner.arch }}-v0.17.3.2
+        key: monerod-${{ runner.os }}-${{ runner.arch }}-v0.18.0.0
 
     - name: Download the Monero Daemon
       if: steps.cache-monerod.outputs.cache-hit != 'true'
@@ -27,11 +27,11 @@ runs:
         RUNNER_OS=linux
         RUNNER_ARCH=x64
 
-        FILE=monero-$RUNNER_OS-$RUNNER_ARCH-v0.17.3.2.tar.bz2
+        FILE=monero-$RUNNER_OS-$RUNNER_ARCH-v0.18.0.0.tar.bz2
         wget https://downloads.getmonero.org/cli/$FILE
         tar -xvf $FILE
 
-        mv monero-x86_64-linux-gnu-v0.17.3.2/monerod monerod
+        mv monero-x86_64-linux-gnu-v0.18.0.0/monerod monerod
 
     - name: Monero Regtest Daemon
       shell: bash

--- a/coins/monero/src/lib.rs
+++ b/coins/monero/src/lib.rs
@@ -25,6 +25,32 @@ pub mod wallet;
 #[cfg(test)]
 mod tests;
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[allow(non_camel_case_types)]
+pub enum Protocol {
+  Unsupported,
+  v14,
+  v16,
+}
+
+impl Protocol {
+  pub(crate) fn ring_len(&self) -> usize {
+    match self {
+      Protocol::Unsupported => panic!("Unsupported protocol version"),
+      Protocol::v14 => 11,
+      Protocol::v16 => 16,
+    }
+  }
+
+  pub(crate) fn bp_plus(&self) -> bool {
+    match self {
+      Protocol::Unsupported => panic!("Unsupported protocol version"),
+      Protocol::v14 => false,
+      Protocol::v16 => true,
+    }
+  }
+}
+
 lazy_static! {
   static ref H: EdwardsPoint =
     CompressedEdwardsY(hash(&ED25519_BASEPOINT_POINT.compress().to_bytes()))

--- a/coins/monero/src/ringct/bulletproofs/mod.rs
+++ b/coins/monero/src/ringct/bulletproofs/mod.rs
@@ -15,6 +15,7 @@ use self::core::{MAX_M, prove, prove_plus};
 pub(crate) const MAX_OUTPUTS: usize = MAX_M;
 
 impl Bulletproofs {
+  // TODO
   pub(crate) fn fee_weight(outputs: usize) -> usize {
     let proofs = 6 + usize::try_from(usize::BITS - (outputs - 1).leading_zeros()).unwrap();
     let len = (9 + (2 * proofs)) * 32;

--- a/coins/monero/src/ringct/bulletproofs/mod.rs
+++ b/coins/monero/src/ringct/bulletproofs/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod scalar_vector;
 
 mod core;
 pub(crate) use self::core::Bulletproofs;
-use self::core::{MAX_M, prove};
+use self::core::{MAX_M, prove, prove_plus};
 
 pub(crate) const MAX_OUTPUTS: usize = MAX_M;
 
@@ -32,11 +32,12 @@ impl Bulletproofs {
   pub fn prove<R: RngCore + CryptoRng>(
     rng: &mut R,
     outputs: &[Commitment],
+    plus: bool,
   ) -> Result<Bulletproofs, TransactionError> {
     if outputs.len() > MAX_OUTPUTS {
       return Err(TransactionError::TooManyOutputs)?;
     }
-    Ok(prove(rng, outputs))
+    Ok(if !plus { prove(rng, outputs) } else { prove_plus(rng, outputs) })
   }
 
   fn serialize_core<W: std::io::Write, F: Fn(&[EdwardsPoint], &mut W) -> std::io::Result<()>>(

--- a/coins/monero/src/ringct/bulletproofs/mod.rs
+++ b/coins/monero/src/ringct/bulletproofs/mod.rs
@@ -58,6 +58,17 @@ impl Bulletproofs {
         write_scalar(b, w)?;
         write_scalar(t, w)
       }
+
+      Bulletproofs::Plus { A, A1, B, r1, s1, d1, L, R } => {
+        write_point(A, w)?;
+        write_point(A1, w)?;
+        write_point(B, w)?;
+        write_scalar(r1, w)?;
+        write_scalar(s1, w)?;
+        write_scalar(d1, w)?;
+        specific_write_vec(L, w)?;
+        specific_write_vec(R, w)
+      }
     }
   }
 
@@ -82,6 +93,19 @@ impl Bulletproofs {
       a: read_scalar(r)?,
       b: read_scalar(r)?,
       t: read_scalar(r)?,
+    })
+  }
+
+  pub fn deserialize_plus<R: std::io::Read>(r: &mut R) -> std::io::Result<Bulletproofs> {
+    Ok(Bulletproofs::Plus {
+      A: read_point(r)?,
+      A1: read_point(r)?,
+      B: read_point(r)?,
+      r1: read_scalar(r)?,
+      s1: read_scalar(r)?,
+      d1: read_scalar(r)?,
+      L: read_vec(read_point, r)?,
+      R: read_vec(read_point, r)?,
     })
   }
 }

--- a/coins/monero/src/ringct/bulletproofs/scalar_vector.rs
+++ b/coins/monero/src/ringct/bulletproofs/scalar_vector.rs
@@ -60,6 +60,24 @@ impl ScalarVector {
     ScalarVector(res)
   }
 
+  pub(crate) fn even_powers(x: Scalar, pow: usize) -> ScalarVector {
+    debug_assert!(pow != 0);
+    // Verify pow is a power of two
+    debug_assert_eq!(((pow - 1) & pow), 0);
+
+    let xsq = x * x;
+    let mut res = ScalarVector(Vec::with_capacity(pow / 2));
+    res.0.push(xsq);
+
+    let mut prev = 2;
+    while prev < pow {
+      res.0.push(res[res.len() - 1] * xsq);
+      prev += 2;
+    }
+
+    res
+  }
+
   pub(crate) fn sum(mut self) -> Scalar {
     self.0.drain(..).sum()
   }

--- a/coins/monero/src/ringct/bulletproofs/scalar_vector.rs
+++ b/coins/monero/src/ringct/bulletproofs/scalar_vector.rs
@@ -104,7 +104,8 @@ pub(crate) fn inner_product(a: &ScalarVector, b: &ScalarVector) -> Scalar {
 }
 
 pub(crate) fn weighted_inner_product(a: &ScalarVector, b: &ScalarVector, y: Scalar) -> Scalar {
-  (a * b * ScalarVector::powers(y, a.len())).sum()
+  // y ** 0 is not used as a power
+  (a * b * ScalarVector(ScalarVector::powers(y, a.len() + 1).0[1 ..].to_vec())).sum()
 }
 
 impl Mul<&[EdwardsPoint]> for &ScalarVector {

--- a/coins/monero/src/ringct/clsag/mod.rs
+++ b/coins/monero/src/ringct/clsag/mod.rs
@@ -12,7 +12,7 @@ use curve25519_dalek::{
 };
 
 use crate::{
-  Commitment, random_scalar, hash_to_scalar, transaction::RING_LEN, wallet::decoys::Decoys,
+  Commitment, random_scalar, hash_to_scalar, wallet::decoys::Decoys,
   ringct::hash_to_point, serialize::*,
 };
 
@@ -292,8 +292,8 @@ impl Clsag {
     Ok(())
   }
 
-  pub(crate) fn fee_weight() -> usize {
-    (RING_LEN * 32) + 32 + 32
+  pub(crate) fn fee_weight(ring_len: usize) -> usize {
+    (ring_len * 32) + 32 + 32
   }
 
   pub fn serialize<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {

--- a/coins/monero/src/ringct/clsag/mod.rs
+++ b/coins/monero/src/ringct/clsag/mod.rs
@@ -12,8 +12,8 @@ use curve25519_dalek::{
 };
 
 use crate::{
-  Commitment, random_scalar, hash_to_scalar, wallet::decoys::Decoys,
-  ringct::hash_to_point, serialize::*,
+  Commitment, random_scalar, hash_to_scalar, wallet::decoys::Decoys, ringct::hash_to_point,
+  serialize::*,
 };
 
 #[cfg(feature = "multisig")]

--- a/coins/monero/src/ringct/mod.rs
+++ b/coins/monero/src/ringct/mod.rs
@@ -93,8 +93,8 @@ impl RctPrunable {
     }
   }
 
-  pub(crate) fn fee_weight(inputs: usize, outputs: usize) -> usize {
-    1 + Bulletproofs::fee_weight(outputs) + (inputs * (Clsag::fee_weight() + 32))
+  pub(crate) fn fee_weight(ring_len: usize, inputs: usize, outputs: usize) -> usize {
+    1 + Bulletproofs::fee_weight(outputs) + (inputs * (Clsag::fee_weight(ring_len) + 32))
   }
 
   pub fn serialize<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {
@@ -155,8 +155,8 @@ pub struct RctSignatures {
 }
 
 impl RctSignatures {
-  pub(crate) fn fee_weight(inputs: usize, outputs: usize) -> usize {
-    RctBase::fee_weight(outputs) + RctPrunable::fee_weight(inputs, outputs)
+  pub(crate) fn fee_weight(ring_len: usize, inputs: usize, outputs: usize) -> usize {
+    RctBase::fee_weight(outputs) + RctPrunable::fee_weight(ring_len, inputs, outputs)
   }
 
   pub fn serialize<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {

--- a/coins/monero/src/wallet/decoys.rs
+++ b/coins/monero/src/wallet/decoys.rs
@@ -7,11 +7,7 @@ use rand_distr::{Distribution, Gamma};
 
 use curve25519_dalek::edwards::EdwardsPoint;
 
-use crate::{
-  transaction::RING_LEN,
-  wallet::SpendableOutput,
-  rpc::{RpcError, Rpc},
-};
+use crate::{wallet::SpendableOutput, rpc::{RpcError, Rpc}};
 
 const LOCK_WINDOW: usize = 10;
 const MATURITY: u64 = 60;
@@ -19,8 +15,6 @@ const RECENT_WINDOW: usize = 15;
 const BLOCK_TIME: usize = 120;
 const BLOCKS_PER_YEAR: usize = 365 * 24 * 60 * 60 / BLOCK_TIME;
 const TIP_APPLICATION: f64 = (LOCK_WINDOW * BLOCK_TIME) as f64;
-
-const DECOYS: usize = RING_LEN - 1;
 
 lazy_static! {
   static ref GAMMA: Gamma<f64> = Gamma::new(19.28, 1.0 / 1.61).unwrap();
@@ -109,9 +103,12 @@ impl Decoys {
   pub(crate) async fn select<R: RngCore + CryptoRng>(
     rng: &mut R,
     rpc: &Rpc,
+    ring_len: usize,
     height: usize,
     inputs: &[SpendableOutput],
   ) -> Result<Vec<Decoys>, RpcError> {
+    let decoy_count = ring_len - 1;
+
     // Convert the inputs in question to the raw output data
     let mut outputs = Vec::with_capacity(inputs.len());
     for input in inputs {
@@ -152,7 +149,7 @@ impl Decoys {
     }
 
     // TODO: Simply create a TX with less than the target amount
-    if (high - MATURITY) < u64::try_from(inputs.len() * RING_LEN).unwrap() {
+    if (high - MATURITY) < u64::try_from(inputs.len() * ring_len).unwrap() {
       Err(RpcError::InternalError("not enough decoy candidates".to_string()))?;
     }
 
@@ -160,12 +157,12 @@ impl Decoys {
     // We should almost never naturally generate an insane transaction, hence why this doesn't
     // bother with an overage
     let mut decoys =
-      select_n(rng, rpc, height, high, per_second, &mut used, inputs.len() * DECOYS).await?;
+      select_n(rng, rpc, height, high, per_second, &mut used, inputs.len() * decoy_count).await?;
 
     let mut res = Vec::with_capacity(inputs.len());
     for o in outputs {
       // Grab the decoys for this specific output
-      let mut ring = decoys.drain((decoys.len() - DECOYS) ..).collect::<Vec<_>>();
+      let mut ring = decoys.drain((decoys.len() - decoy_count) ..).collect::<Vec<_>>();
       ring.push(o);
       ring.sort_by(|a, b| a.0.cmp(&b.0));
 
@@ -180,9 +177,9 @@ impl Decoys {
       if high > 500 {
         // Make sure the TX passes the sanity check that the median output is within the last 40%
         let target_median = high * 3 / 5;
-        while ring[RING_LEN / 2].0 < target_median {
+        while ring[ring_len / 2].0 < target_median {
           // If it's not, update the bottom half with new values to ensure the median only moves up
-          for removed in ring.drain(0 .. (RING_LEN / 2)).collect::<Vec<_>>() {
+          for removed in ring.drain(0 .. (ring_len / 2)).collect::<Vec<_>>() {
             // If we removed the real spend, add it back
             if removed.0 == o.0 {
               ring.push(o);
@@ -197,7 +194,7 @@ impl Decoys {
 
           // Select new outputs until we have a full sized ring again
           ring.extend(
-            select_n(rng, rpc, height, high, per_second, &mut used, RING_LEN - ring.len()).await?,
+            select_n(rng, rpc, height, high, per_second, &mut used, ring_len - ring.len()).await?,
           );
           ring.sort_by(|a, b| a.0.cmp(&b.0));
         }

--- a/coins/monero/src/wallet/decoys.rs
+++ b/coins/monero/src/wallet/decoys.rs
@@ -7,7 +7,10 @@ use rand_distr::{Distribution, Gamma};
 
 use curve25519_dalek::edwards::EdwardsPoint;
 
-use crate::{wallet::SpendableOutput, rpc::{RpcError, Rpc}};
+use crate::{
+  wallet::SpendableOutput,
+  rpc::{RpcError, Rpc},
+};
 
 const LOCK_WINDOW: usize = 10;
 const MATURITY: u64 = 60;

--- a/coins/monero/src/wallet/send/mod.rs
+++ b/coins/monero/src/wallet/send/mod.rs
@@ -211,7 +211,8 @@ impl SignableTransaction {
     let extra = (outputs * (2 + 32)) - (outputs.saturating_sub(2) * 2);
 
     // Calculate the fee.
-    let mut fee = fee_rate.calculate(Transaction::fee_weight(ring_len, inputs.len(), outputs, extra));
+    let mut fee =
+      fee_rate.calculate(Transaction::fee_weight(ring_len, inputs.len(), outputs, extra));
 
     // Make sure we have enough funds
     let in_amount = inputs.iter().map(|input| input.commitment.amount).sum::<u64>();
@@ -224,7 +225,8 @@ impl SignableTransaction {
     if (!change) && change_address.is_some() && (in_amount != out_amount) {
       // Check even with the new fee, there's remaining funds
       let change_fee =
-        fee_rate.calculate(Transaction::fee_weight(ring_len, inputs.len(), outputs + 1, extra)) - fee;
+        fee_rate.calculate(Transaction::fee_weight(ring_len, inputs.len(), outputs + 1, extra)) -
+          fee;
       if (out_amount + change_fee) < in_amount {
         change = true;
         outputs += 1;
@@ -310,8 +312,8 @@ impl SignableTransaction {
   pub async fn sign<R: RngCore + CryptoRng>(
     &mut self,
     rng: &mut R,
-    ring_len: usize,
     rpc: &Rpc,
+    ring_len: usize,
     spend: &Scalar,
   ) -> Result<Transaction, TransactionError> {
     let mut images = Vec::with_capacity(self.inputs.len());

--- a/coins/monero/src/wallet/send/mod.rs
+++ b/coins/monero/src/wallet/send/mod.rs
@@ -294,6 +294,7 @@ impl SignableTransaction {
           commitments: commitments.iter().map(|commitment| commitment.calculate()).collect(),
         },
         prunable: RctPrunable::Clsag {
+          plus: matches!(bp, Bulletproofs::Plus { .. }),
           bulletproofs: vec![bp],
           clsags: vec![],
           pseudo_outs: vec![],
@@ -329,7 +330,8 @@ impl SignableTransaction {
       ),
     );
 
-    let mut tx = self.prepare_transaction(&commitments, Bulletproofs::prove(rng, &commitments)?);
+    let mut tx =
+      self.prepare_transaction(&commitments, Bulletproofs::prove(rng, &commitments, false)?);
 
     let signable = prepare_inputs(rng, rpc, &self.inputs, spend, &mut tx).await?;
 

--- a/coins/monero/src/wallet/send/multisig.rs
+++ b/coins/monero/src/wallet/send/multisig.rs
@@ -70,6 +70,7 @@ impl SignableTransaction {
   pub async fn multisig(
     self,
     rpc: &Rpc,
+    ring_len: usize,
     keys: FrostKeys<Ed25519>,
     mut transcript: RecommendedTranscript,
     height: usize,
@@ -143,6 +144,7 @@ impl SignableTransaction {
       // committed to. They'll also be committed to later via the TX message as a whole
       &mut ChaCha12Rng::from_seed(transcript.rng_seed(b"decoys")),
       rpc,
+      ring_len,
       height,
       &self.inputs,
     )

--- a/coins/monero/src/wallet/send/multisig.rs
+++ b/coins/monero/src/wallet/send/multisig.rs
@@ -304,6 +304,7 @@ impl SignMachine<Transaction> for TransactionSignMachine {
         Bulletproofs::prove(
           &mut ChaCha12Rng::from_seed(self.transcript.rng_seed(b"bulletproofs")),
           &commitments,
+          false,
         )
         .unwrap(),
       )

--- a/coins/monero/src/wallet/send/multisig.rs
+++ b/coins/monero/src/wallet/send/multisig.rs
@@ -306,7 +306,7 @@ impl SignMachine<Transaction> for TransactionSignMachine {
         Bulletproofs::prove(
           &mut ChaCha12Rng::from_seed(self.transcript.rng_seed(b"bulletproofs")),
           &commitments,
-          false,
+          true,
         )
         .unwrap(),
       )

--- a/coins/monero/tests/rpc.rs
+++ b/coins/monero/tests/rpc.rs
@@ -10,7 +10,7 @@ use monero::{
 };
 
 use monero_serai::{
-  random_scalar,
+  Protocol, random_scalar,
   rpc::{EmptyResponse, RpcError, Rpc},
 };
 
@@ -29,8 +29,10 @@ pub async fn rpc() -> Rpc {
   )
   .to_string();
 
-  // Mine 10 blocks so we have 10 decoys so decoy selection doesn't fail
+  // Mine 20 blocks to ensure decoy availability
   mine_block(&rpc, &addr).await.unwrap();
+  mine_block(&rpc, &addr).await.unwrap();
+  assert!(!matches!(rpc.get_protocol().await.unwrap(), Protocol::Unsupported));
 
   rpc
 }

--- a/coins/monero/tests/send.rs
+++ b/coins/monero/tests/send.rs
@@ -137,7 +137,7 @@ async fn send_core(test: usize, multisig: bool) {
         .unwrap();
 
     if !multisig {
-      tx = Some(signable.sign(&mut OsRng, &rpc, &spend).await.unwrap());
+      tx = Some(signable.sign(&mut OsRng, 16, &rpc, &spend).await.unwrap());
     } else {
       #[cfg(feature = "multisig")]
       {
@@ -149,6 +149,7 @@ async fn send_core(test: usize, multisig: bool) {
               .clone()
               .multisig(
                 &rpc,
+                16,
                 (*keys[&i]).clone(),
                 RecommendedTranscript::new(b"Monero Serai Test Transaction"),
                 rpc.get_height().await.unwrap() - 10,

--- a/coins/monero/tests/send.rs
+++ b/coins/monero/tests/send.rs
@@ -137,7 +137,7 @@ async fn send_core(test: usize, multisig: bool) {
         .unwrap();
 
     if !multisig {
-      tx = Some(signable.sign(&mut OsRng, 16, &rpc, &spend).await.unwrap());
+      tx = Some(signable.sign(&mut OsRng, &rpc, 16, &spend).await.unwrap());
     } else {
       #[cfg(feature = "multisig")]
       {

--- a/processor/src/coin/monero.rs
+++ b/processor/src/coin/monero.rs
@@ -169,6 +169,7 @@ impl Coin for Monero {
       .clone()
       .multisig(
         &self.rpc,
+        16,
         (*transaction.0).clone(),
         transaction.1.clone(),
         transaction.2,
@@ -231,7 +232,7 @@ impl Coin for Monero {
       .ignore_timelock();
 
     let amount = outputs[0].commitment.amount;
-    let fee = 1000000000; // TODO
+    let fee = 3000000000; // TODO
     let tx = MSignableTransaction::new(
       outputs,
       vec![(address, amount - fee)],
@@ -239,7 +240,7 @@ impl Coin for Monero {
       self.rpc.get_fee().await.unwrap(),
     )
     .unwrap()
-    .sign(&mut OsRng, &self.rpc, &Scalar::one())
+    .sign(&mut OsRng, &self.rpc, 16, &Scalar::one())
     .await
     .unwrap();
     self.rpc.publish_transaction(&tx).await.unwrap();

--- a/processor/src/coin/monero.rs
+++ b/processor/src/coin/monero.rs
@@ -150,6 +150,7 @@ impl Coin for Monero {
       transcript,
       height,
       MSignableTransaction::new(
+        self.rpc.get_protocol().await.unwrap(), // TODO: Make this deterministic
         inputs.drain(..).map(|input| input.0).collect(),
         payments.to_vec(),
         Some(self.address(spend)),
@@ -169,7 +170,6 @@ impl Coin for Monero {
       .clone()
       .multisig(
         &self.rpc,
-        16,
         (*transaction.0).clone(),
         transaction.1.clone(),
         transaction.2,
@@ -234,13 +234,14 @@ impl Coin for Monero {
     let amount = outputs[0].commitment.amount;
     let fee = 3000000000; // TODO
     let tx = MSignableTransaction::new(
+      self.rpc.get_protocol().await.unwrap(),
       outputs,
       vec![(address, amount - fee)],
       Some(self.empty_address()),
       self.rpc.get_fee().await.unwrap(),
     )
     .unwrap()
-    .sign(&mut OsRng, &self.rpc, 16, &Scalar::one())
+    .sign(&mut OsRng, &self.rpc, &Scalar::one())
     .await
     .unwrap();
     self.rpc.publish_transaction(&tx).await.unwrap();


### PR DESCRIPTION
Diversifies Monero to support v14 and v16 TXs at the same time. It does not complete v16 support, as per #8, due to its lack of proper support for view tags. For systems which ignore view tags, like this library right now, it does fine.