### PR TITLE
Add a cargo deny workflow

### DIFF
--- a/.github/workflows/monero-tests.yaml
+++ b/.github/workflows/monero-tests.yaml
@@ -17,8 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       - name: Test Dependencies
         uses: ./.github/actions/test-dependencies
@@ -37,8 +35,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       - name: Test Dependencies
         uses: ./.github/actions/test-dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       - name: Get nightly version to use
         id: nightly
@@ -29,12 +27,36 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --all-features -- -D warnings -A clippy::type_complexity -A dead_code
 
+  deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Rust Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/advisory-db
+          key: rust-advisory-db
+
+      - name: Install cargo
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+
+      - name: Install cargo deny
+        run: cargo install --locked cargo-deny
+
+      # Doesn't run on advisores due to their frequency and general irrelevancy
+      # The official recommendation is to continue when they fail, yet you can't
+      # even open an issue when they do, making it pointless to have here
+      - name: Run cargo deny
+        run: cargo deny -L error --all-features check bans licenses sources
+
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       - name: Test Dependencies
         uses: ./.github/actions/test-dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,12 +47,8 @@ jobs:
       - name: Install cargo deny
         run: cargo install --locked cargo-deny
 
-      # Doesn't run on advisores due to their frequency and general irrelevancy
-      # The official recommendation is to continue when they fail, yet you can't
-      # even open an issue when they do, making it pointless to have here
-      # GitHub will still alert us if an advisory appears
       - name: Run cargo deny
-        run: cargo deny -L error --all-features check licenses bans sources
+        run: cargo deny -L error --all-features check
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,8 +50,9 @@ jobs:
       # Doesn't run on advisores due to their frequency and general irrelevancy
       # The official recommendation is to continue when they fail, yet you can't
       # even open an issue when they do, making it pointless to have here
+      # GitHub will still alert us if an advisory appears
       - name: Run cargo deny
-        run: cargo deny -L error --all-features check bans licenses sources
+        run: cargo deny -L error --all-features check licenses bans sources
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,8 +118,7 @@ dependencies = [
 [[package]]
 name = "array-bytes"
 version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a913633b0c922e6b745072795f50d90ebea78ba31a57e2ac8c2fc7b50950949"
+source = "git+https://github.com/hack-ink/array-bytes?rev=994cd29b66bd2ab5c8c15f0b15a1618d4bb2d94c#994cd29b66bd2ab5c8c15f0b15a1618d4bb2d94c"
 
 [[package]]
 name = "array-init"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,8 @@ monero-serai = { opt-level = 3 }
 
 [profile.release]
 panic = "unwind"
+
+[patch.crates-io]
+# array-bytes 4.1.0 is GPL-3.0.
+# array-bytes git, which has no code changes, includes a dual-license under Apache-2.0.
+array-bytes = { git = "https://github.com/hack-ink/array-bytes", rev = "994cd29b66bd2ab5c8c15f0b15a1618d4bb2d94c" }

--- a/deny.toml
+++ b/deny.toml
@@ -34,10 +34,10 @@ allow = [
   "OpenSSL",
 
   # Non-invasive copyleft
+  "MPL-2.0",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
-  "GPL-3.0-only WITH Classpath-exception-2.0",
-  "GPL-3.0-or-later WITH Classpath-exception-2.0",
+  "GPL-3.0 WITH Classpath-exception-2.0",
 ]
 
 copyleft = "warn"

--- a/deny.toml
+++ b/deny.toml
@@ -45,6 +45,15 @@ allow-osi-fsf-free = "neither"
 default = "deny"
 
 exceptions = [
+  { allow = ["AGPL-3.0"], name = "ethereum-serai" },
+  { allow = ["AGPL-3.0"], name = "serai-processor" },
+
+  { allow = ["AGPL-3.0"], name = "serai-extension" },
+  { allow = ["AGPL-3.0"], name = "serai-multisig" },
+
+  { allow = ["AGPL-3.0"], name = "serai-runtime" },
+  { allow = ["AGPL-3.0"], name = "serai-consensus" },
+  { allow = ["AGPL-3.0"], name = "serai-node" },
 ]
 
 [[licenses.clarify]]

--- a/deny.toml
+++ b/deny.toml
@@ -75,4 +75,5 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
   "https://github.com/serai-dex/substrate",
+  "https://github.com/hack-ink/array-bytes"
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -40,7 +40,7 @@ allow = [
   "GPL-3.0 WITH Classpath-exception-2.0",
 ]
 
-copyleft = "warn"
+copyleft = "deny"
 allow-osi-fsf-free = "neither"
 default = "deny"
 
@@ -54,9 +54,6 @@ expression = "MIT AND ISC AND OpenSSL"
 license-files = [
   { path = "LICENSE", hash = 0xbd0eed23 }
 ]
-
-[licenses.private]
-ignore = true
 
 [bans]
 multiple-versions = "warn"

--- a/deny.toml
+++ b/deny.toml
@@ -1,9 +1,3 @@
-# Note that all fields that take a lint level have these possible values:
-# * deny - An error will be produced and the check will fail
-# * warn - A warning will be produced, but the check will not fail
-# * allow - No warning or error will be produced, though in some cases a note
-# will be
-
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,80 @@
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+
+vulnerability = "deny"
+yanked = "deny"
+notice = "warn"
+unmaintained = "warn"
+
+ignore = [
+  "RUSTSEC-2020-0071", # https://github.com/chronotope/chrono/issues/602
+]
+
+[licenses]
+unlicensed = "deny"
+
+allow = [
+  # Effective public domain
+  "CC0-1.0",
+  "Unlicense",
+
+  # Attribution required
+  "MIT",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "Unicode-DFS-2016",
+  "OpenSSL",
+
+  # Non-invasive copyleft
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "GPL-3.0-only WITH Classpath-exception-2.0",
+  "GPL-3.0-or-later WITH Classpath-exception-2.0",
+]
+
+deny = []
+
+copyleft = "warn"
+allow-osi-fsf-free = "neither"
+default = "deny"
+
+confidence-threshold = 0.8
+exceptions = [
+  #{ allow = ["Zlib"], name = "adler32", version = "*" },
+]
+
+[[licenses.clarify]]
+name = "ring"
+version = "*"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+  { path = "LICENSE", hash = 0xbd0eed23 }
+]
+
+[licenses.private]
+ignore = true
+
+[bans]
+multiple-versions = "warn"
+wildcards = "warn"
+highlight = "all"
+
+allow = []
+deny = []
+
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = ["https://github.com/serai-dex/substrate", "https://github.com/zip-rs/zip"]

--- a/deny.toml
+++ b/deny.toml
@@ -13,6 +13,10 @@ yanked = "deny"
 notice = "warn"
 unmaintained = "warn"
 
+ignore = [
+  "RUSTSEC-2020-0071", # https://github.com/chronotope/chrono/issues/602
+]
+
 [licenses]
 unlicensed = "deny"
 

--- a/deny.toml
+++ b/deny.toml
@@ -13,10 +13,6 @@ yanked = "deny"
 notice = "warn"
 unmaintained = "warn"
 
-ignore = [
-  "RUSTSEC-2020-0071", # https://github.com/chronotope/chrono/issues/602
-]
-
 [licenses]
 unlicensed = "deny"
 
@@ -77,4 +73,6 @@ skip-tree = []
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = ["https://github.com/serai-dex/substrate", "https://github.com/zip-rs/zip"]
+allow-git = [
+  "https://github.com/serai-dex/substrate",
+]

--- a/deny.toml
+++ b/deny.toml
@@ -36,15 +36,11 @@ allow = [
   "GPL-3.0-or-later WITH Classpath-exception-2.0",
 ]
 
-deny = []
-
 copyleft = "warn"
 allow-osi-fsf-free = "neither"
 default = "deny"
 
-confidence-threshold = 0.8
 exceptions = [
-  #{ allow = ["Zlib"], name = "adler32", version = "*" },
 ]
 
 [[licenses.clarify]]
@@ -62,12 +58,6 @@ ignore = true
 multiple-versions = "warn"
 wildcards = "warn"
 highlight = "all"
-
-allow = []
-deny = []
-
-skip = []
-skip-tree = []
 
 [sources]
 unknown-registry = "deny"


### PR DESCRIPTION
Also trims out a pointless submodule checkout (we have none).

Relevant to #81 and #82.