### PR TITLE
Zeroizing allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10130,6 +10130,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "zalloc"
+version = "0.1.0"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 members = [
+  "common/zalloc",
+
   "crypto/transcript",
 
   "crypto/dalek-ff-group",

--- a/common/zalloc/Cargo.toml
+++ b/common/zalloc/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "zalloc"
+version = "0.1.0"
+description = "A global allocator wrapper zeroizing memory on dealloc"
+license = "MIT"
+repository = "https://github.com/serai-dex/serai/tree/develop/common/zalloc"
+authors = ["Luke Parker <lukeparker5132@gmail.com>"]
+keywords = []
+edition = "2021"
+
+[dependencies]
+zeroize = "1.5"

--- a/common/zalloc/Cargo.toml
+++ b/common/zalloc/Cargo.toml
@@ -8,5 +8,12 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 zeroize = "1.5"
+
+[features]
+allocator = []

--- a/common/zalloc/Cargo.toml
+++ b/common/zalloc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zalloc"
 version = "0.1.0"
-description = "A global allocator wrapper zeroizing memory on dealloc"
+description = "An allocator wrapper which zeroizes memory on dealloc"
 license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/common/zalloc"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]

--- a/common/zalloc/LICENSE
+++ b/common/zalloc/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Luke Parker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/common/zalloc/src/lib.rs
+++ b/common/zalloc/src/lib.rs
@@ -1,0 +1,19 @@
+use core::{
+  slice,
+  alloc::{Layout, GlobalAlloc},
+};
+
+use zeroize::Zeroize;
+
+pub struct ZeroizingAlloc<T: GlobalAlloc>(pub T);
+
+unsafe impl<T: GlobalAlloc> GlobalAlloc for ZeroizingAlloc<T> {
+  unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+    self.0.alloc(layout)
+  }
+
+  unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+    slice::from_raw_parts_mut(ptr, layout.size()).zeroize();
+    self.0.dealloc(ptr, layout);
+  }
+}


### PR DESCRIPTION
Cherry-picked from the zeroizing-allocator branch to not require moving to nightly, while still adding the library.