### PR TITLE
fix for monero docker

### DIFF
--- a/deploy/coins/monero/scripts/entry-dev.sh
+++ b/deploy/coins/monero/scripts/entry-dev.sh
@@ -2,15 +2,13 @@
 # Setup Environment
 RPC_USER="${RPC_USER:=serai}"
 RPC_PASS="${RPC_PASS:=seraidex}"
-MINER="${MINER:=xmraddr}"
 BLOCK_TIME=${BLOCK_TIME:=5}
-
 
 # Run Monero
 monerod --regtest --rpc-login ${RPC_USER}:${RPC_PASS} \
---rpc-access-control-origins * --rpc-bind-ip=0.0.0.0 --offline \
---fixed-difficulty=1 --non-interactive --start-mining ${MINER} \
---mining-threads 1 --bg-mining-enable --detach
+--rpc-access-control-origins * --confirm-external-bind \
+--rpc-bind-ip=0.0.0.0 --offline --fixed-difficulty=1 \
+--non-interactive --mining-threads 1 --bg-mining-enable --detach
 
 # give time to monerod to start
 while true; do


### PR DESCRIPTION
There was a problem with monerod command in monero dockerfile. RPC wasn't working. Therefore, I added "--confirm-external-bind" as parameter to monerod and deleted " --start-mining" parameter to make it work.