### PR TITLE
Curve lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4548,6 +4548,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "modular-schnorr"
+version = "0.1.0"
+dependencies = [
+ "blake2",
+ "composable-curve",
+ "dalek-ff-group",
+ "multiexp",
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "monero"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4532,12 +4532,11 @@ dependencies = [
 name = "modular-frost"
 version = "0.2.0"
 dependencies = [
+ "composable-curve",
  "dalek-ff-group",
  "dleq",
  "elliptic-curve",
- "ff",
  "flexible-transcript",
- "group",
  "hex",
  "k256",
  "multiexp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,6 +1001,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "composable-curve"
+version = "0.12.0"
+dependencies = [
+ "ff",
+ "group",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,11 +1539,10 @@ name = "dleq"
 version = "0.1.0"
 dependencies = [
  "blake2",
+ "composable-curve",
  "dalek-ff-group",
  "digest 0.10.3",
- "ff",
  "flexible-transcript",
- "group",
  "hex-literal",
  "k256",
  "multiexp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7534,6 +7534,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "blake2",
+ "composable-curve",
  "curve25519-dalek 3.2.0",
  "dalek-ff-group",
  "flexible-transcript",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
 
   "crypto/multiexp",
 
+  "crypto/schnorr",
   "crypto/dleq",
   "crypto/frost",
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,9 @@
 members = [
   "crypto/transcript",
 
+  "crypto/curve",
   "crypto/dalek-ff-group",
+
   "crypto/multiexp",
 
   "crypto/dleq",

--- a/coins/ethereum/src/crypto.rs
+++ b/coins/ethereum/src/crypto.rs
@@ -6,7 +6,7 @@ use k256::{
   AffinePoint, ProjectivePoint, Scalar, U256,
 };
 
-use frost::{algorithm::Hram, curve::Secp256k1};
+use frost::algorithm::Hram;
 
 pub fn keccak256(data: &[u8]) -> [u8; 32] {
   Keccak256::digest(data).try_into().unwrap()
@@ -47,7 +47,7 @@ pub fn ecrecover(message: Scalar, v: u8, r: Scalar, s: Scalar) -> Option<[u8; 20
 
 #[derive(Clone, Default)]
 pub struct EthereumHram {}
-impl Hram<Secp256k1> for EthereumHram {
+impl Hram<ProjectivePoint> for EthereumHram {
   #[allow(non_snake_case)]
   fn hram(R: &ProjectivePoint, A: &ProjectivePoint, m: &[u8]) -> Scalar {
     let a_encoded_point = A.to_encoded_point(true);

--- a/coins/ethereum/tests/contract.rs
+++ b/coins/ethereum/tests/contract.rs
@@ -19,11 +19,10 @@ async fn test_ecrecover_hack() {
   use ethers::utils::keccak256;
   use frost::{
     algorithm::Schnorr,
-    curve::Secp256k1,
     tests::{algorithm_machines, key_gen, sign},
   };
   use k256::elliptic_curve::bigint::ArrayEncoding;
-  use k256::{Scalar, U256};
+  use k256::{U256, Scalar, ProjectivePoint};
   use rand_core::OsRng;
 
   let anvil = Anvil::new().spawn();
@@ -33,7 +32,7 @@ async fn test_ecrecover_hack() {
   let chain_id = provider.get_chainid().await.unwrap();
   let client = Arc::new(SignerMiddleware::new(provider, wallet));
 
-  let keys = key_gen::<_, Secp256k1>(&mut OsRng);
+  let keys = key_gen::<_, ProjectivePoint>(&mut OsRng);
   let group_key = keys[&1].group_key();
 
   const MESSAGE: &'static [u8] = b"Hello, World!";
@@ -44,7 +43,7 @@ async fn test_ecrecover_hack() {
 
   let sig = sign(
     &mut OsRng,
-    algorithm_machines(&mut OsRng, Schnorr::<Secp256k1, crypto::EthereumHram>::new(), &keys),
+    algorithm_machines(&mut OsRng, Schnorr::<ProjectivePoint, crypto::EthereumHram>::new(), &keys),
     full_message,
   );
   let mut processed_sig =

--- a/coins/ethereum/tests/crypto.rs
+++ b/coins/ethereum/tests/crypto.rs
@@ -1,9 +1,9 @@
-use ethereum_serai::crypto::*;
-use frost::curve::Secp256k1;
 use k256::{
   elliptic_curve::{bigint::ArrayEncoding, ops::Reduce, sec1::ToEncodedPoint},
   ProjectivePoint, Scalar, U256,
 };
+
+use ethereum_serai::crypto::*;
 
 #[test]
 fn test_ecrecover() {
@@ -35,14 +35,14 @@ fn test_signing() {
   };
   use rand_core::OsRng;
 
-  let keys = key_gen::<_, Secp256k1>(&mut OsRng);
+  let keys = key_gen::<_, ProjectivePoint>(&mut OsRng);
   let _group_key = keys[&1].group_key();
 
   const MESSAGE: &'static [u8] = b"Hello, World!";
 
   let _sig = sign(
     &mut OsRng,
-    algorithm_machines(&mut OsRng, Schnorr::<Secp256k1, EthereumHram>::new(), &keys),
+    algorithm_machines(&mut OsRng, Schnorr::<ProjectivePoint, EthereumHram>::new(), &keys),
     MESSAGE,
   );
 }
@@ -55,7 +55,7 @@ fn test_ecrecover_hack() {
   };
   use rand_core::OsRng;
 
-  let keys = key_gen::<_, Secp256k1>(&mut OsRng);
+  let keys = key_gen::<_, ProjectivePoint>(&mut OsRng);
   let group_key = keys[&1].group_key();
   let group_key_encoded = group_key.to_encoded_point(true);
   let group_key_compressed = group_key_encoded.as_ref();
@@ -69,7 +69,7 @@ fn test_ecrecover_hack() {
 
   let sig = sign(
     &mut OsRng,
-    algorithm_machines(&mut OsRng, Schnorr::<Secp256k1, EthereumHram>::new(), &keys),
+    algorithm_machines(&mut OsRng, Schnorr::<ProjectivePoint, EthereumHram>::new(), &keys),
     full_message,
   );
 

--- a/coins/monero/src/frost.rs
+++ b/coins/monero/src/frost.rs
@@ -34,7 +34,7 @@ pub(crate) fn write_dleq<R: RngCore + CryptoRng>(
   mut x: Scalar,
 ) -> Vec<u8> {
   let mut res = Vec::with_capacity(64);
-  DLEqProof::prove(
+  DLEqProof::<dfg::EdwardsPoint>::prove(
     rng,
     // Doesn't take in a larger transcript object due to the usage of this
     // Every prover would immediately write their own DLEq proof, when they can only do so in

--- a/coins/monero/src/ringct/bulletproofs/mod.rs
+++ b/coins/monero/src/ringct/bulletproofs/mod.rs
@@ -2,8 +2,6 @@
 
 use rand_core::{RngCore, CryptoRng};
 
-use zeroize::Zeroize;
-
 use curve25519_dalek::edwards::EdwardsPoint;
 use multiexp::BatchVerifier;
 
@@ -75,16 +73,15 @@ impl Bulletproofs {
   }
 
   #[must_use]
-  pub fn batch_verify<ID: Copy + Zeroize, R: RngCore + CryptoRng>(
+  pub fn batch_verify<ID: Copy>(
     &self,
-    rng: &mut R,
     verifier: &mut BatchVerifier<ID, dalek_ff_group::EdwardsPoint>,
     id: ID,
     commitments: &[EdwardsPoint],
   ) -> bool {
     match self {
-      Bulletproofs::Original(bp) => bp.batch_verify(rng, verifier, id, commitments),
-      Bulletproofs::Plus(bp) => bp.batch_verify(rng, verifier, id, commitments),
+      Bulletproofs::Original(bp) => bp.batch_verify(verifier, id, commitments),
+      Bulletproofs::Plus(bp) => bp.batch_verify(verifier, id, commitments),
     }
   }
 

--- a/coins/monero/src/ringct/bulletproofs/original.rs
+++ b/coins/monero/src/ringct/bulletproofs/original.rs
@@ -168,9 +168,8 @@ impl OriginalStruct {
   }
 
   #[must_use]
-  fn verify_core<ID: Copy + Zeroize, R: RngCore + CryptoRng>(
+  fn verify_core<ID: Copy>(
     &self,
-    rng: &mut R,
     verifier: &mut BatchVerifier<ID, EdwardsPoint>,
     id: ID,
     commitments: &[DalekPoint],
@@ -246,7 +245,7 @@ impl OriginalStruct {
 
     proof.push((x, T1));
     proof.push((x * x, T2));
-    verifier.queue(&mut *rng, id, proof);
+    verifier.queue(id, proof);
 
     proof = Vec::with_capacity(4 + (2 * (MN + logMN)));
     let z3 = (Scalar(self.t) - (Scalar(self.a) * Scalar(self.b))) * x_ip;
@@ -277,7 +276,7 @@ impl OriginalStruct {
       proof.push((w[i] * w[i], L[i]));
       proof.push((winv[i] * winv[i], R[i]));
     }
-    verifier.queue(rng, id, proof);
+    verifier.queue(id, proof);
 
     true
   }
@@ -289,21 +288,20 @@ impl OriginalStruct {
     commitments: &[DalekPoint],
   ) -> bool {
     let mut verifier = BatchVerifier::new(1);
-    if self.verify_core(rng, &mut verifier, (), commitments) {
-      verifier.verify_vartime()
+    if self.verify_core(&mut verifier, (), commitments) {
+      verifier.verify_vartime(rng)
     } else {
       false
     }
   }
 
   #[must_use]
-  pub(crate) fn batch_verify<ID: Copy + Zeroize, R: RngCore + CryptoRng>(
+  pub(crate) fn batch_verify<ID: Copy>(
     &self,
-    rng: &mut R,
     verifier: &mut BatchVerifier<ID, EdwardsPoint>,
     id: ID,
     commitments: &[DalekPoint],
   ) -> bool {
-    self.verify_core(rng, verifier, id, commitments)
+    self.verify_core(verifier, id, commitments)
   }
 }

--- a/coins/monero/src/ringct/bulletproofs/plus.rs
+++ b/coins/monero/src/ringct/bulletproofs/plus.rs
@@ -177,9 +177,8 @@ impl PlusStruct {
   }
 
   #[must_use]
-  fn verify_core<ID: Copy + Zeroize, R: RngCore + CryptoRng>(
+  fn verify_core<ID: Copy>(
     &self,
-    rng: &mut R,
     verifier: &mut BatchVerifier<ID, EdwardsPoint>,
     id: ID,
     commitments: &[DalekPoint],
@@ -284,7 +283,7 @@ impl PlusStruct {
       proof.push((minus_esq * winv[i] * winv[i], R[i]));
     }
 
-    verifier.queue(rng, id, proof);
+    verifier.queue(id, proof);
     true
   }
 
@@ -295,21 +294,20 @@ impl PlusStruct {
     commitments: &[DalekPoint],
   ) -> bool {
     let mut verifier = BatchVerifier::new(1);
-    if self.verify_core(rng, &mut verifier, (), commitments) {
-      verifier.verify_vartime()
+    if self.verify_core(&mut verifier, (), commitments) {
+      verifier.verify_vartime(rng)
     } else {
       false
     }
   }
 
   #[must_use]
-  pub(crate) fn batch_verify<ID: Copy + Zeroize, R: RngCore + CryptoRng>(
+  pub(crate) fn batch_verify<ID: Copy>(
     &self,
-    rng: &mut R,
     verifier: &mut BatchVerifier<ID, EdwardsPoint>,
     id: ID,
     commitments: &[DalekPoint],
   ) -> bool {
-    self.verify_core(rng, verifier, id, commitments)
+    self.verify_core(verifier, id, commitments)
   }
 }

--- a/coins/monero/src/ringct/clsag/multisig.rs
+++ b/coins/monero/src/ringct/clsag/multisig.rs
@@ -19,7 +19,7 @@ use curve25519_dalek::{
 use group::Group;
 
 use transcript::{Transcript, RecommendedTranscript};
-use frost::{curve::Ed25519, FrostError, FrostView, algorithm::Algorithm};
+use frost::{FrostError, FrostView, algorithm::Algorithm};
 use dalek_ff_group as dfg;
 
 use crate::{
@@ -124,7 +124,7 @@ impl ClsagMultisig {
   }
 }
 
-impl Algorithm<Ed25519> for ClsagMultisig {
+impl Algorithm<dfg::EdwardsPoint> for ClsagMultisig {
   type Transcript = RecommendedTranscript;
   type Signature = (Clsag, EdwardsPoint);
 
@@ -135,7 +135,7 @@ impl Algorithm<Ed25519> for ClsagMultisig {
   fn preprocess_addendum<R: RngCore + CryptoRng>(
     &mut self,
     rng: &mut R,
-    view: &FrostView<Ed25519>,
+    view: &FrostView<dfg::EdwardsPoint>,
   ) -> Vec<u8> {
     let mut serialized = Vec::with_capacity(Self::serialized_len());
     serialized.extend((view.secret_share().0 * self.H).compress().to_bytes());
@@ -145,7 +145,7 @@ impl Algorithm<Ed25519> for ClsagMultisig {
 
   fn process_addendum<Re: Read>(
     &mut self,
-    view: &FrostView<Ed25519>,
+    view: &FrostView<dfg::EdwardsPoint>,
     l: u16,
     serialized: &mut Re,
   ) -> Result<(), FrostError> {
@@ -171,7 +171,7 @@ impl Algorithm<Ed25519> for ClsagMultisig {
 
   fn sign_share(
     &mut self,
-    view: &FrostView<Ed25519>,
+    view: &FrostView<dfg::EdwardsPoint>,
     nonce_sums: &[Vec<dfg::EdwardsPoint>],
     nonces: &[dfg::Scalar],
     msg: &[u8],

--- a/coins/monero/src/tests/bulletproofs.rs
+++ b/coins/monero/src/tests/bulletproofs.rs
@@ -76,9 +76,9 @@ macro_rules! bulletproofs_tests {
 
         let commitments = commitments.iter().map(Commitment::calculate).collect::<Vec<_>>();
         assert!(bp.verify(&mut OsRng, &commitments));
-        assert!(bp.batch_verify(&mut OsRng, &mut verifier, i, &commitments));
+        assert!(bp.batch_verify(&mut verifier, i, &commitments));
       }
-      assert!(verifier.verify_vartime());
+      assert!(verifier.verify_vartime(&mut OsRng));
     }
 
     #[test]

--- a/coins/monero/src/tests/clsag.rs
+++ b/coins/monero/src/tests/clsag.rs
@@ -8,7 +8,7 @@ use curve25519_dalek::{constants::ED25519_BASEPOINT_TABLE, scalar::Scalar};
 #[cfg(feature = "multisig")]
 use transcript::{Transcript, RecommendedTranscript};
 #[cfg(feature = "multisig")]
-use frost::curve::Ed25519;
+use dalek_ff_group::EdwardsPoint;
 
 use crate::{
   Commitment, random_scalar,
@@ -80,7 +80,7 @@ fn clsag() {
 #[cfg(feature = "multisig")]
 #[test]
 fn clsag_multisig() -> Result<(), MultisigError> {
-  let keys = key_gen::<_, Ed25519>(&mut OsRng);
+  let keys = key_gen::<_, EdwardsPoint>(&mut OsRng);
 
   let randomness = random_scalar(&mut OsRng);
   let mut ring = vec![];

--- a/coins/monero/src/wallet/send/multisig.rs
+++ b/coins/monero/src/wallet/send/multisig.rs
@@ -13,9 +13,10 @@ use curve25519_dalek::{
   edwards::{EdwardsPoint, CompressedEdwardsY},
 };
 
+use dalek_ff_group as dfg;
+
 use transcript::{Transcript, RecommendedTranscript};
 use frost::{
-  curve::Ed25519,
   FrostError, FrostKeys,
   sign::{
     PreprocessMachine, SignMachine, SignatureMachine, AlgorithmMachine, AlgorithmSignMachine,
@@ -43,7 +44,7 @@ pub struct TransactionMachine {
   decoys: Vec<Decoys>,
 
   inputs: Vec<Arc<RwLock<Option<ClsagDetails>>>>,
-  clsags: Vec<AlgorithmMachine<Ed25519, ClsagMultisig>>,
+  clsags: Vec<AlgorithmMachine<dfg::EdwardsPoint, ClsagMultisig>>,
 }
 
 pub struct TransactionSignMachine {
@@ -55,21 +56,21 @@ pub struct TransactionSignMachine {
   decoys: Vec<Decoys>,
 
   inputs: Vec<Arc<RwLock<Option<ClsagDetails>>>>,
-  clsags: Vec<AlgorithmSignMachine<Ed25519, ClsagMultisig>>,
+  clsags: Vec<AlgorithmSignMachine<dfg::EdwardsPoint, ClsagMultisig>>,
 
   our_preprocess: Vec<u8>,
 }
 
 pub struct TransactionSignatureMachine {
   tx: Transaction,
-  clsags: Vec<AlgorithmSignatureMachine<Ed25519, ClsagMultisig>>,
+  clsags: Vec<AlgorithmSignatureMachine<dfg::EdwardsPoint, ClsagMultisig>>,
 }
 
 impl SignableTransaction {
   pub async fn multisig(
     self,
     rpc: &Rpc,
-    keys: FrostKeys<Ed25519>,
+    keys: FrostKeys<dfg::EdwardsPoint>,
     mut transcript: RecommendedTranscript,
     height: usize,
     mut included: Vec<u16>,

--- a/coins/monero/tests/send.rs
+++ b/coins/monero/tests/send.rs
@@ -17,7 +17,7 @@ use dalek_ff_group::Scalar;
 use transcript::{Transcript, RecommendedTranscript};
 #[cfg(feature = "multisig")]
 use frost::{
-  curve::Ed25519,
+  curve::dfg::EdwardsPoint,
   tests::{THRESHOLD, key_gen, sign},
 };
 
@@ -66,7 +66,7 @@ async fn send_core(test: usize, multisig: bool) {
   let mut spend_pub = &spend * &ED25519_BASEPOINT_TABLE;
 
   #[cfg(feature = "multisig")]
-  let keys = key_gen::<_, Ed25519>(&mut OsRng);
+  let keys = key_gen::<_, dfg::EdwardsPoint>(&mut OsRng);
 
   if multisig {
     #[cfg(not(feature = "multisig"))]

--- a/coins/monero/tests/send.rs
+++ b/coins/monero/tests/send.rs
@@ -12,14 +12,11 @@ use blake2::{digest::Update, Digest, Blake2b512};
 use curve25519_dalek::constants::ED25519_BASEPOINT_TABLE;
 
 #[cfg(feature = "multisig")]
-use dalek_ff_group::Scalar;
+use dalek_ff_group::{Scalar, EdwardsPoint};
 #[cfg(feature = "multisig")]
 use transcript::{Transcript, RecommendedTranscript};
 #[cfg(feature = "multisig")]
-use frost::{
-  curve::dfg::EdwardsPoint,
-  tests::{THRESHOLD, key_gen, sign},
-};
+use frost::tests::{THRESHOLD, key_gen, sign};
 
 use monero_serai::{
   random_scalar,
@@ -66,7 +63,7 @@ async fn send_core(test: usize, multisig: bool) {
   let mut spend_pub = &spend * &ED25519_BASEPOINT_TABLE;
 
   #[cfg(feature = "multisig")]
-  let keys = key_gen::<_, dfg::EdwardsPoint>(&mut OsRng);
+  let keys = key_gen::<_, EdwardsPoint>(&mut OsRng);
 
   if multisig {
     #[cfg(not(feature = "multisig"))]

--- a/crypto/curve/Cargo.toml
+++ b/crypto/curve/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "composable-curve"
+version = "0.12.0"
+description = "Sugar around ff/group"
+license = "MIT"
+authors = ["Luke Parker <lukeparker5132@gmail.com>"]
+edition = "2021"
+
+[dependencies]
+thiserror = "1"
+
+zeroize = "1.3"
+
+ff = { version = "0.12", features = ["bits"] }
+group = "0.12"

--- a/crypto/curve/Cargo.toml
+++ b/crypto/curve/Cargo.toml
@@ -7,9 +7,13 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-thiserror = "1"
+thiserror = { version = "1", optional = true }
 
 zeroize = "1.3"
 
 ff = { version = "0.12", features = ["bits"] }
 group = "0.12"
+
+[features]
+std = []
+serialize = ["std", "thiserror"]

--- a/crypto/curve/src/lib.rs
+++ b/crypto/curve/src/lib.rs
@@ -7,7 +7,11 @@ use zeroize::Zeroize;
 
 pub use group;
 pub use group::ff;
-use group::{ff::{PrimeField, PrimeFieldBits}, Group, GroupOps, GroupEncoding, prime::PrimeGroup};
+use group::{
+  ff::{PrimeField, PrimeFieldBits},
+  Group, GroupOps, GroupEncoding,
+  prime::PrimeGroup,
+};
 
 /// Set of errors for curve-related operations, namely encoding and decoding
 #[derive(Clone, Error, Debug)]
@@ -74,7 +78,10 @@ pub trait Curve: Zeroize + Clone + Copy + PartialEq + Eq + Debug {
   }
 }
 
-impl<G: Zeroize + PrimeGroup> Curve for G where G::Scalar: Zeroize + PrimeField + PrimeFieldBits {
+impl<G: Zeroize + PrimeGroup> Curve for G
+where
+  G::Scalar: Zeroize + PrimeField + PrimeFieldBits,
+{
   type F = G::Scalar;
   type G = G;
 

--- a/crypto/curve/src/lib.rs
+++ b/crypto/curve/src/lib.rs
@@ -19,7 +19,7 @@ pub enum CurveError {
 }
 
 /// Curve trait ensuring access to a variety of ff/group APIs
-pub trait Curve: Clone + Copy + PartialEq + Eq + Debug {
+pub trait Curve: Zeroize + Clone + Copy + PartialEq + Eq + Debug {
   /// Scalar field element type
   type F: Zeroize + PrimeField + PrimeFieldBits;
   /// Group element type

--- a/crypto/curve/src/lib.rs
+++ b/crypto/curve/src/lib.rs
@@ -1,6 +1,10 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 use core::fmt::Debug;
+
+#[cfg(feature = "serialize")]
 use std::io::Read;
 
+#[cfg(feature = "serialize")]
 use thiserror::Error;
 
 use zeroize::Zeroize;
@@ -9,11 +13,14 @@ pub use group;
 pub use group::ff;
 use group::{
   ff::{PrimeField, PrimeFieldBits},
-  Group, GroupOps, GroupEncoding,
+  Group, GroupOps,
   prime::PrimeGroup,
 };
+#[cfg(feature = "serialize")]
+use group::GroupEncoding;
 
 /// Set of errors for curve-related operations, namely encoding and decoding
+#[cfg(feature = "serialize")]
 #[derive(Clone, Error, Debug)]
 pub enum CurveError {
   #[error("invalid scalar")]
@@ -35,18 +42,21 @@ pub trait Curve: Zeroize + Clone + Copy + PartialEq + Eq + Debug {
   fn generator() -> Self::G;
 
   /// Length of a serialized Scalar field element
+  #[cfg(feature = "serialize")]
   #[allow(non_snake_case)]
   fn F_len() -> usize {
     <Self::F as PrimeField>::Repr::default().as_ref().len()
   }
 
   /// Length of a serialized group element
+  #[cfg(feature = "serialize")]
   #[allow(non_snake_case)]
   fn G_len() -> usize {
     <Self::G as GroupEncoding>::Repr::default().as_ref().len()
   }
 
   /// Read a canonical Scalar field element from a Reader
+  #[cfg(feature = "serialize")]
   #[allow(non_snake_case)]
   fn read_F<R: Read>(r: &mut R) -> Result<Self::F, CurveError> {
     let mut encoding = <Self::F as PrimeField>::Repr::default();
@@ -62,6 +72,7 @@ pub trait Curve: Zeroize + Clone + Copy + PartialEq + Eq + Debug {
   }
 
   /// Read a canonical, non-identity, group element from a Reader
+  #[cfg(feature = "serialize")]
   #[allow(non_snake_case)]
   fn read_G<R: Read>(r: &mut R) -> Result<Self::G, CurveError> {
     let mut encoding = <Self::G as GroupEncoding>::Repr::default();

--- a/crypto/curve/src/lib.rs
+++ b/crypto/curve/src/lib.rs
@@ -1,0 +1,92 @@
+use core::fmt::Debug;
+use std::io::Read;
+
+use thiserror::Error;
+
+use zeroize::Zeroize;
+
+pub use group;
+pub use group::ff;
+use group::{ff::{PrimeField, PrimeFieldBits}, Group, GroupOps, GroupEncoding, prime::PrimeGroup};
+
+/// Set of errors for curve-related operations, namely encoding and decoding
+#[derive(Clone, Error, Debug)]
+pub enum CurveError {
+  #[error("invalid scalar")]
+  InvalidScalar,
+  #[error("invalid point")]
+  InvalidPoint,
+}
+
+/// Curve trait ensuring access to a variety of ff/group APIs
+pub trait Curve: Clone + Copy + PartialEq + Eq + Debug {
+  /// Scalar field element type
+  type F: Zeroize + PrimeField + PrimeFieldBits;
+  /// Group element type
+  type G: Zeroize + Group<Scalar = Self::F> + GroupOps + PrimeGroup;
+
+  /// Generator for the group
+  // While group does provide this in its API, multiple schemes frequently require a
+  // different/variable one
+  fn generator() -> Self::G;
+
+  /// Length of a serialized Scalar field element
+  #[allow(non_snake_case)]
+  fn F_len() -> usize {
+    <Self::F as PrimeField>::Repr::default().as_ref().len()
+  }
+
+  /// Length of a serialized group element
+  #[allow(non_snake_case)]
+  fn G_len() -> usize {
+    <Self::G as GroupEncoding>::Repr::default().as_ref().len()
+  }
+
+  /// Read a canonical Scalar field element from a Reader
+  #[allow(non_snake_case)]
+  fn read_F<R: Read>(r: &mut R) -> Result<Self::F, CurveError> {
+    let mut encoding = <Self::F as PrimeField>::Repr::default();
+    r.read_exact(encoding.as_mut()).map_err(|_| CurveError::InvalidScalar)?;
+
+    // ff mandates this is canonical
+    let res =
+      Option::<Self::F>::from(Self::F::from_repr(encoding)).ok_or(CurveError::InvalidScalar);
+    for b in encoding.as_mut() {
+      b.zeroize();
+    }
+    res
+  }
+
+  /// Read a canonical, non-identity, group element from a Reader
+  #[allow(non_snake_case)]
+  fn read_G<R: Read>(r: &mut R) -> Result<Self::G, CurveError> {
+    let mut encoding = <Self::G as GroupEncoding>::Repr::default();
+    r.read_exact(encoding.as_mut()).map_err(|_| CurveError::InvalidPoint)?;
+
+    let point =
+      Option::<Self::G>::from(Self::G::from_bytes(&encoding)).ok_or(CurveError::InvalidPoint)?;
+
+    if (point.is_identity().into()) || (point.to_bytes().as_ref() != encoding.as_ref()) {
+      Err(CurveError::InvalidPoint)?;
+    }
+
+    Ok(point)
+  }
+}
+
+impl<G: Zeroize + PrimeGroup> Curve for G where G::Scalar: Zeroize + PrimeField + PrimeFieldBits {
+  type F = G::Scalar;
+  type G = G;
+
+  fn generator() -> G {
+    G::generator()
+  }
+}
+
+/// Curve implementing hash to curve for its field/group
+pub trait HashToCurve: Curve {
+  #[allow(non_snake_case)]
+  fn hash_to_F(dst: &[u8], msg: &[u8]) -> Self::F;
+  #[allow(non_snake_case)]
+  fn hash_to_G(dst: &[u8], msg: &[u8]) -> Self::G;
+}

--- a/crypto/dleq/Cargo.toml
+++ b/crypto/dleq/Cargo.toml
@@ -32,7 +32,7 @@ transcript = { package = "flexible-transcript", path = "../transcript", features
 
 [features]
 std = []
-serialize = ["std"]
+serialize = ["std", "curve/serialize"]
 experimental = ["std", "multiexp"]
 secure_capacity_difference = []
 

--- a/crypto/dleq/Cargo.toml
+++ b/crypto/dleq/Cargo.toml
@@ -16,8 +16,7 @@ digest = "0.10"
 
 transcript = { package = "flexible-transcript", path = "../transcript", version = "0.1" }
 
-ff = "0.12"
-group = "0.12"
+curve = { package = "composable-curve", path = "../curve", version = "0.12" }
 
 multiexp = { path = "../multiexp", version = "0.2", features = ["batch"], optional = true }
 

--- a/crypto/dleq/src/cross_group/aos.rs
+++ b/crypto/dleq/src/cross_group/aos.rs
@@ -149,9 +149,8 @@ impl<C0: Curve, C1: Curve, const RING_LEN: usize> Aos<C0, C1, RING_LEN> {
   }
 
   // Assumes the ring has already been transcripted in some form. Critically insecure if it hasn't
-  pub(crate) fn verify<R: RngCore + CryptoRng, T: Clone + Transcript>(
+  pub(crate) fn verify<T: Clone + Transcript>(
     &self,
-    rng: &mut R,
     transcript: T,
     generators: (Generators<C0::G>, Generators<C1::G>),
     batch: &mut (BatchVerifier<(), C0::G>, BatchVerifier<(), C1::G>),
@@ -173,8 +172,8 @@ impl<C0: Curve, C1: Curve, const RING_LEN: usize> Aos<C0, C1, RING_LEN> {
           Self::R_batch(generators, *self.s.last().unwrap(), *ring.last().unwrap(), e);
         statements.0.push((C0::F::one(), R0_0));
         statements.1.push((C1::F::one(), R1_0));
-        batch.0.queue(&mut *rng, (), statements.0);
-        batch.1.queue(&mut *rng, (), statements.1);
+        batch.0.queue((), statements.0);
+        batch.1.queue((), statements.1);
       }
 
       Re::e(e_0) => {

--- a/crypto/dleq/src/cross_group/bits.rs
+++ b/crypto/dleq/src/cross_group/bits.rs
@@ -131,9 +131,8 @@ impl<C0: Curve, C1: Curve, const SIGNATURE: u8, const RING_LEN: usize>
     Bits { commitments, signature }
   }
 
-  pub(crate) fn verify<R: RngCore + CryptoRng, T: Clone + Transcript>(
+  pub(crate) fn verify<T: Clone + Transcript>(
     &self,
-    rng: &mut R,
     transcript: &mut T,
     generators: (Generators<C0::G>, Generators<C1::G>),
     batch: &mut (BatchVerifier<(), C0::G>, BatchVerifier<(), C1::G>),

--- a/crypto/dleq/src/cross_group/bits.rs
+++ b/crypto/dleq/src/cross_group/bits.rs
@@ -143,7 +143,6 @@ impl<C0: Curve, C1: Curve, const SIGNATURE: u8, const RING_LEN: usize>
     Self::transcript(transcript, i, self.commitments);
 
     self.signature.verify(
-      rng,
       transcript.clone(),
       generators,
       batch,

--- a/crypto/dleq/src/cross_group/mod.rs
+++ b/crypto/dleq/src/cross_group/mod.rs
@@ -323,18 +323,18 @@ impl<
     };
     let mut batch = (BatchVerifier::new(batch_capacity), BatchVerifier::new(batch_capacity));
 
-    self.poks.0.verify(&mut *rng, transcript, generators.0.primary, keys.0, &mut batch.0);
-    self.poks.1.verify(&mut *rng, transcript, generators.1.primary, keys.1, &mut batch.1);
+    self.poks.0.verify(ranscript, generators.0.primary, keys.0, &mut batch.0);
+    self.poks.1.verify(transcript, generators.1.primary, keys.1, &mut batch.1);
 
     let mut pow_2 = (generators.0.primary, generators.1.primary);
     for (i, bits) in self.bits.iter().enumerate() {
-      bits.verify(&mut *rng, transcript, generators, &mut batch, i, &mut pow_2)?;
+      bits.verify(transcript, generators, &mut batch, i, &mut pow_2)?;
     }
     if let Some(bit) = &self.remainder {
-      bit.verify(&mut *rng, transcript, generators, &mut batch, self.bits.len(), &mut pow_2)?;
+      bit.verify(transcript, generators, &mut batch, self.bits.len(), &mut pow_2)?;
     }
 
-    if (!batch.0.verify_vartime()) || (!batch.1.verify_vartime()) {
+    if (!batch.0.verify_vartime(&mut *rng)) || (!batch.1.verify_vartime(rng)) {
       Err(DLEqError::InvalidProof)?;
     }
 

--- a/crypto/dleq/src/cross_group/mod.rs
+++ b/crypto/dleq/src/cross_group/mod.rs
@@ -323,7 +323,7 @@ impl<
     };
     let mut batch = (BatchVerifier::new(batch_capacity), BatchVerifier::new(batch_capacity));
 
-    self.poks.0.verify(ranscript, generators.0.primary, keys.0, &mut batch.0);
+    self.poks.0.verify(transcript, generators.0.primary, keys.0, &mut batch.0);
     self.poks.1.verify(transcript, generators.1.primary, keys.1, &mut batch.1);
 
     let mut pow_2 = (generators.0.primary, generators.1.primary);

--- a/crypto/dleq/src/cross_group/scalar.rs
+++ b/crypto/dleq/src/cross_group/scalar.rs
@@ -1,6 +1,6 @@
-use ff::PrimeFieldBits;
-
 use zeroize::Zeroize;
+
+use curve::ff::PrimeFieldBits;
 
 /// Convert a uniform scalar into one usable on both fields, clearing the top bits as needed
 pub fn scalar_normalize<F0: PrimeFieldBits + Zeroize, F1: PrimeFieldBits>(

--- a/crypto/dleq/src/cross_group/schnorr.rs
+++ b/crypto/dleq/src/cross_group/schnorr.rs
@@ -51,16 +51,14 @@ impl<C: Curve> SchnorrPoK<C> {
     res
   }
 
-  pub(crate) fn verify<R: RngCore + CryptoRng, T: Transcript>(
+  pub(crate) fn verify<T: Transcript>(
     &self,
-    rng: &mut R,
     transcript: &mut T,
     generator: C::G,
     public_key: C::G,
     batch: &mut BatchVerifier<(), C::G>,
   ) {
     batch.queue(
-      rng,
       (),
       [
         (-self.s, generator),

--- a/crypto/dleq/src/tests/cross_group/aos.rs
+++ b/crypto/dleq/src/tests/cross_group/aos.rs
@@ -1,6 +1,6 @@
 use rand_core::OsRng;
 
-use group::{ff::Field, Group};
+use curve::{ff::Field, group::Group};
 
 use multiexp::BatchVerifier;
 

--- a/crypto/dleq/src/tests/cross_group/scalar.rs
+++ b/crypto/dleq/src/tests/cross_group/scalar.rs
@@ -1,6 +1,6 @@
 use rand_core::OsRng;
 
-use ff::{Field, PrimeField};
+use curve::ff::{Field, PrimeField};
 
 use k256::Scalar as K256Scalar;
 use dalek_ff_group::Scalar as DalekScalar;

--- a/crypto/dleq/src/tests/cross_group/schnorr.rs
+++ b/crypto/dleq/src/tests/cross_group/schnorr.rs
@@ -2,9 +2,9 @@ use rand_core::OsRng;
 
 use zeroize::Zeroize;
 
-use group::{
+use curve::{
   ff::{Field, PrimeFieldBits},
-  prime::PrimeGroup,
+  group::prime::PrimeGroup,
 };
 use multiexp::BatchVerifier;
 
@@ -21,7 +21,7 @@ where
   let mut batch = BatchVerifier::new(10);
   for _ in 0 .. 10 {
     let private = G::Scalar::random(&mut OsRng);
-    SchnorrPoK::prove(&mut OsRng, &mut transcript.clone(), G::generator(), private).verify(
+    SchnorrPoK::<G>::prove(&mut OsRng, &mut transcript.clone(), G::generator(), private).verify(
       &mut OsRng,
       &mut transcript.clone(),
       G::generator(),

--- a/crypto/dleq/src/tests/mod.rs
+++ b/crypto/dleq/src/tests/mod.rs
@@ -4,8 +4,7 @@ mod cross_group;
 use hex_literal::hex;
 use rand_core::OsRng;
 
-use ff::Field;
-use group::GroupEncoding;
+use curve::{ff::Field, group::GroupEncoding};
 
 use k256::{Scalar, ProjectivePoint};
 
@@ -40,7 +39,8 @@ fn test_dleq() {
 
   for i in 0 .. 5 {
     let key = Scalar::random(&mut OsRng);
-    let proof = DLEqProof::prove(&mut OsRng, &mut transcript(), &generators[.. i], key);
+    let proof =
+      DLEqProof::<ProjectivePoint>::prove(&mut OsRng, &mut transcript(), &generators[.. i], key);
 
     let mut keys = [ProjectivePoint::GENERATOR; 5];
     for k in 0 .. 5 {

--- a/crypto/frost/Cargo.toml
+++ b/crypto/frost/Cargo.toml
@@ -19,8 +19,7 @@ hex = "0.4"
 
 sha2 = { version = "0.10", optional = true }
 
-ff = "0.12"
-group = "0.12"
+curve = { package = "composable-curve", path = "../curve", version = "0.12" }
 
 elliptic-curve = { version = "0.12", features = ["hash2curve"], optional = true }
 p256 = { version = "0.11", features = ["arithmetic", "bits", "hash2curve"], optional = true }

--- a/crypto/frost/src/curve/dalek.rs
+++ b/crypto/frost/src/curve/dalek.rs
@@ -1,5 +1,3 @@
-use zeroize::Zeroize;
-
 use sha2::{Digest, Sha512};
 
 use dalek_ff_group::Scalar;
@@ -8,30 +6,18 @@ use crate::{curve::Curve, algorithm::Hram};
 
 macro_rules! dalek_curve {
   (
-    $Curve:      ident,
-    $Hram:       ident,
     $Point:      ident,
-
-    $POINT: ident,
+    $Hram:       ident,
 
     $ID:      literal,
     $CONTEXT: literal,
     $chal:    literal,
     $digest:  literal,
   ) => {
-    use dalek_ff_group::{$Point, $POINT};
+    use dalek_ff_group::$Point;
 
-    #[derive(Clone, Copy, PartialEq, Eq, Debug, Zeroize)]
-    pub struct $Curve;
-    impl Curve for $Curve {
-      type F = Scalar;
-      type G = $Point;
-
+    impl Curve for $Point {
       const ID: &'static [u8] = $ID;
-
-      fn generator() -> Self::G {
-        $POINT
-      }
 
       fn hash_msg(msg: &[u8]) -> Vec<u8> {
         Sha512::new()
@@ -53,10 +39,10 @@ macro_rules! dalek_curve {
 
     #[derive(Copy, Clone)]
     pub struct $Hram;
-    impl Hram<$Curve> for $Hram {
+    impl Hram<$Point> for $Hram {
       #[allow(non_snake_case)]
       fn hram(R: &$Point, A: &$Point, m: &[u8]) -> Scalar {
-        $Curve::hash_to_F($chal, &[&R.compress().to_bytes(), &A.compress().to_bytes(), m].concat())
+        $Point::hash_to_F($chal, &[&R.compress().to_bytes(), &A.compress().to_bytes(), m].concat())
       }
     }
   };
@@ -64,10 +50,8 @@ macro_rules! dalek_curve {
 
 #[cfg(any(test, feature = "ristretto"))]
 dalek_curve!(
-  Ristretto,
-  IetfRistrettoHram,
   RistrettoPoint,
-  RISTRETTO_BASEPOINT_POINT,
+  IetfRistrettoHram,
   b"ristretto",
   b"FROST-RISTRETTO255-SHA512-v5",
   b"chal",
@@ -75,13 +59,4 @@ dalek_curve!(
 );
 
 #[cfg(feature = "ed25519")]
-dalek_curve!(
-  Ed25519,
-  IetfEd25519Hram,
-  EdwardsPoint,
-  ED25519_BASEPOINT_POINT,
-  b"edwards25519",
-  b"",
-  b"",
-  b"",
-);
+dalek_curve!(EdwardsPoint, IetfEd25519Hram, b"edwards25519", b"", b"", b"",);

--- a/crypto/frost/src/curve/mod.rs
+++ b/crypto/frost/src/curve/mod.rs
@@ -1,37 +1,23 @@
-use core::fmt::Debug;
-use std::io::Read;
-
-use thiserror::Error;
-
 use rand_core::{RngCore, CryptoRng};
 
 use zeroize::Zeroize;
 
-use ff::{PrimeField, PrimeFieldBits};
-use group::{Group, GroupOps, GroupEncoding, prime::PrimeGroup};
+use ::curve::ff::PrimeField;
+pub use ::curve::CurveError;
 
 #[cfg(any(test, feature = "dalek"))]
 mod dalek;
 #[cfg(any(test, feature = "ristretto"))]
-pub use dalek::{Ristretto, IetfRistrettoHram};
+pub use dalek::IetfRistrettoHram;
 #[cfg(feature = "ed25519")]
-pub use dalek::{Ed25519, IetfEd25519Hram};
+pub use dalek::IetfEd25519Hram;
 
 #[cfg(feature = "kp256")]
 mod kp256;
 #[cfg(feature = "secp256k1")]
-pub use kp256::{Secp256k1, NonIetfSecp256k1Hram};
+pub use kp256::IetfSecp256k1Hram;
 #[cfg(feature = "p256")]
-pub use kp256::{P256, IetfP256Hram};
-
-/// Set of errors for curve-related operations, namely encoding and decoding
-#[derive(Clone, Error, Debug)]
-pub enum CurveError {
-  #[error("invalid scalar")]
-  InvalidScalar,
-  #[error("invalid point")]
-  InvalidPoint,
-}
+pub use kp256::IetfP256Hram;
 
 /// Unified trait to manage a field/group
 // This should be moved into its own crate if the need for generic cryptography over ff/group
@@ -39,19 +25,9 @@ pub enum CurveError {
 // elliptic-curve exists, yet it doesn't really serve the same role, nor does it use &[u8]/Vec<u8>
 // It uses GenericArray which will hopefully be deprecated as Rust evolves and doesn't offer enough
 // advantages in the modern day to be worth the hassle -- Kayaba
-pub trait Curve: Clone + Copy + PartialEq + Eq + Debug + Zeroize {
-  /// Scalar field element type
-  // This is available via G::Scalar yet `C::G::Scalar` is ambiguous, forcing horrific accesses
-  type F: PrimeField + PrimeFieldBits + Zeroize;
-  /// Group element type
-  type G: Group<Scalar = Self::F> + GroupOps + PrimeGroup + Zeroize;
-
+pub trait Curve: ::curve::Curve {
   /// ID for this curve
   const ID: &'static [u8];
-
-  /// Generator for the group
-  // While group does provide this in its API, privacy coins may want to use a custom basepoint
-  fn generator() -> Self::G;
 
   /// Hash the message for the binding factor. H3 from the IETF draft
   // This doesn't actually need to be part of Curve as it does nothing with the curve
@@ -90,42 +66,4 @@ pub trait Curve: Clone + Copy + PartialEq + Eq + Debug + Zeroize {
   // hash_msg and hash_binding_factor
   #[allow(non_snake_case)]
   fn hash_to_F(dst: &[u8], msg: &[u8]) -> Self::F;
-
-  #[allow(non_snake_case)]
-  fn F_len() -> usize {
-    <Self::F as PrimeField>::Repr::default().as_ref().len()
-  }
-
-  #[allow(non_snake_case)]
-  fn G_len() -> usize {
-    <Self::G as GroupEncoding>::Repr::default().as_ref().len()
-  }
-
-  #[allow(non_snake_case)]
-  fn read_F<R: Read>(r: &mut R) -> Result<Self::F, CurveError> {
-    let mut encoding = <Self::F as PrimeField>::Repr::default();
-    r.read_exact(encoding.as_mut()).map_err(|_| CurveError::InvalidScalar)?;
-
-    // ff mandates this is canonical
-    let res =
-      Option::<Self::F>::from(Self::F::from_repr(encoding)).ok_or(CurveError::InvalidScalar);
-    for b in encoding.as_mut() {
-      b.zeroize();
-    }
-    res
-  }
-
-  #[allow(non_snake_case)]
-  fn read_G<R: Read>(r: &mut R) -> Result<Self::G, CurveError> {
-    let mut encoding = <Self::G as GroupEncoding>::Repr::default();
-    r.read_exact(encoding.as_mut()).map_err(|_| CurveError::InvalidPoint)?;
-
-    let point =
-      Option::<Self::G>::from(Self::G::from_bytes(&encoding)).ok_or(CurveError::InvalidPoint)?;
-    // Ban the identity, per the FROST spec, and non-canonical points
-    if (point.is_identity().into()) || (point.to_bytes().as_ref() != encoding.as_ref()) {
-      Err(CurveError::InvalidPoint)?;
-    }
-    Ok(point)
-  }
 }

--- a/crypto/frost/src/key_gen.rs
+++ b/crypto/frost/src/key_gen.rs
@@ -227,9 +227,9 @@ fn complete_r2<Re: Read, R: RngCore + CryptoRng, C: Curve>(
     values.push((-*share, C::generator()));
     share.zeroize();
 
-    batch.queue(rng, *l, values);
+    batch.queue(*l, values);
   }
-  batch.verify_with_vartime_blame().map_err(FrostError::InvalidCommitment)?;
+  batch.verify_with_vartime_blame(rng).map_err(FrostError::InvalidCommitment)?;
 
   // Stripe commitments per t and sum them in advance. Calculating verification shares relies on
   // these sums so preprocessing them is a massive speedup

--- a/crypto/frost/src/key_gen.rs
+++ b/crypto/frost/src/key_gen.rs
@@ -8,7 +8,7 @@ use rand_core::{RngCore, CryptoRng};
 
 use zeroize::Zeroize;
 
-use group::{
+use ::curve::group::{
   ff::{Field, PrimeField},
   GroupEncoding,
 };

--- a/crypto/frost/src/lib.rs
+++ b/crypto/frost/src/lib.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 use zeroize::Zeroize;
 
-use group::{
+use ::curve::group::{
   ff::{Field, PrimeField},
   GroupEncoding,
 };
@@ -13,7 +13,7 @@ use group::{
 mod schnorr;
 
 pub mod curve;
-use curve::Curve;
+use crate::curve::Curve;
 
 pub mod key_gen;
 pub mod promote;

--- a/crypto/frost/src/promote.rs
+++ b/crypto/frost/src/promote.rs
@@ -7,7 +7,7 @@ use std::{
 
 use rand_core::{RngCore, CryptoRng};
 
-use group::GroupEncoding;
+use ::curve::group::GroupEncoding;
 
 use transcript::{Transcript, RecommendedTranscript};
 use dleq::DLEqProof;

--- a/crypto/frost/src/schnorr.rs
+++ b/crypto/frost/src/schnorr.rs
@@ -2,7 +2,7 @@ use rand_core::{RngCore, CryptoRng};
 
 use zeroize::Zeroize;
 
-use group::{
+use ::curve::group::{
   ff::{Field, PrimeField},
   GroupEncoding,
 };

--- a/crypto/frost/src/schnorr.rs
+++ b/crypto/frost/src/schnorr.rs
@@ -65,8 +65,8 @@ pub(crate) fn batch_verify<C: Curve, R: RngCore + CryptoRng>(
     // -sG
     values[2].0 = -triple.3.s;
 
-    batch.queue(rng, triple.0, values);
+    batch.queue(triple.0, values);
   }
 
-  batch.verify_vartime_with_vartime_blame()
+  batch.verify_vartime_with_vartime_blame(rng)
 }

--- a/crypto/frost/src/sign.rs
+++ b/crypto/frost/src/sign.rs
@@ -10,7 +10,7 @@ use zeroize::Zeroize;
 
 use transcript::Transcript;
 
-use group::{
+use ::curve::group::{
   ff::{Field, PrimeField},
   Group, GroupEncoding,
 };
@@ -134,7 +134,7 @@ fn preprocess<R: RngCore + CryptoRng, C: Curve, A: Algorithm<C>>(
         // This could be further optimized with a multi-nonce proof.
         // See https://github.com/serai-dex/serai/issues/38
         for mut nonce in nonces {
-          DLEqProof::prove(&mut *rng, &mut transcript, generators, nonce)
+          DLEqProof::<C>::prove(&mut *rng, &mut transcript, generators, nonce)
             .serialize(&mut serialized)
             .unwrap();
           nonce.zeroize();
@@ -229,7 +229,7 @@ fn sign_with_share<Re: Read, C: Curve, A: Algorithm<C>>(
           if nonce_generators.len() >= 2 {
             let mut transcript = nonce_transcript::<A::Transcript>();
             for de in 0 .. 2 {
-              DLEqProof::deserialize(&mut cursor)
+              DLEqProof::<C>::deserialize(&mut cursor)
                 .map_err(|_| FrostError::InvalidCommitment(*l))?
                 .verify(
                   &mut transcript,

--- a/crypto/frost/src/tests/curve.rs
+++ b/crypto/frost/src/tests/curve.rs
@@ -2,7 +2,7 @@ use std::io::Cursor;
 
 use rand_core::{RngCore, CryptoRng};
 
-use group::{ff::Field, Group};
+use ::curve::group::{ff::Field, Group};
 
 use crate::{Curve, FrostCore, tests::core_gen};
 

--- a/crypto/frost/src/tests/literal/dalek.rs
+++ b/crypto/frost/src/tests/literal/dalek.rs
@@ -8,7 +8,7 @@ use crate::{
 #[cfg(any(test, feature = "ristretto"))]
 #[test]
 fn ristretto_vectors() {
-  test_with_vectors::<_, curve::Ristretto, curve::IetfRistrettoHram>(
+  test_with_vectors::<_, dalek_ff_group::RistrettoPoint, curve::IetfRistrettoHram>(
     &mut OsRng,
     Vectors {
       threshold: 2,
@@ -45,7 +45,7 @@ fn ristretto_vectors() {
 #[cfg(feature = "ed25519")]
 #[test]
 fn ed25519_vectors() {
-  test_with_vectors::<_, curve::Ed25519, curve::IetfEd25519Hram>(
+  test_with_vectors::<_, dalek_ff_group::EdwardsPoint, curve::IetfEd25519Hram>(
     &mut OsRng,
     Vectors {
       threshold: 2,

--- a/crypto/frost/src/tests/literal/kp256.rs
+++ b/crypto/frost/src/tests/literal/kp256.rs
@@ -4,15 +4,15 @@ use rand_core::OsRng;
 use crate::tests::vectors::{Vectors, test_with_vectors};
 
 #[cfg(feature = "secp256k1")]
-use crate::curve::{Secp256k1, NonIetfSecp256k1Hram};
+use crate::curve::IetfSecp256k1Hram;
 
 #[cfg(feature = "p256")]
-use crate::curve::{P256, IetfP256Hram};
+use crate::curve::IetfP256Hram;
 
 #[cfg(feature = "secp256k1")]
 #[test]
 fn secp256k1_non_ietf() {
-  test_with_vectors::<_, Secp256k1, NonIetfSecp256k1Hram>(
+  test_with_vectors::<_, k256::ProjectivePoint, IetfSecp256k1Hram>(
     &mut OsRng,
     Vectors {
       threshold: 2,
@@ -49,7 +49,7 @@ fn secp256k1_non_ietf() {
 #[cfg(feature = "p256")]
 #[test]
 fn p256_vectors() {
-  test_with_vectors::<_, P256, IetfP256Hram>(
+  test_with_vectors::<_, p256::ProjectivePoint, IetfP256Hram>(
     &mut OsRng,
     Vectors {
       threshold: 2,

--- a/crypto/frost/src/tests/mod.rs
+++ b/crypto/frost/src/tests/mod.rs
@@ -2,7 +2,7 @@ use std::{io::Cursor, collections::HashMap};
 
 use rand_core::{RngCore, CryptoRng};
 
-use group::ff::Field;
+use ::curve::group::ff::Field;
 
 use crate::{
   Curve, FrostParams, FrostCore, FrostKeys, lagrange,

--- a/crypto/frost/src/tests/promote.rs
+++ b/crypto/frost/src/tests/promote.rs
@@ -4,11 +4,9 @@ use rand_core::{RngCore, CryptoRng};
 
 use zeroize::Zeroize;
 
-use group::Group;
-
 use crate::{
-  Curve, // FrostKeys,
-  promote::{GeneratorPromotion /* CurvePromote */},
+  Curve,
+  promote::GeneratorPromotion,
   tests::{clone_without, key_gen, schnorr::sign_core},
 };
 
@@ -18,15 +16,17 @@ struct AltFunctions<C: Curve> {
   _curve: PhantomData<C>,
 }
 
-impl<C: Curve> Curve for AltFunctions<C> {
+impl<C: Curve> ::curve::Curve for AltFunctions<C> {
   type F = C::F;
   type G = C::G;
-
-  const ID: &'static [u8] = b"alt_functions";
 
   fn generator() -> Self::G {
     C::generator()
   }
+}
+
+impl<C: Curve> Curve for AltFunctions<C> {
+  const ID: &'static [u8] = b"alt_functions";
 
   fn hash_msg(msg: &[u8]) -> Vec<u8> {
     C::hash_msg(&[msg, b"alt"].concat())
@@ -60,15 +60,17 @@ struct AltGenerator<C: Curve> {
   _curve: PhantomData<C>,
 }
 
-impl<C: Curve> Curve for AltGenerator<C> {
+impl<C: Curve> ::curve::Curve for AltGenerator<C> {
   type F = C::F;
   type G = C::G;
-
-  const ID: &'static [u8] = b"alt_generator";
 
   fn generator() -> Self::G {
     C::G::generator() * C::hash_to_F(b"FROST_tests", b"generator")
   }
+}
+
+impl<C: Curve> Curve for AltGenerator<C> {
+  const ID: &'static [u8] = b"alt_generator";
 
   fn hash_msg(msg: &[u8]) -> Vec<u8> {
     C::hash_msg(msg)

--- a/crypto/frost/src/tests/schnorr.rs
+++ b/crypto/frost/src/tests/schnorr.rs
@@ -2,7 +2,7 @@ use std::{marker::PhantomData, collections::HashMap};
 
 use rand_core::{RngCore, CryptoRng};
 
-use group::{ff::Field, Group, GroupEncoding};
+use ::curve::group::{ff::Field, Group, GroupEncoding};
 
 use crate::{
   Curve, FrostKeys,

--- a/crypto/frost/src/tests/vectors.rs
+++ b/crypto/frost/src/tests/vectors.rs
@@ -2,7 +2,7 @@ use std::{io::Cursor, collections::HashMap};
 
 use rand_core::{RngCore, CryptoRng};
 
-use group::{ff::PrimeField, GroupEncoding};
+use ::curve::group::{ff::PrimeField, GroupEncoding};
 
 use crate::{
   curve::Curve,

--- a/crypto/multiexp/src/batch.rs
+++ b/crypto/multiexp/src/batch.rs
@@ -8,11 +8,67 @@ use group::Group;
 use crate::{multiexp, multiexp_vartime};
 
 #[cfg(feature = "batch")]
-#[derive(Clone, Zeroize)]
-pub struct BatchVerifier<Id: Copy + Zeroize, G: Group + Zeroize>(Vec<(Id, Vec<(G::Scalar, G)>)>);
+#[derive(Clone)]
+pub struct BatchVerifier<Id: Copy, G: Group + Zeroize>(Vec<(Id, Vec<(G::Scalar, G)>)>);
+impl<Id: Copy, G: Group + Zeroize> Zeroize for BatchVerifier<Id, G>
+where
+  G::Scalar: Zeroize,
+{
+  fn zeroize(&mut self) {
+    for (_, pairs) in self.0.iter_mut() {
+      for pair in pairs.iter_mut() {
+        pair.zeroize();
+      }
+    }
+  }
+}
+
+fn weight<R: RngCore + CryptoRng, F: Field>(rng: &mut R, i: usize) -> F {
+  if i == 0 {
+    F::one()
+  } else {
+    let mut weight;
+    while {
+      // Generate a random scalar
+      weight = F::random(&mut *rng);
+
+      // Clears half the bits, maintaining security, to minimize scalar additions
+      // Is not practically faster for whatever reason
+      /*
+      // Generate a random scalar
+      let mut repr = G::Scalar::random(&mut *rng).to_repr();
+
+      // Calculate the amount of bytes to clear. We want to clear less than half
+      let repr_len = repr.as_ref().len();
+      let unused_bits = (repr_len * 8) - usize::try_from(G::Scalar::CAPACITY).unwrap();
+      // Don't clear any partial bytes
+      let to_clear = (repr_len / 2) - ((unused_bits + 7) / 8);
+
+      // Clear a safe amount of bytes
+      for b in &mut repr.as_mut()[.. to_clear] {
+        *b = 0;
+      }
+
+      // Ensure these bits are used as the low bits so low scalars multiplied by this don't
+      // become large scalars
+      weight = G::Scalar::from_repr(repr).unwrap();
+      // Tests if any bit we supposedly just cleared is set, and if so, reverses it
+      // Not a security issue if this fails, just a minor performance hit at ~2^-120 odds
+      if weight.to_le_bits().iter().take(to_clear * 8).any(|bit| *bit) {
+        repr.as_mut().reverse();
+        weight = G::Scalar::from_repr(repr).unwrap();
+      }
+      */
+
+      // Ensure it's non-zero, as a zero scalar would cause this item to pass no matter what
+      weight.is_zero().into()
+    } {}
+    weight
+  }
+}
 
 #[cfg(feature = "batch")]
-impl<Id: Copy + Zeroize, G: Group + Zeroize> BatchVerifier<Id, G>
+impl<Id: Copy, G: Group + Zeroize> BatchVerifier<Id, G>
 where
   <G as Group>::Scalar: PrimeFieldBits + Zeroize,
 {
@@ -20,89 +76,48 @@ where
     BatchVerifier(Vec::with_capacity(capacity))
   }
 
-  pub fn queue<R: RngCore + CryptoRng, I: IntoIterator<Item = (G::Scalar, G)>>(
-    &mut self,
-    rng: &mut R,
-    id: Id,
-    pairs: I,
-  ) {
-    // Define a unique scalar factor for this set of variables so individual items can't overlap
-    let u = if self.0.is_empty() {
-      G::Scalar::one()
-    } else {
-      let mut weight;
-      while {
-        // Generate a random scalar
-        weight = G::Scalar::random(&mut *rng);
+  pub fn queue<I: IntoIterator<Item = (G::Scalar, G)>>(&mut self, id: Id, pairs: I) {
+    self.0.push((id, pairs.into_iter().collect()));
+  }
 
-        // Clears half the bits, maintaining security, to minimize scalar additions
-        // Is not practically faster for whatever reason
-        /*
-        // Generate a random scalar
-        let mut repr = G::Scalar::random(&mut *rng).to_repr();
-
-        // Calculate the amount of bytes to clear. We want to clear less than half
-        let repr_len = repr.as_ref().len();
-        let unused_bits = (repr_len * 8) - usize::try_from(G::Scalar::CAPACITY).unwrap();
-        // Don't clear any partial bytes
-        let to_clear = (repr_len / 2) - ((unused_bits + 7) / 8);
-
-        // Clear a safe amount of bytes
-        for b in &mut repr.as_mut()[.. to_clear] {
-          *b = 0;
-        }
-
-        // Ensure these bits are used as the low bits so low scalars multiplied by this don't
-        // become large scalars
-        weight = G::Scalar::from_repr(repr).unwrap();
-        // Tests if any bit we supposedly just cleared is set, and if so, reverses it
-        // Not a security issue if this fails, just a minor performance hit at ~2^-120 odds
-        if weight.to_le_bits().iter().take(to_clear * 8).any(|bit| *bit) {
-          repr.as_mut().reverse();
-          weight = G::Scalar::from_repr(repr).unwrap();
-        }
-        */
-
-        // Ensure it's non-zero, as a zero scalar would cause this item to pass no matter what
-        weight.is_zero().into()
-      } {}
-      weight
-    };
-    self.0.push((id, pairs.into_iter().map(|(scalar, point)| (scalar * u, point)).collect()));
+  fn flat<R: RngCore + CryptoRng>(&self, rng: &mut R) -> Vec<(G::Scalar, G)> {
+    self
+      .0
+      .iter()
+      .enumerate()
+      .flat_map(|(i, pairs)| {
+        let weight: G::Scalar = weight(rng, i);
+        pairs.1.iter().map(move |(f, g)| (*f * weight, *g))
+      })
+      .collect::<Vec<_>>()
   }
 
   #[must_use]
-  pub fn verify_core(&self) -> bool {
-    let mut flat = self.0.iter().flat_map(|pairs| pairs.1.iter()).cloned().collect::<Vec<_>>();
+  pub fn verify_core<R: RngCore + CryptoRng>(&self, rng: &mut R) -> bool {
+    let mut flat = self.flat(rng);
     let res = multiexp(&flat).is_identity().into();
     flat.zeroize();
     res
   }
 
-  pub fn verify(mut self) -> bool {
-    let res = self.verify_core();
+  #[must_use]
+  pub fn verify<R: RngCore + CryptoRng>(mut self, rng: &mut R) -> bool {
+    let res = self.verify_core(rng);
     self.zeroize();
     res
   }
 
   #[must_use]
-  pub fn verify_vartime(&self) -> bool {
-    multiexp_vartime(&self.0.iter().flat_map(|pairs| pairs.1.iter()).cloned().collect::<Vec<_>>())
-      .is_identity()
-      .into()
+  pub fn verify_vartime<R: RngCore + CryptoRng>(&self, rng: &mut R) -> bool {
+    multiexp_vartime(&self.flat(rng)).is_identity().into()
   }
 
   // A constant time variant may be beneficial for robust protocols
-  pub fn blame_vartime(&self) -> Option<Id> {
+  pub fn blame_vartime<R: RngCore + CryptoRng>(&self, rng: &mut R) -> Option<Id> {
     let mut slice = self.0.as_slice();
     while slice.len() > 1 {
       let split = slice.len() / 2;
-      if multiexp_vartime(
-        &slice[.. split].iter().flat_map(|pairs| pairs.1.iter()).cloned().collect::<Vec<_>>(),
-      )
-      .is_identity()
-      .into()
-      {
+      if BatchVerifier(slice[.. split].to_vec()).verify_vartime(rng) {
         slice = &slice[split ..];
       } else {
         slice = &slice[.. split];
@@ -115,17 +130,23 @@ where
       .map(|(id, _)| *id)
   }
 
-  pub fn verify_with_vartime_blame(mut self) -> Result<(), Id> {
-    let res = if self.verify_core() { Ok(()) } else { Err(self.blame_vartime().unwrap()) };
+  pub fn verify_with_vartime_blame<R: RngCore + CryptoRng>(
+    mut self,
+    rng: &mut R,
+  ) -> Result<(), Id> {
+    let res = if self.verify_core(rng) { Ok(()) } else { Err(self.blame_vartime(rng).unwrap()) };
     self.zeroize();
     res
   }
 
-  pub fn verify_vartime_with_vartime_blame(&self) -> Result<(), Id> {
-    if self.verify_vartime() {
+  pub fn verify_vartime_with_vartime_blame<R: RngCore + CryptoRng>(
+    &self,
+    rng: &mut R,
+  ) -> Result<(), Id> {
+    if self.verify_vartime(rng) {
       Ok(())
     } else {
-      Err(self.blame_vartime().unwrap())
+      Err(self.blame_vartime(rng).unwrap())
     }
   }
 }

--- a/crypto/multiexp/src/tests/mod.rs
+++ b/crypto/multiexp/src/tests/mod.rs
@@ -107,6 +107,17 @@ fn test_ed25519() {
   test_multiexp::<EdwardsPoint>();
 }
 
+#[cfg(feature = "batch")]
+#[test]
+fn test_weighting() {
+  // Queue statements which sum to 0 yet in different groups
+  let mut verifier = crate::BatchVerifier::new(2);
+  verifier.queue(0, [(k256::Scalar::one(), ProjectivePoint::GENERATOR)]);
+  verifier.queue(1, [(-k256::Scalar::one(), ProjectivePoint::GENERATOR)]);
+  // Should fail
+  assert!(!verifier.verify_vartime(&mut OsRng));
+}
+
 #[ignore]
 #[test]
 fn benchmark() {

--- a/crypto/schnorr/Cargo.toml
+++ b/crypto/schnorr/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "modular-schnorr"
+version = "0.1.0"
+description = "Implementation of Schnorr signatures for ff/group"
+license = "MIT"
+authors = ["Luke Parker <lukeparker5132@gmail.com>"]
+edition = "2021"
+
+[dependencies]
+rand_core = "0.6"
+
+curve = { package = "composable-curve", path = "../curve", version = "0.12" }
+
+multiexp = { path = "../multiexp", version = "0.2", features = ["batch"], optional = true }
+
+[dev-dependencies]
+blake2 = "0.10"
+dalek-ff-group = { path = "../dalek-ff-group" }
+
+[features]
+std = []
+serialize = ["std"]
+batch = ["std", "multiexp"]

--- a/crypto/schnorr/Cargo.toml
+++ b/crypto/schnorr/Cargo.toml
@@ -19,5 +19,5 @@ dalek-ff-group = { path = "../dalek-ff-group" }
 
 [features]
 std = []
-serialize = ["std"]
+serialize = ["std", "curve/serialize"]
 batch = ["std", "multiexp"]

--- a/crypto/schnorr/src/lib.rs
+++ b/crypto/schnorr/src/lib.rs
@@ -1,0 +1,129 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use core::marker::PhantomData;
+
+use rand_core::{RngCore, CryptoRng};
+
+use curve::{
+  group::{ff::Field, Group},
+  Curve,
+};
+
+#[cfg(feature = "batch")]
+use multiexp::BatchVerifier;
+
+pub trait Signature<C: Curve>: Sized + Clone + Copy {
+  /// Sign a msg with the provided nonce.
+  fn sign_core(key: C::F, nonce: C::F, msg: &[u8]) -> Self;
+
+  /// Sign a msg with a randomly generated nonce.
+  fn sign_random_nonce<R: RngCore + CryptoRng>(rng: &mut R, key: C::F, msg: &[u8]) -> Self {
+    Self::sign_core(key, C::F::random(rng), msg)
+  }
+
+  /*
+  For a properly selected hash function (no length extension attacks and so on), this would be
+  optimal. sign could then call sign_deterministic_nonce with SHA3. The issues are two-fold:
+  1) Needing to perform multiple hashes for the needed bits/use SHAKE256
+  2) Needing to convert this to a Scalar for an arbitratry field (only possible with
+     double-and-add-style schemes)
+  The latter is the main objection at this time.
+  */
+  /// Sign a msg with a deterministic nonce generated as H(x || m).
+  // pub fn sign_deterministic_nonce<D: Digest>(key: C::F, msg: &[u8]) -> Self {}
+
+  /// Alias to the preferred sign function, which is currently sign_random_nonce but may change to
+  /// a deterministic scheme in the future.
+  fn sign<R: RngCore + CryptoRng>(rng: &mut R, key: C::F, msg: &[u8]) -> Self {
+    Self::sign_random_nonce(rng, key, msg)
+  }
+
+  /// Verify a signature.
+  #[must_use]
+  fn verify(&self, key: C::G, msg: &[u8]) -> bool;
+}
+
+/// A parameterizable HRAm to support a variety of signature specifications.
+pub trait Hram<C: Curve>: Sized + Clone + Copy {
+  /// HRAM function to generate a challenge
+  #[allow(non_snake_case)]
+  fn hram(R: C::G, A: C::G, m: &[u8]) -> C::F;
+}
+
+#[allow(non_snake_case)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Schnorr<C: Curve, H: Hram<C>> {
+  pub R: C::G,
+  pub s: C::F,
+  _hram: PhantomData<H>,
+}
+
+#[allow(non_snake_case)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ClassicalSchnorr<C: Curve, H: Hram<C>> {
+  pub c: C::F,
+  pub s: C::F,
+  _hram: PhantomData<H>,
+}
+
+impl<C: Curve, H: Hram<C>> Schnorr<C, H> {
+  #[allow(non_snake_case)]
+  pub fn new(R: C::G, s: C::F) -> Self {
+    Self { R, s, _hram: PhantomData }
+  }
+
+  fn verification_statements(&self, key: C::G, msg: &[u8]) -> [(C::F, C::G); 3] {
+    // R + cA == sG where s = r + cx
+    [(C::F::one(), self.R), (H::hram(self.R, key, msg), key), (-self.s, C::generator())]
+  }
+
+  #[cfg(feature = "batch")]
+  pub fn queue_batch_verification<R: RngCore + CryptoRng, Id: Copy>(
+    &self,
+    rng: &mut R,
+    verifier: &mut BatchVerifier<Id, C::G>,
+    id: Id,
+    key: C::G,
+    msg: &[u8],
+  ) {
+    verifier.queue(rng, id, self.verification_statements(key, msg));
+  }
+}
+
+impl<C: Curve, H: Hram<C>> Signature<C> for Schnorr<C, H> {
+  fn sign_core(key: C::F, nonce: C::F, msg: &[u8]) -> Self {
+    #[allow(non_snake_case)]
+    let R = C::generator() * nonce;
+    Self { R, s: nonce + (key * H::hram(R, C::generator() * key, msg)), _hram: PhantomData }
+  }
+
+  /// Verify a signature.
+  #[must_use]
+  fn verify(&self, key: C::G, msg: &[u8]) -> bool {
+    let mut accum = C::G::identity();
+    for statement in self.verification_statements(key, msg) {
+      accum += statement.1 * statement.0;
+    }
+    accum.is_identity().into()
+  }
+}
+
+impl<C: Curve, H: Hram<C>> ClassicalSchnorr<C, H> {
+  pub fn new(c: C::F, s: C::F) -> Self {
+    Self { c, s, _hram: PhantomData }
+  }
+}
+
+impl<C: Curve, H: Hram<C>> Signature<C> for ClassicalSchnorr<C, H> {
+  fn sign_core(key: C::F, nonce: C::F, msg: &[u8]) -> Self {
+    let c = H::hram(C::generator() * nonce, C::generator() * key, msg);
+    Self { c, s: nonce - (key * c), _hram: PhantomData }
+  }
+
+  /// Verify a signature.
+  #[must_use]
+  fn verify(&self, key: C::G, msg: &[u8]) -> bool {
+    self.c == H::hram((C::generator() * self.s) + (key * self.c), key, msg)
+  }
+}
+

--- a/crypto/schnorr/src/lib.rs
+++ b/crypto/schnorr/src/lib.rs
@@ -78,15 +78,14 @@ impl<C: Curve, H: Hram<C>> Schnorr<C, H> {
   }
 
   #[cfg(feature = "batch")]
-  pub fn queue_batch_verification<R: RngCore + CryptoRng, Id: Copy>(
+  pub fn queue_batch_verification<Id: Copy>(
     &self,
-    rng: &mut R,
     verifier: &mut BatchVerifier<Id, C::G>,
     id: Id,
     key: C::G,
     msg: &[u8],
   ) {
-    verifier.queue(rng, id, self.verification_statements(key, msg));
+    verifier.queue(id, self.verification_statements(key, msg));
   }
 }
 
@@ -126,4 +125,3 @@ impl<C: Curve, H: Hram<C>> Signature<C> for ClassicalSchnorr<C, H> {
     self.c == H::hram((C::generator() * self.s) + (key * self.c), key, msg)
   }
 }
-

--- a/crypto/schnorr/tests/tests.rs
+++ b/crypto/schnorr/tests/tests.rs
@@ -90,26 +90,19 @@ fn batch_verify() {
       &[MSG, &i.to_le_bytes()].concat(),
     ));
     sigs[i].queue_batch_verification(
-      &mut OsRng,
       &mut verifier,
       i,
       RistrettoPoint::generator() * keys[i],
       &[MSG, &i.to_le_bytes()].concat(),
     );
   }
-  assert!(verifier.verify_vartime());
+  assert!(verifier.verify_vartime(&mut OsRng));
 
   // Test invalid signatures don't batch verify
   Schnorr::<RistrettoPoint, SimpleHram>::new(
     RistrettoPoint::random(&mut OsRng),
     Scalar::random(&mut OsRng),
   )
-  .queue_batch_verification(
-    &mut OsRng,
-    &mut verifier,
-    5,
-    RistrettoPoint::random(&mut OsRng),
-    MSG,
-  );
-  assert_eq!(verifier.verify_vartime_with_vartime_blame().unwrap_err(), 5);
+  .queue_batch_verification(&mut verifier, 5, RistrettoPoint::random(&mut OsRng), MSG);
+  assert_eq!(verifier.verify_vartime_with_vartime_blame(&mut OsRng).unwrap_err(), 5);
 }

--- a/crypto/schnorr/tests/tests.rs
+++ b/crypto/schnorr/tests/tests.rs
@@ -1,0 +1,115 @@
+use rand_core::OsRng;
+
+use blake2::{Digest, Blake2b512};
+
+use curve::group::{ff::Field, Group, GroupEncoding};
+use dalek_ff_group::{Scalar, RistrettoPoint};
+
+use multiexp::BatchVerifier;
+
+use modular_schnorr::{Hram, Signature, Schnorr, ClassicalSchnorr};
+
+const MSG: &[u8] = b"Hello, World";
+
+#[derive(Clone, Copy)]
+struct SimpleHram;
+impl Hram<RistrettoPoint> for SimpleHram {
+  #[allow(non_snake_case)]
+  fn hram(R: RistrettoPoint, A: RistrettoPoint, m: &[u8]) -> Scalar {
+    Scalar::from_hash(Blake2b512::new().chain_update(&[&R.to_bytes(), &A.to_bytes(), m].concat()))
+  }
+}
+
+#[test]
+fn sign_verify() {
+  let key = Scalar::random(&mut OsRng);
+  assert!(Schnorr::<RistrettoPoint, SimpleHram>::sign(&mut OsRng, key, MSG)
+    .verify(RistrettoPoint::generator() * key, MSG));
+  assert!(ClassicalSchnorr::<RistrettoPoint, SimpleHram>::sign(&mut OsRng, key, MSG)
+    .verify(RistrettoPoint::generator() * key, MSG));
+}
+
+/*
+#[test]
+fn conversion() {
+  let key = Scalar::random(&mut OsRng);
+  let pub = RistrettoPoint::generator() * key;
+  let sig = Schnorr::<RistrettoPoint, SimpleHram>::sign(&mut OsRng, key, MSG);
+  assert!(sig.verify(public_key, MSG));
+
+  let classical = ClassicalSchnorr::from(sig);
+  assert!(classical.verify(public_key, MSG));
+  let back = Schnorr::from(classical);
+  assert!(back.verify(public_key, MSG));
+  assert_eq!(sig, back);
+}
+*/
+
+#[test]
+fn zero() {
+  // True zero should pass for any message
+  assert!(Schnorr::<RistrettoPoint, SimpleHram>::new(RistrettoPoint::identity(), Scalar::zero())
+    .verify(RistrettoPoint::identity(), MSG));
+  // ClassicalSchnorr doesn't have a "true zero" as c is a hash output
+  // While it's possible to craft a c for a 0 nonce, that's just checking a 0 nonce
+
+  // But not for an actual key
+  assert!(!Schnorr::<RistrettoPoint, SimpleHram>::new(RistrettoPoint::identity(), Scalar::zero())
+    .verify(RistrettoPoint::random(&mut OsRng), MSG));
+  assert!(!ClassicalSchnorr::<RistrettoPoint, SimpleHram>::new(Scalar::zero(), Scalar::zero())
+    .verify(RistrettoPoint::random(&mut OsRng), MSG));
+}
+
+#[test]
+fn random_fails() {
+  assert!(!Schnorr::<RistrettoPoint, SimpleHram>::new(
+    RistrettoPoint::random(&mut OsRng),
+    Scalar::random(&mut OsRng)
+  )
+  .verify(RistrettoPoint::random(&mut OsRng), MSG));
+
+  assert!(!ClassicalSchnorr::<RistrettoPoint, SimpleHram>::new(
+    Scalar::random(&mut OsRng),
+    Scalar::random(&mut OsRng)
+  )
+  .verify(RistrettoPoint::random(&mut OsRng), MSG));
+}
+
+#[cfg(feature = "batch")]
+#[test]
+fn batch_verify() {
+  // Create 5 signatures
+  let mut keys = vec![];
+  let mut sigs = vec![];
+  let mut verifier = BatchVerifier::new(5);
+  for i in 0 .. 5 {
+    keys.push(Scalar::random(&mut OsRng));
+    sigs.push(Schnorr::<RistrettoPoint, SimpleHram>::sign(
+      &mut OsRng,
+      keys[i],
+      &[MSG, &i.to_le_bytes()].concat(),
+    ));
+    sigs[i].queue_batch_verification(
+      &mut OsRng,
+      &mut verifier,
+      i,
+      RistrettoPoint::generator() * keys[i],
+      &[MSG, &i.to_le_bytes()].concat(),
+    );
+  }
+  assert!(verifier.verify_vartime());
+
+  // Test invalid signatures don't batch verify
+  Schnorr::<RistrettoPoint, SimpleHram>::new(
+    RistrettoPoint::random(&mut OsRng),
+    Scalar::random(&mut OsRng),
+  )
+  .queue_batch_verification(
+    &mut OsRng,
+    &mut verifier,
+    5,
+    RistrettoPoint::random(&mut OsRng),
+    MSG,
+  );
+  assert_eq!(verifier.verify_vartime_with_vartime_blame().unwrap_err(), 5);
+}

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -26,6 +26,7 @@ k256 = { version = "0.11", features = ["arithmetic", "keccak256", "ecdsa"] }
 curve25519-dalek = { version = "3", features = ["std"] }
 
 transcript = { package = "flexible-transcript", path = "../crypto/transcript", features = ["recommended"] }
+curve = { package = "composable-curve", path = "../crypto/curve" }
 dalek-ff-group = { path = "../crypto/dalek-ff-group" }
 frost = { package = "modular-frost", path = "../crypto/frost", features = ["secp256k1", "ed25519"] }
 

--- a/processor/src/coin/mod.rs
+++ b/processor/src/coin/mod.rs
@@ -45,14 +45,14 @@ pub trait Coin {
   const MAX_OUTPUTS: usize; // TODO: Decide if this includes change or not
 
   // Doesn't have to take self, enables some level of caching which is pleasant
-  fn address(&self, key: <Self::Curve as Curve>::G) -> Self::Address;
+  fn address(&self, key: <Self::Curve as ::curve::Curve>::G) -> Self::Address;
 
   async fn get_height(&self) -> Result<usize, CoinError>;
   async fn get_block(&self, height: usize) -> Result<Self::Block, CoinError>;
   async fn get_outputs(
     &self,
     block: &Self::Block,
-    key: <Self::Curve as Curve>::G,
+    key: <Self::Curve as ::curve::Curve>::G,
   ) -> Vec<Self::Output>;
 
   async fn prepare_send(

--- a/processor/src/coin/monero.rs
+++ b/processor/src/coin/monero.rs
@@ -4,7 +4,7 @@ use curve25519_dalek::scalar::Scalar;
 
 use dalek_ff_group as dfg;
 use transcript::RecommendedTranscript;
-use frost::{curve::Ed25519, FrostKeys};
+use frost::FrostKeys;
 
 use monero_serai::{
   ringct::bulletproofs::Bulletproofs,
@@ -55,7 +55,7 @@ impl OutputTrait for Output {
 
 #[derive(Debug)]
 pub struct SignableTransaction(
-  FrostKeys<Ed25519>,
+  FrostKeys<dfg::EdwardsPoint>,
   RecommendedTranscript,
   usize,
   MSignableTransaction,
@@ -97,7 +97,7 @@ impl Monero {
 
 #[async_trait]
 impl Coin for Monero {
-  type Curve = Ed25519;
+  type Curve = dfg::EdwardsPoint;
 
   type Fee = Fee;
   type Transaction = Transaction;
@@ -142,7 +142,7 @@ impl Coin for Monero {
 
   async fn prepare_send(
     &self,
-    keys: FrostKeys<Ed25519>,
+    keys: FrostKeys<dfg::EdwardsPoint>,
     transcript: RecommendedTranscript,
     height: usize,
     mut inputs: Vec<Output>,

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -33,6 +33,6 @@ pub enum SignError {
 // Generate a static view key for a given chain in a globally consistent manner
 // Doesn't consider the current group key to increase the simplicity of verifying Serai's status
 // Takes an index, k, for more modern privacy protocols which use multiple view keys
-pub fn view_key<C: Coin>(k: u64) -> <C::Curve as Curve>::F {
+pub fn view_key<C: Coin>(k: u64) -> <C::Curve as ::curve::Curve>::F {
   C::Curve::hash_to_F(b"Serai DEX View Key", &[C::ID, &k.to_le_bytes()].concat())
 }


### PR DESCRIPTION
Provides common sugar between DLEq and FROST. Quirks the API a bit, while resolving it in other ways at the same time.

I'd like to bring #83 under this to fully validate it before merging, yet wanted this open now.

Closes #84.

TODO:
- [ ] HashToCurve usage in frost
- [x] Move Curve's serialize to std, enabling nostd like DLEq