### PR TITLE
[Draft] Slash malevolent validators 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10120,7 +10120,6 @@ dependencies = [
  "flexible-transcript",
  "futures",
  "hex",
- "lazy_static",
  "log",
  "parity-scale-codec",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9694,6 +9694,7 @@ dependencies = [
  "hex",
  "log",
  "parity-scale-codec",
+ "sha3",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10121,6 +10121,7 @@ dependencies = [
  "flexible-transcript",
  "futures",
  "hex",
+ "lazy_static",
  "log",
  "parity-scale-codec",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9694,7 +9694,6 @@ dependencies = [
  "hex",
  "log",
  "parity-scale-codec",
- "sha3",
  "thiserror",
  "tokio",
 ]

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -30,8 +30,7 @@ use tokio::{
 };
 
 use ::tributary::{
-  TributaryReader, ReadWrite, ProvidedError, Block, Tributary,
-  transaction::{TransactionKind, Transaction as TransactionTrait},
+  ReadWrite, ProvidedError, TransactionKind, TransactionTrait, Block, Tributary, TributaryReader,
 };
 
 mod tributary;

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -30,8 +30,8 @@ use tokio::{
 };
 
 use ::tributary::{
-  ReadWrite, ProvidedError, TransactionKind, Transaction as TransactionTrait, Block, Tributary,
-  TributaryReader,
+  TributaryReader, ReadWrite, ProvidedError, Block, Tributary,
+  transaction::{TransactionKind, Transaction as TransactionTrait},
 };
 
 mod tributary;

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -185,7 +185,7 @@ pub async fn scan_tributaries<D: Db, Pro: Processors, P: P2p>(
     }
 
     for (spec, reader) in &tributary_readers {
-      tributary::scanner::handle_new_blocks(
+      tributary::scanner::handle_new_blocks::<_, _, _, _, P>(
         &mut tributary_db,
         &key,
         &recognized_id_send,

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -460,7 +460,7 @@ pub async fn handle_processors<D: Db, Pro: Processors, P: P2p>(
           if id.attempt != 0 {
             panic!("attempt wasn't 0");
           }
-          let nonces = crate::tributary::scanner::dkg_confirmation_nonces(&key, &spec);
+          let nonces = crate::tributary::dkg_confirmation_nonces(&key, &spec);
           Some(Transaction::DkgShares {
             attempt: id.attempt,
             sender_i: my_i,
@@ -478,7 +478,7 @@ pub async fn handle_processors<D: Db, Pro: Processors, P: P2p>(
 
           // Tell the Tributary the key pair, get back the share for the MuSig signature
           let mut txn = db.txn();
-          let share = crate::tributary::scanner::generated_key_pair::<D>(
+          let share = crate::tributary::generated_key_pair::<D>(
             &mut txn,
             &key,
             &spec,

--- a/coordinator/src/tests/tributary/chain.rs
+++ b/coordinator/src/tests/tributary/chain.rs
@@ -20,7 +20,7 @@ use tokio::time::sleep;
 
 use serai_db::MemDb;
 
-use tributary::{Transaction as TransactionTrait, Tributary};
+use tributary::Tributary;
 
 use crate::{
   P2pMessageKind, P2p,

--- a/coordinator/src/tests/tributary/dkg.rs
+++ b/coordinator/src/tests/tributary/dkg.rs
@@ -84,7 +84,7 @@ async fn dkg_test() {
     let mut scanner_db = TributaryDb(MemDb::new());
     let processors = MemProcessors::new();
     // Uses a brand new channel since this channel won't be used within this test
-    handle_new_blocks(
+    handle_new_blocks::<_, _, LocalP2p>(
       &mut scanner_db,
       key,
       &mpsc::unbounded_channel().0,
@@ -108,7 +108,7 @@ async fn dkg_test() {
   sleep(Duration::from_secs(Tributary::<MemDb, Transaction, LocalP2p>::block_time().into())).await;
 
   // Verify the scanner emits a KeyGen::Commitments message
-  handle_new_blocks(
+  handle_new_blocks::<_, _, LocalP2p>(
     &mut scanner_db,
     &keys[0],
     &mpsc::unbounded_channel().0,
@@ -186,7 +186,7 @@ async fn dkg_test() {
   }
 
   // With just 4 sets of shares, nothing should happen yet
-  handle_new_blocks(
+  handle_new_blocks::<_, _, LocalP2p>(
     &mut scanner_db,
     &keys[0],
     &mpsc::unbounded_channel().0,
@@ -227,7 +227,7 @@ async fn dkg_test() {
   };
 
   // Any scanner which has handled the prior blocks should only emit the new event
-  handle_new_blocks(
+  handle_new_blocks::<_, _, LocalP2p>(
     &mut scanner_db,
     &keys[0],
     &mpsc::unbounded_channel().0,

--- a/coordinator/src/tests/tributary/dkg.rs
+++ b/coordinator/src/tests/tributary/dkg.rs
@@ -20,7 +20,7 @@ use processor_messages::{
   CoordinatorMessage,
 };
 
-use tributary::{transaction::Transaction as TransactionTrait, Tributary};
+use tributary::{TransactionTrait, Tributary};
 
 use crate::{
   tributary::{TributaryDb, Transaction, TributarySpec, scanner::handle_new_blocks},

--- a/coordinator/src/tests/tributary/dkg.rs
+++ b/coordinator/src/tests/tributary/dkg.rs
@@ -20,7 +20,7 @@ use processor_messages::{
   CoordinatorMessage,
 };
 
-use tributary::{Transaction as TransactionTrait, Tributary};
+use tributary::{transaction::Transaction as TransactionTrait, Tributary};
 
 use crate::{
   tributary::{TributaryDb, Transaction, TributarySpec, scanner::handle_new_blocks},

--- a/coordinator/src/tests/tributary/tx.rs
+++ b/coordinator/src/tests/tributary/tx.rs
@@ -6,7 +6,9 @@ use tokio::time::sleep;
 
 use serai_db::MemDb;
 
-use tributary::{Transaction as TransactionTrait, Tributary};
+use tributary::{
+  transaction::Transaction as TransactionTrait, Transaction as TributaryTransaction, Tributary,
+};
 
 use crate::{
   tributary::Transaction,
@@ -49,6 +51,6 @@ async fn tx_test() {
   // All tributaries should have acknowledged this transaction in a block
   for (_, tributary) in tributaries {
     let block = tributary.reader().block(&included_in).unwrap();
-    assert_eq!(block.transactions, vec![tx.clone()]);
+    assert_eq!(block.transactions, vec![TributaryTransaction::Application(tx.clone())]);
   }
 }

--- a/coordinator/src/tributary/db.rs
+++ b/coordinator/src/tributary/db.rs
@@ -39,14 +39,14 @@ impl<D: Db> TributaryDb<D> {
     Self::tributary_key(b"slash_point", [genesis, id].concat())
   }
 
-  pub fn slash_vote_key(genesis: [u8; 32], id: [u8; 32]) -> Vec<u8> {
-    Self::tributary_key(b"slash_vote", [genesis, id].concat())
+  pub fn slash_vote_key(genesis: [u8; 32], id: [u8; 32], target: [u8; 32]) -> Vec<u8> {
+    Self::tributary_key(b"slash_vote", [genesis, id, target].concat())
   }
 
   pub fn set_fatally_slashed(txn: &mut D::Transaction<'_>, genesis: [u8; 32], id: [u8; 32]) {
     let key = Self::fatal_slash_key(genesis);
     let mut existing = txn.get(&key).unwrap_or(vec![]);
-    
+
     // don't append if we already have it.
     if !existing.is_empty() && existing.chunks(32).any(|ex_id| ex_id == id) {
       return;

--- a/coordinator/src/tributary/db.rs
+++ b/coordinator/src/tributary/db.rs
@@ -31,6 +31,25 @@ impl<D: Db> TributaryDb<D> {
     self.0.get(Self::block_key(genesis)).map(|last| last.try_into().unwrap()).unwrap_or(genesis)
   }
 
+  fn fatal_slash_key(genesis: [u8; 32]) -> Vec<u8> {
+    Self::tributary_key(b"fatal_slash", genesis)
+  }
+
+  pub fn slash_point_key(genesis: [u8; 32], id: [u8; 32]) -> Vec<u8> {
+    Self::tributary_key(b"slash_point", [genesis, id].concat())
+  }
+
+  pub fn slash_vote_key(genesis: [u8; 32], id: [u8; 32]) -> Vec<u8> {
+    Self::tributary_key(b"slash_vote", [genesis, id].concat())
+  }
+
+  pub fn set_fatally_slashed(txn: &mut D::Transaction<'_>, genesis: [u8; 32], id: [u8; 32]) {
+    let key = Self::fatal_slash_key(genesis);
+    let mut existing = txn.get(&key).unwrap_or(vec![]);
+    existing.extend(id);
+    txn.put(key, existing);
+  }
+
   fn plan_ids_key(genesis: &[u8], block: u64) -> Vec<u8> {
     Self::tributary_key(b"plan_ids", [genesis, block.to_le_bytes().as_ref()].concat())
   }

--- a/coordinator/src/tributary/db.rs
+++ b/coordinator/src/tributary/db.rs
@@ -46,6 +46,12 @@ impl<D: Db> TributaryDb<D> {
   pub fn set_fatally_slashed(txn: &mut D::Transaction<'_>, genesis: [u8; 32], id: [u8; 32]) {
     let key = Self::fatal_slash_key(genesis);
     let mut existing = txn.get(&key).unwrap_or(vec![]);
+    
+    // don't append if we already have it.
+    if !existing.is_empty() && existing.chunks(32).any(|ex_id| ex_id == id) {
+      return;
+    }
+
     existing.extend(id);
     txn.put(key, existing);
   }

--- a/coordinator/src/tributary/db.rs
+++ b/coordinator/src/tributary/db.rs
@@ -31,25 +31,25 @@ impl<D: Db> TributaryDb<D> {
     self.0.get(Self::block_key(genesis)).map(|last| last.try_into().unwrap()).unwrap_or(genesis)
   }
 
-  fn fatal_slash_key(genesis: [u8; 32]) -> Vec<u8> {
-    Self::tributary_key(b"fatal_slash", genesis)
-  }
-
-  #[allow(unused)] // TODO
+  /* TODO
   pub fn slash_point_key(genesis: [u8; 32], id: [u8; 32]) -> Vec<u8> {
     Self::tributary_key(b"slash_point", [genesis, id].concat())
   }
+  */
 
-  pub fn slash_vote_key(genesis: [u8; 32], id: [u8; 32], target: [u8; 32]) -> Vec<u8> {
-    Self::tributary_key(b"slash_vote", [genesis, id, target].concat())
+  pub fn slash_vote_key(genesis: [u8; 32], id: [u8; 13], target: [u8; 32]) -> Vec<u8> {
+    Self::tributary_key(b"slash_vote", [genesis.as_slice(), &id, &target].concat())
   }
 
+  fn fatal_slash_key(genesis: [u8; 32]) -> Vec<u8> {
+    Self::tributary_key(b"fatal_slash", genesis)
+  }
   pub fn set_fatally_slashed(txn: &mut D::Transaction<'_>, genesis: [u8; 32], id: [u8; 32]) {
     let key = Self::fatal_slash_key(genesis);
     let mut existing = txn.get(&key).unwrap_or(vec![]);
 
     // don't append if we already have it.
-    if !existing.is_empty() && existing.chunks(32).any(|ex_id| ex_id == id) {
+    if existing.chunks(32).any(|ex_id| ex_id == id) {
       return;
     }
 

--- a/coordinator/src/tributary/db.rs
+++ b/coordinator/src/tributary/db.rs
@@ -35,6 +35,7 @@ impl<D: Db> TributaryDb<D> {
     Self::tributary_key(b"fatal_slash", genesis)
   }
 
+  #[allow(unused)] // TODO
   pub fn slash_point_key(genesis: [u8; 32], id: [u8; 32]) -> Vec<u8> {
     Self::tributary_key(b"slash_point", [genesis, id].concat())
   }

--- a/coordinator/src/tributary/handle.rs
+++ b/coordinator/src/tributary/handle.rs
@@ -1,137 +1,322 @@
-use core::ops::Deref;
+use core::{ops::Deref, future::Future};
 use std::collections::HashMap;
-
-use ciphersuite::{Ciphersuite, Ristretto};
-use frost::Participant;
 
 use zeroize::Zeroizing;
 
+use rand_core::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+
+use transcript::{Transcript, RecommendedTranscript};
+use ciphersuite::{Ciphersuite, Ristretto};
+use frost::{
+  FrostError,
+  dkg::{Participant, musig::musig},
+  sign::*,
+};
+use frost_schnorrkel::Schnorrkel;
+
 use tokio::sync::mpsc::UnboundedSender;
 
-use crate::processors::Processors;
+use serai_client::{
+  Signature,
+  validator_sets::primitives::{ValidatorSet, KeyPair, musig_context, set_keys_message},
+  subxt::utils::Encoded,
+  Serai,
+};
+
+use tributary::Signed;
+
 use processor_messages::{
   CoordinatorMessage, coordinator,
   key_gen::{self, KeyGenId},
   sign::{self, SignId},
 };
 
-use serai_db::Db;
+use serai_db::{Get, Db};
 
-use tributary::Signed;
-
+use crate::processors::Processors;
 use super::{Transaction, TributarySpec, TributaryDb, scanner::RecognizedIdType};
 
-// Used to determine if an ID is acceptable
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-enum Zone {
-  Dkg,
-  Batch,
-  Sign,
-}
+const DKG_CONFIRMATION_NONCES: &[u8] = b"dkg_confirmation_nonces";
+const DKG_CONFIRMATION_SHARES: &[u8] = b"dkg_confirmation_shares";
 
-impl Zone {
-  fn label(&self) -> &'static str {
-    match self {
-      Zone::Dkg => {
-        panic!("getting the label for dkg despite dkg code paths not needing a label")
-      }
-      Zone::Batch => "batch",
-      Zone::Sign => "sign",
-    }
+// Instead of maintaing state, this simply re-creates the machine(s) in-full on every call.
+// This simplifies data flow and prevents requiring multiple paths.
+// While more expensive, this only runs an O(n) algorithm, which is tolerable to run multiple
+// times.
+struct DkgConfirmer;
+impl DkgConfirmer {
+  fn preprocess_internal(
+    spec: &TributarySpec,
+    key: &Zeroizing<<Ristretto as Ciphersuite>::F>,
+  ) -> (AlgorithmSignMachine<Ristretto, Schnorrkel>, [u8; 64]) {
+    // TODO: Does Substrate already have a validator-uniqueness check?
+    let validators = spec.validators().iter().map(|val| val.0).collect::<Vec<_>>();
+
+    let context = musig_context(spec.set());
+    let mut chacha = ChaCha20Rng::from_seed({
+      let mut entropy_transcript = RecommendedTranscript::new(b"DkgConfirmer Entropy");
+      entropy_transcript.append_message(b"spec", spec.serialize());
+      entropy_transcript.append_message(b"key", Zeroizing::new(key.to_bytes()));
+      // TODO: This is incredibly insecure unless message-bound (or bound via the attempt)
+      Zeroizing::new(entropy_transcript).rng_seed(b"preprocess")
+    });
+    let (machine, preprocess) = AlgorithmMachine::new(
+      Schnorrkel::new(b"substrate"),
+      musig(&context, key, &validators)
+        .expect("confirming the DKG for a set we aren't in/validator present multiple times")
+        .into(),
+    )
+    .preprocess(&mut chacha);
+
+    (machine, preprocess.serialize().try_into().unwrap())
+  }
+  // Get the preprocess for this confirmation.
+  fn preprocess(spec: &TributarySpec, key: &Zeroizing<<Ristretto as Ciphersuite>::F>) -> [u8; 64] {
+    Self::preprocess_internal(spec, key).1
+  }
+
+  fn share_internal(
+    spec: &TributarySpec,
+    key: &Zeroizing<<Ristretto as Ciphersuite>::F>,
+    preprocesses: HashMap<Participant, Vec<u8>>,
+    key_pair: &KeyPair,
+  ) -> Result<(AlgorithmSignatureMachine<Ristretto, Schnorrkel>, [u8; 32]), Participant> {
+    let machine = Self::preprocess_internal(spec, key).0;
+    let preprocesses = preprocesses
+      .into_iter()
+      .map(|(p, preprocess)| {
+        machine
+          .read_preprocess(&mut preprocess.as_slice())
+          .map(|preprocess| (p, preprocess))
+          .map_err(|_| p)
+      })
+      .collect::<Result<HashMap<_, _>, _>>()?;
+    let (machine, share) = machine
+      .sign(preprocesses, &set_keys_message(&spec.set(), key_pair))
+      .map_err(|e| match e {
+        FrostError::InternalError(e) => unreachable!("FrostError::InternalError {e}"),
+        FrostError::InvalidParticipant(_, _) |
+        FrostError::InvalidSigningSet(_) |
+        FrostError::InvalidParticipantQuantity(_, _) |
+        FrostError::DuplicatedParticipant(_) |
+        FrostError::MissingParticipant(_) => unreachable!("{e:?}"),
+        FrostError::InvalidPreprocess(p) | FrostError::InvalidShare(p) => p,
+      })?;
+
+    Ok((machine, share.serialize().try_into().unwrap()))
+  }
+  // Get the share for this confirmation, if the preprocesses are valid.
+  fn share(
+    spec: &TributarySpec,
+    key: &Zeroizing<<Ristretto as Ciphersuite>::F>,
+    preprocesses: HashMap<Participant, Vec<u8>>,
+    key_pair: &KeyPair,
+  ) -> Result<[u8; 32], Participant> {
+    Self::share_internal(spec, key, preprocesses, key_pair).map(|(_, share)| share)
+  }
+
+  fn complete(
+    spec: &TributarySpec,
+    key: &Zeroizing<<Ristretto as Ciphersuite>::F>,
+    preprocesses: HashMap<Participant, Vec<u8>>,
+    key_pair: &KeyPair,
+    shares: HashMap<Participant, Vec<u8>>,
+  ) -> Result<[u8; 64], Participant> {
+    let machine = Self::share_internal(spec, key, preprocesses, key_pair)
+      .expect("trying to complete a machine which failed to preprocess")
+      .0;
+
+    let shares = shares
+      .into_iter()
+      .map(|(p, share)| {
+        machine.read_share(&mut share.as_slice()).map(|share| (p, share)).map_err(|_| p)
+      })
+      .collect::<Result<HashMap<_, _>, _>>()?;
+    let signature = machine.complete(shares).map_err(|e| match e {
+      FrostError::InternalError(e) => unreachable!("FrostError::InternalError {e}"),
+      FrostError::InvalidParticipant(_, _) |
+      FrostError::InvalidSigningSet(_) |
+      FrostError::InvalidParticipantQuantity(_, _) |
+      FrostError::DuplicatedParticipant(_) |
+      FrostError::MissingParticipant(_) => unreachable!("{e:?}"),
+      FrostError::InvalidPreprocess(p) | FrostError::InvalidShare(p) => p,
+    })?;
+
+    Ok(signature.to_bytes())
   }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn handle<D: Db>(
-  zone: Zone,
-  label: &'static [u8],
-  needed: u16,
-  id: [u8; 32],
-  attempt: u32,
-  mut bytes: Vec<u8>,
-  signed: Signed,
-  genesis: [u8; 32],
+#[allow(clippy::too_many_arguments)] // TODO
+fn read_known_to_exist_data<D: Db, G: Get>(
+  getter: &G,
   spec: &TributarySpec,
-  txn: &mut <D as Db>::Transaction<'_>,
-) -> Option<HashMap<Participant, Vec<u8>>> {
-  // let label = label.to_owned();
-  if zone == Zone::Dkg {
-    // Since Dkg doesn't have an ID, solely attempts, this should just be [0; 32]
-    assert_eq!(id, [0; 32], "DKG, which shouldn't have IDs, had a non-0 ID");
-  } else if !TributaryDb::<D>::recognized_id(txn, zone.label(), genesis, id) {
-    // TODO: Full slash
-    todo!();
+  key: &Zeroizing<<Ristretto as Ciphersuite>::F>,
+  label: &'static [u8],
+  id: [u8; 32],
+  needed: u16,
+  attempt: u32,
+  bytes: Vec<u8>,
+  signed: Option<&Signed>,
+) -> HashMap<Participant, Vec<u8>> {
+  let mut data = HashMap::new();
+  for validator in spec.validators().iter().map(|validator| validator.0) {
+    data.insert(
+      spec.i(validator).unwrap(),
+      if Some(&validator) == signed.map(|signed| &signed.signer) {
+        bytes.clone()
+      } else if let Some(data) =
+        TributaryDb::<D>::data(label, getter, spec.genesis(), id, attempt, validator)
+      {
+        data
+      } else {
+        continue;
+      },
+    );
   }
+  assert_eq!(data.len(), usize::from(needed));
 
-  // If they've already published a TX for this attempt, slash
-  if let Some(data) = TributaryDb::<D>::data(label, txn, genesis, id, attempt, signed.signer) {
-    if data != bytes {
-      // TODO: Full slash
-      todo!();
-    }
+  // Remove our own piece of data
+  assert!(data
+    .remove(
+      &spec
+        .i(Ristretto::generator() * key.deref())
+        .expect("handling a message for a Tributary we aren't part of")
+    )
+    .is_some());
 
-    // TODO: Slash
-    return None;
-  }
-
-  // If the attempt is lesser than the blockchain's, slash
-  let curr_attempt = TributaryDb::<D>::attempt(txn, genesis, id);
-  if attempt < curr_attempt {
-    // TODO: Slash for being late
-    return None;
-  }
-  if attempt > curr_attempt {
-    // TODO: Full slash
-    todo!();
-  }
-
-  // TODO: We can also full slash if shares before all commitments, or share before the
-  // necessary preprocesses
-
-  // TODO: If this is shares, we need to check they are part of the selected signing set
-
-  // Store this data
-  let received =
-    TributaryDb::<D>::set_data(label, txn, genesis, id, attempt, signed.signer, &bytes);
-
-  // If we have all the needed commitments/preprocesses/shares, tell the processor
-  // TODO: This needs to be coded by weight, not by validator count
-  if received == needed {
-    let mut data = HashMap::new();
-    for validator in spec.validators().iter().map(|validator| validator.0) {
-      data.insert(
-        spec.i(validator).unwrap(),
-        if validator == signed.signer {
-          bytes.split_off(0)
-        } else if let Some(data) =
-          TributaryDb::<D>::data(label, txn, genesis, id, attempt, validator)
-        {
-          data
-        } else {
-          continue;
-        },
-      );
-    }
-    assert_eq!(data.len(), usize::from(needed));
-
-    return Some(data);
-  }
-  None
+  data
 }
 
-pub async fn handle_application_tx<D: Db, Pro: Processors>(
+pub fn dkg_confirmation_nonces(
+  key: &Zeroizing<<Ristretto as Ciphersuite>::F>,
+  spec: &TributarySpec,
+) -> [u8; 64] {
+  DkgConfirmer::preprocess(spec, key)
+}
+
+#[allow(clippy::needless_pass_by_ref_mut)]
+pub fn generated_key_pair<D: Db>(
+  txn: &mut D::Transaction<'_>,
+  key: &Zeroizing<<Ristretto as Ciphersuite>::F>,
+  spec: &TributarySpec,
+  key_pair: &KeyPair,
+) -> Result<[u8; 32], Participant> {
+  TributaryDb::<D>::save_currently_completing_key_pair(txn, spec.genesis(), key_pair);
+
+  let attempt = 0; // TODO
+  let preprocesses = read_known_to_exist_data::<D, _>(
+    txn,
+    spec,
+    key,
+    DKG_CONFIRMATION_NONCES,
+    [0; 32],
+    spec.n(),
+    attempt,
+    vec![],
+    None,
+  );
+  DkgConfirmer::share(spec, key, preprocesses, key_pair)
+}
+
+pub async fn handle_application_tx<
+  D: Db,
+  Pro: Processors,
+  F: Future<Output = ()>,
+  PST: Clone + Fn(ValidatorSet, Encoded) -> F,
+>(
   tx: Transaction,
   spec: &TributarySpec,
   processors: &Pro,
+  publish_serai_tx: PST,
   genesis: [u8; 32],
   key: &Zeroizing<<Ristretto as Ciphersuite>::F>,
   recognized_id: &UnboundedSender<([u8; 32], RecognizedIdType, [u8; 32])>,
   txn: &mut <D as Db>::Transaction<'_>,
 ) {
+  // Used to determine if an ID is acceptable
+  #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+  enum Zone {
+    Dkg,
+    Batch,
+    Sign,
+  }
+
+  impl Zone {
+    fn label(&self) -> &'static str {
+      match self {
+        Zone::Dkg => {
+          panic!("getting the label for dkg despite dkg code paths not needing a label")
+        }
+        Zone::Batch => "batch",
+        Zone::Sign => "sign",
+      }
+    }
+  }
+
+  let handle =
+    |txn: &mut _, zone: Zone, label, needed, id, attempt, bytes: Vec<u8>, signed: &Signed| {
+      if zone == Zone::Dkg {
+        // Since Dkg doesn't have an ID, solely attempts, this should just be [0; 32]
+        assert_eq!(id, [0; 32], "DKG, which shouldn't have IDs, had a non-0 ID");
+      } else if !TributaryDb::<D>::recognized_id(txn, zone.label(), genesis, id) {
+        // TODO: Full slash
+        todo!();
+      }
+
+      // If they've already published a TX for this attempt, slash
+      if let Some(data) = TributaryDb::<D>::data(label, txn, genesis, id, attempt, signed.signer) {
+        if data != bytes {
+          // TODO: Full slash
+          todo!();
+        }
+
+        // TODO: Slash
+        return None;
+      }
+
+      // If the attempt is lesser than the blockchain's, slash
+      let curr_attempt = TributaryDb::<D>::attempt(txn, genesis, id);
+      if attempt < curr_attempt {
+        // TODO: Slash for being late
+        return None;
+      }
+      if attempt > curr_attempt {
+        // TODO: Full slash
+        todo!();
+      }
+
+      // TODO: We can also full slash if shares before all commitments, or share before the
+      // necessary preprocesses
+
+      // TODO: If this is shares, we need to check they are part of the selected signing set
+
+      // Store this data
+      let received =
+        TributaryDb::<D>::set_data(label, txn, genesis, id, attempt, signed.signer, &bytes);
+
+      // If we have all the needed commitments/preprocesses/shares, tell the processor
+      // TODO: This needs to be coded by weight, not by validator count
+      if received == needed {
+        return Some(read_known_to_exist_data::<D, _>(
+          txn,
+          spec,
+          key,
+          label,
+          id,
+          needed,
+          attempt,
+          bytes,
+          Some(signed),
+        ));
+      }
+      None
+    };
+
   match tx {
     Transaction::DkgCommitments(attempt, bytes, signed) => {
       if let Some(commitments) =
-        handle(&mut txn, Zone::Dkg, b"dkg_commitments", spec.n(), [0; 32], attempt, bytes, &signed)
+        handle(txn, Zone::Dkg, b"dkg_commitments", spec.n(), [0; 32], attempt, bytes, &signed)
       {
         log::info!("got all DkgCommitments for {}", hex::encode(genesis));
         processors
@@ -170,7 +355,7 @@ pub async fn handle_application_tx<D: Db, Pro: Processors>(
       let bytes = if sender_i == our_i { vec![] } else { shares.remove(&our_i).unwrap() };
 
       let confirmation_nonces = handle(
-        &mut txn,
+        txn,
         Zone::Dkg,
         DKG_CONFIRMATION_NONCES,
         spec.n(),
@@ -180,7 +365,7 @@ pub async fn handle_application_tx<D: Db, Pro: Processors>(
         &signed,
       );
       if let Some(shares) =
-        handle(&mut txn, Zone::Dkg, b"dkg_shares", spec.n(), [0; 32], attempt, bytes, &signed)
+        handle(txn, Zone::Dkg, b"dkg_shares", spec.n(), [0; 32], attempt, bytes, &signed)
       {
         log::info!("got all DkgShares for {}", hex::encode(genesis));
         assert!(confirmation_nonces.is_some());
@@ -200,7 +385,7 @@ pub async fn handle_application_tx<D: Db, Pro: Processors>(
 
     Transaction::DkgConfirmed(attempt, shares, signed) => {
       if let Some(shares) = handle(
-        &mut txn,
+        txn,
         Zone::Dkg,
         DKG_CONFIRMATION_SHARES,
         spec.n(),
@@ -212,7 +397,7 @@ pub async fn handle_application_tx<D: Db, Pro: Processors>(
         log::info!("got all DkgConfirmed for {}", hex::encode(genesis));
 
         let preprocesses = read_known_to_exist_data::<D, _>(
-          &txn,
+          txn,
           spec,
           key,
           DKG_CONFIRMATION_NONCES,
@@ -223,7 +408,7 @@ pub async fn handle_application_tx<D: Db, Pro: Processors>(
           None,
         );
 
-        let key_pair = TributaryDb::<D>::currently_completing_key_pair(&txn, genesis)
+        let key_pair = TributaryDb::<D>::currently_completing_key_pair(txn, genesis)
           .unwrap_or_else(|| {
             panic!(
               "in DkgConfirmed handling, which happens after everyone {}",
@@ -245,34 +430,20 @@ pub async fn handle_application_tx<D: Db, Pro: Processors>(
 
     Transaction::ExternalBlock(block) => {
       // Because this external block has been finalized, its batch ID should be authorized
-      TributaryDb::<D>::recognize_id(&mut txn, Zone::Batch.label(), genesis, block);
+      TributaryDb::<D>::recognize_id(txn, Zone::Batch.label(), genesis, block);
       recognized_id
         .send((genesis, RecognizedIdType::Block, block))
         .expect("recognized_id_recv was dropped. are we shutting down?");
     }
 
     Transaction::SubstrateBlock(block) => {
-      let plan_ids = TributaryDb::<D>::plan_ids(&txn, genesis, block).expect(
+      let plan_ids = TributaryDb::<D>::plan_ids(txn, genesis, block).expect(
         "synced a tributary block finalizing a substrate block in a provided transaction \
-      despite us not providing that transaction",
+          despite us not providing that transaction",
       );
 
       for id in plan_ids {
-        TributaryDb::<D>::recognize_id(&mut txn, Zone::Sign.label(), genesis, id);
-        recognized_id
-          .send((genesis, RecognizedIdType::Plan, id))
-          .expect("recognized_id_recv was dropped. are we shutting down?");
-      }
-    }
-
-    Transaction::SubstrateBlock(block) => {
-      let plan_ids = TributaryDb::<D>::plan_ids(&txn, genesis, block).expect(
-        "synced a tributary block finalizing a substrate block in a provided transaction \
-        despite us not providing that transaction",
-      );
-
-      for id in plan_ids {
-        TributaryDb::<D>::recognize_id(&mut txn, Zone::Sign.label(), genesis, id);
+        TributaryDb::<D>::recognize_id(txn, Zone::Sign.label(), genesis, id);
         recognized_id
           .send((genesis, RecognizedIdType::Plan, id))
           .expect("recognized_id_recv was dropped. are we shutting down?");
@@ -281,7 +452,7 @@ pub async fn handle_application_tx<D: Db, Pro: Processors>(
 
     Transaction::BatchPreprocess(data) => {
       if let Some(preprocesses) = handle(
-        &mut txn,
+        txn,
         Zone::Batch,
         b"batch_preprocess",
         spec.t(),
@@ -303,7 +474,7 @@ pub async fn handle_application_tx<D: Db, Pro: Processors>(
     }
     Transaction::BatchShare(data) => {
       if let Some(shares) = handle(
-        &mut txn,
+        txn,
         Zone::Batch,
         b"batch_share",
         spec.t(),
@@ -329,7 +500,7 @@ pub async fn handle_application_tx<D: Db, Pro: Processors>(
 
     Transaction::SignPreprocess(data) => {
       if let Some(preprocesses) = handle(
-        &mut txn,
+        txn,
         Zone::Sign,
         b"sign_preprocess",
         spec.t(),
@@ -351,7 +522,7 @@ pub async fn handle_application_tx<D: Db, Pro: Processors>(
     }
     Transaction::SignShare(data) => {
       if let Some(shares) = handle(
-        &mut txn,
+        txn,
         Zone::Sign,
         b"sign_share",
         spec.t(),

--- a/coordinator/src/tributary/handle.rs
+++ b/coordinator/src/tributary/handle.rs
@@ -130,279 +130,247 @@ pub async fn handle_application_tx<D: Db, Pro: Processors>(
 ) {
   match tx {
     Transaction::DkgCommitments(attempt, bytes, signed) => {
-      if let Some(commitments) = handle(
-        &mut txn,
-        Zone::Dkg,
-        b"dkg_commitments",
-        spec.n(),
-        [0; 32],
-        attempt,
-        bytes,
-        &signed,
-      ) {
-      log::info!("got all DkgCommitments for {}", hex::encode(genesis));
-      processors
-        .send(
-          spec.set().network,
-          CoordinatorMessage::KeyGen(key_gen::CoordinatorMessage::Commitments {
-            id: KeyGenId { set: spec.set(), attempt },
-            commitments,
-          }),
-        )
-        .await;
-    }
-  }
-
-  Transaction::DkgShares { attempt, sender_i, mut shares, confirmation_nonces, signed } => {
-    if sender_i !=
-      spec
-        .i(signed.signer)
-        .expect("transaction added to tributary by signer who isn't a participant")
-    {
-      // TODO: Full slash
-      todo!();
-    }
-
-    if shares.len() != (usize::from(spec.n()) - 1) {
-      // TODO: Full slash
-      todo!();
-    }
-
-    // Only save our share's bytes
-    let our_i = spec
-      .i(Ristretto::generator() * key.deref())
-      .expect("in a tributary we're not a validator for");
-    // This unwrap is safe since the length of shares is checked, the the only missing key
-    // within the valid range will be the sender's i
-    let bytes = if sender_i == our_i { vec![] } else { shares.remove(&our_i).unwrap() };
-
-    let confirmation_nonces = handle(
-      &mut txn,
-      Zone::Dkg,
-      DKG_CONFIRMATION_NONCES,
-      spec.n(),
-      [0; 32],
-      attempt,
-      confirmation_nonces.to_vec(),
-      &signed,
-    );
-    if let Some(shares) =
-      handle(&mut txn, Zone::Dkg, b"dkg_shares", spec.n(), [0; 32], attempt, bytes, &signed)
-    {
-      log::info!("got all DkgShares for {}", hex::encode(genesis));
-      assert!(confirmation_nonces.is_some());
-      processors
-        .send(
-          spec.set().network,
-          CoordinatorMessage::KeyGen(key_gen::CoordinatorMessage::Shares {
-            id: KeyGenId { set: spec.set(), attempt },
-            shares,
-          }),
-        )
-        .await;
-    } else {
-      assert!(confirmation_nonces.is_none());
-    }
-  }
-
-  Transaction::DkgConfirmed(attempt, shares, signed) => {
-    if let Some(shares) = handle(
-      &mut txn,
-      Zone::Dkg,
-      DKG_CONFIRMATION_SHARES,
-      spec.n(),
-      [0; 32],
-      attempt,
-      shares.to_vec(),
-      &signed,
-    ) {
-      log::info!("got all DkgConfirmed for {}", hex::encode(genesis));
-
-      let preprocesses = read_known_to_exist_data::<D, _>(
-        &txn,
-        spec,
-        key,
-        DKG_CONFIRMATION_NONCES,
-        [0; 32],
-        spec.n(),
-        attempt,
-        vec![],
-        None,
-      );
-
-      let key_pair = TributaryDb::<D>::currently_completing_key_pair(&txn, genesis)
-        .unwrap_or_else(|| {
-          panic!(
-            "in DkgConfirmed handling, which happens after everyone {}",
-            "(including us) fires DkgConfirmed, yet no confirming key pair"
+      if let Some(commitments) =
+        handle(&mut txn, Zone::Dkg, b"dkg_commitments", spec.n(), [0; 32], attempt, bytes, &signed)
+      {
+        log::info!("got all DkgCommitments for {}", hex::encode(genesis));
+        processors
+          .send(
+            spec.set().network,
+            CoordinatorMessage::KeyGen(key_gen::CoordinatorMessage::Commitments {
+              id: KeyGenId { set: spec.set(), attempt },
+              commitments,
+            }),
           )
-        });
-      let Ok(sig) = DkgConfirmer::complete(spec, key, preprocesses, &key_pair, shares) else {
+          .await;
+      }
+    }
+
+    Transaction::DkgShares { attempt, sender_i, mut shares, confirmation_nonces, signed } => {
+      if sender_i !=
+        spec
+          .i(signed.signer)
+          .expect("transaction added to tributary by signer who isn't a participant")
+      {
         // TODO: Full slash
         todo!();
-      };
+      }
 
-      publish_serai_tx(
-        spec.set(),
-        Serai::set_validator_set_keys(spec.set().network, key_pair, Signature(sig)),
-      )
-      .await;
-    }
-  }
+      if shares.len() != (usize::from(spec.n()) - 1) {
+        // TODO: Full slash
+        todo!();
+      }
 
-  let bytes = shares
-    .remove(
-      &spec
+      // Only save our share's bytes
+      let our_i = spec
         .i(Ristretto::generator() * key.deref())
-        .expect("in a tributary we're not a validator for"),
-    )
-    .unwrap();
+        .expect("in a tributary we're not a validator for");
+      // This unwrap is safe since the length of shares is checked, the the only missing key
+      // within the valid range will be the sender's i
+      let bytes = if sender_i == our_i { vec![] } else { shares.remove(&our_i).unwrap() };
 
-  if let Some(shares) =
-    handle(Zone::Dkg, b"dkg_shares", spec.n(), [0; 32], attempt, bytes, signed)
-  {
-    processors
-      .send(
-        spec.set().network,
-        CoordinatorMessage::KeyGen(key_gen::CoordinatorMessage::Shares {
-          id: KeyGenId { set: spec.set(), attempt },
-          shares,
-        }),
-      )
-      .await;
-  }
-}
+      let confirmation_nonces = handle(
+        &mut txn,
+        Zone::Dkg,
+        DKG_CONFIRMATION_NONCES,
+        spec.n(),
+        [0; 32],
+        attempt,
+        confirmation_nonces.to_vec(),
+        &signed,
+      );
+      if let Some(shares) =
+        handle(&mut txn, Zone::Dkg, b"dkg_shares", spec.n(), [0; 32], attempt, bytes, &signed)
+      {
+        log::info!("got all DkgShares for {}", hex::encode(genesis));
+        assert!(confirmation_nonces.is_some());
+        processors
+          .send(
+            spec.set().network,
+            CoordinatorMessage::KeyGen(key_gen::CoordinatorMessage::Shares {
+              id: KeyGenId { set: spec.set(), attempt },
+              shares,
+            }),
+          )
+          .await;
+      } else {
+        assert!(confirmation_nonces.is_none());
+      }
+    }
 
-Transaction::ExternalBlock(block) => {
-  // Because this external block has been finalized, its batch ID should be authorized
-  TributaryDb::<D>::recognize_id(&mut txn, Zone::Batch.label(), genesis, block);
-  recognized_id
-    .send((genesis, RecognizedIdType::Block, block))
-    .expect("recognized_id_recv was dropped. are we shutting down?");
-}
+    Transaction::DkgConfirmed(attempt, shares, signed) => {
+      if let Some(shares) = handle(
+        &mut txn,
+        Zone::Dkg,
+        DKG_CONFIRMATION_SHARES,
+        spec.n(),
+        [0; 32],
+        attempt,
+        shares.to_vec(),
+        &signed,
+      ) {
+        log::info!("got all DkgConfirmed for {}", hex::encode(genesis));
 
-Transaction::SubstrateBlock(block) => {
-  let plan_ids = TributaryDb::<D>::plan_ids(&txn, genesis, block).expect(
-    "synced a tributary block finalizing a substrate block in a provided transaction \
-    despite us not providing that transaction",
-  );
+        let preprocesses = read_known_to_exist_data::<D, _>(
+          &txn,
+          spec,
+          key,
+          DKG_CONFIRMATION_NONCES,
+          [0; 32],
+          spec.n(),
+          attempt,
+          vec![],
+          None,
+        );
 
-  for id in plan_ids {
-    TributaryDb::<D>::recognize_id(&mut txn, Zone::Sign.label(), genesis, id);
-    recognized_id
-      .send((genesis, RecognizedIdType::Plan, id))
-      .expect("recognized_id_recv was dropped. are we shutting down?");
-  }
-}
+        let key_pair = TributaryDb::<D>::currently_completing_key_pair(&txn, genesis)
+          .unwrap_or_else(|| {
+            panic!(
+              "in DkgConfirmed handling, which happens after everyone {}",
+              "(including us) fires DkgConfirmed, yet no confirming key pair"
+            )
+          });
+        let Ok(sig) = DkgConfirmer::complete(spec, key, preprocesses, &key_pair, shares) else {
+          // TODO: Full slash
+          todo!();
+        };
 
-  Transaction::SubstrateBlock(block) => {
-    let plan_ids = TributaryDb::<D>::plan_ids(&txn, genesis, block).expect(
-      "synced a tributary block finalizing a substrate block in a provided transaction \
-      despite us not providing that transaction",
-    );
+        publish_serai_tx(
+          spec.set(),
+          Serai::set_validator_set_keys(spec.set().network, key_pair, Signature(sig)),
+        )
+        .await;
+      }
+    }
 
-    for id in plan_ids {
-      TributaryDb::<D>::recognize_id(&mut txn, Zone::Sign.label(), genesis, id);
+    Transaction::ExternalBlock(block) => {
+      // Because this external block has been finalized, its batch ID should be authorized
+      TributaryDb::<D>::recognize_id(&mut txn, Zone::Batch.label(), genesis, block);
       recognized_id
-        .send((genesis, RecognizedIdType::Plan, id))
+        .send((genesis, RecognizedIdType::Block, block))
         .expect("recognized_id_recv was dropped. are we shutting down?");
     }
-  }
 
-  Transaction::BatchPreprocess(data) => {
-    if let Some(preprocesses) = handle(
-      &mut txn,
-      Zone::Batch,
-      b"batch_preprocess",
-      spec.t(),
-      data.plan,
-      data.attempt,
-      data.data,
-      &data.signed,
-    ) {
-      processors
-        .send(
-          spec.set().network,
-          CoordinatorMessage::Coordinator(
-            coordinator::CoordinatorMessage::BatchPreprocesses {
+    Transaction::SubstrateBlock(block) => {
+      let plan_ids = TributaryDb::<D>::plan_ids(&txn, genesis, block).expect(
+        "synced a tributary block finalizing a substrate block in a provided transaction \
+      despite us not providing that transaction",
+      );
+
+      for id in plan_ids {
+        TributaryDb::<D>::recognize_id(&mut txn, Zone::Sign.label(), genesis, id);
+        recognized_id
+          .send((genesis, RecognizedIdType::Plan, id))
+          .expect("recognized_id_recv was dropped. are we shutting down?");
+      }
+    }
+
+    Transaction::SubstrateBlock(block) => {
+      let plan_ids = TributaryDb::<D>::plan_ids(&txn, genesis, block).expect(
+        "synced a tributary block finalizing a substrate block in a provided transaction \
+        despite us not providing that transaction",
+      );
+
+      for id in plan_ids {
+        TributaryDb::<D>::recognize_id(&mut txn, Zone::Sign.label(), genesis, id);
+        recognized_id
+          .send((genesis, RecognizedIdType::Plan, id))
+          .expect("recognized_id_recv was dropped. are we shutting down?");
+      }
+    }
+
+    Transaction::BatchPreprocess(data) => {
+      if let Some(preprocesses) = handle(
+        &mut txn,
+        Zone::Batch,
+        b"batch_preprocess",
+        spec.t(),
+        data.plan,
+        data.attempt,
+        data.data,
+        &data.signed,
+      ) {
+        processors
+          .send(
+            spec.set().network,
+            CoordinatorMessage::Coordinator(coordinator::CoordinatorMessage::BatchPreprocesses {
               id: SignId { key: todo!(), id: data.plan, attempt: data.attempt },
               preprocesses,
-            },
-          ),
-        )
-        .await;
+            }),
+          )
+          .await;
+      }
     }
-  }
-  Transaction::BatchShare(data) => {
-    if let Some(shares) = handle(
-      &mut txn,
-      Zone::Batch,
-      b"batch_share",
-      spec.t(),
-      data.plan,
-      data.attempt,
-      data.data,
-      &data.signed,
-    ) {
-      processors
-        .send(
-          spec.set().network,
-          CoordinatorMessage::Coordinator(coordinator::CoordinatorMessage::BatchShares {
-            id: SignId { key: todo!(), id: data.plan, attempt: data.attempt },
-            shares: shares
-              .drain()
-              .map(|(validator, share)| (validator, share.try_into().unwrap()))
-              .collect(),
-          }),
-        )
-        .await;
+    Transaction::BatchShare(data) => {
+      if let Some(shares) = handle(
+        &mut txn,
+        Zone::Batch,
+        b"batch_share",
+        spec.t(),
+        data.plan,
+        data.attempt,
+        data.data,
+        &data.signed,
+      ) {
+        processors
+          .send(
+            spec.set().network,
+            CoordinatorMessage::Coordinator(coordinator::CoordinatorMessage::BatchShares {
+              id: SignId { key: todo!(), id: data.plan, attempt: data.attempt },
+              shares: shares
+                .drain()
+                .map(|(validator, share)| (validator, share.try_into().unwrap()))
+                .collect(),
+            }),
+          )
+          .await;
+      }
     }
-  }
 
-  Transaction::SignPreprocess(data) => {
-    if let Some(preprocesses) = handle(
-      &mut txn,
-      Zone::Sign,
-      b"sign_preprocess",
-      spec.t(),
-      data.plan,
-      data.attempt,
-      data.data,
-      &data.signed,
-    ) {
-      processors
-        .send(
-          spec.set().network,
-          CoordinatorMessage::Sign(sign::CoordinatorMessage::Preprocesses {
-            id: SignId { key: todo!(), id: data.plan, attempt: data.attempt },
-            preprocesses,
-          },
-        ),
-      )
-      .await;
-  }
-  Transaction::SignShare(data) => {
-    if let Some(shares) = handle(
-      &mut txn,
-      Zone::Sign,
-      b"sign_share",
-      spec.t(),
-      data.plan,
-      data.attempt,
-      data.data,
-      &data.signed,
-    ) {
-      processors
-        .send(
-          spec.set().network,
-          CoordinatorMessage::Sign(sign::CoordinatorMessage::Shares {
-            id: SignId { key: todo!(), id: data.plan, attempt: data.attempt },
-            shares,
-          }),
-        )
-        .await;
+    Transaction::SignPreprocess(data) => {
+      if let Some(preprocesses) = handle(
+        &mut txn,
+        Zone::Sign,
+        b"sign_preprocess",
+        spec.t(),
+        data.plan,
+        data.attempt,
+        data.data,
+        &data.signed,
+      ) {
+        processors
+          .send(
+            spec.set().network,
+            CoordinatorMessage::Sign(sign::CoordinatorMessage::Preprocesses {
+              id: SignId { key: todo!(), id: data.plan, attempt: data.attempt },
+              preprocesses,
+            }),
+          )
+          .await;
+      }
     }
+    Transaction::SignShare(data) => {
+      if let Some(shares) = handle(
+        &mut txn,
+        Zone::Sign,
+        b"sign_share",
+        spec.t(),
+        data.plan,
+        data.attempt,
+        data.data,
+        &data.signed,
+      ) {
+        processors
+          .send(
+            spec.set().network,
+            CoordinatorMessage::Sign(sign::CoordinatorMessage::Shares {
+              id: SignId { key: todo!(), id: data.plan, attempt: data.attempt },
+              shares,
+            }),
+          )
+          .await;
+      }
+    }
+    Transaction::SignCompleted(_, _, _) => todo!(),
   }
-  Transaction::SignCompleted(_, _, _) => todo!(),
-}
 }

--- a/coordinator/src/tributary/handle.rs
+++ b/coordinator/src/tributary/handle.rs
@@ -219,6 +219,7 @@ pub fn generated_key_pair<D: Db>(
   DkgConfirmer::share(spec, key, preprocesses, key_pair)
 }
 
+#[allow(clippy::too_many_arguments)] // TODO
 pub async fn handle_application_tx<
   D: Db,
   Pro: Processors,

--- a/coordinator/src/tributary/handle.rs
+++ b/coordinator/src/tributary/handle.rs
@@ -1,0 +1,408 @@
+use core::ops::Deref;
+use std::collections::HashMap;
+
+use ciphersuite::{Ciphersuite, Ristretto};
+use frost::Participant;
+
+use zeroize::Zeroizing;
+
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::processors::Processors;
+use processor_messages::{
+  CoordinatorMessage, coordinator,
+  key_gen::{self, KeyGenId},
+  sign::{self, SignId},
+};
+
+use serai_db::Db;
+
+use tributary::Signed;
+
+use super::{Transaction, TributarySpec, TributaryDb, scanner::RecognizedIdType};
+
+// Used to determine if an ID is acceptable
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Zone {
+  Dkg,
+  Batch,
+  Sign,
+}
+
+impl Zone {
+  fn label(&self) -> &'static str {
+    match self {
+      Zone::Dkg => {
+        panic!("getting the label for dkg despite dkg code paths not needing a label")
+      }
+      Zone::Batch => "batch",
+      Zone::Sign => "sign",
+    }
+  }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn handle<D: Db>(
+  zone: Zone,
+  label: &'static [u8],
+  needed: u16,
+  id: [u8; 32],
+  attempt: u32,
+  mut bytes: Vec<u8>,
+  signed: Signed,
+  genesis: [u8; 32],
+  spec: &TributarySpec,
+  txn: &mut <D as Db>::Transaction<'_>,
+) -> Option<HashMap<Participant, Vec<u8>>> {
+  // let label = label.to_owned();
+  if zone == Zone::Dkg {
+    // Since Dkg doesn't have an ID, solely attempts, this should just be [0; 32]
+    assert_eq!(id, [0; 32], "DKG, which shouldn't have IDs, had a non-0 ID");
+  } else if !TributaryDb::<D>::recognized_id(txn, zone.label(), genesis, id) {
+    // TODO: Full slash
+    todo!();
+  }
+
+  // If they've already published a TX for this attempt, slash
+  if let Some(data) = TributaryDb::<D>::data(label, txn, genesis, id, attempt, signed.signer) {
+    if data != bytes {
+      // TODO: Full slash
+      todo!();
+    }
+
+    // TODO: Slash
+    return None;
+  }
+
+  // If the attempt is lesser than the blockchain's, slash
+  let curr_attempt = TributaryDb::<D>::attempt(txn, genesis, id);
+  if attempt < curr_attempt {
+    // TODO: Slash for being late
+    return None;
+  }
+  if attempt > curr_attempt {
+    // TODO: Full slash
+    todo!();
+  }
+
+  // TODO: We can also full slash if shares before all commitments, or share before the
+  // necessary preprocesses
+
+  // TODO: If this is shares, we need to check they are part of the selected signing set
+
+  // Store this data
+  let received =
+    TributaryDb::<D>::set_data(label, txn, genesis, id, attempt, signed.signer, &bytes);
+
+  // If we have all the needed commitments/preprocesses/shares, tell the processor
+  // TODO: This needs to be coded by weight, not by validator count
+  if received == needed {
+    let mut data = HashMap::new();
+    for validator in spec.validators().iter().map(|validator| validator.0) {
+      data.insert(
+        spec.i(validator).unwrap(),
+        if validator == signed.signer {
+          bytes.split_off(0)
+        } else if let Some(data) =
+          TributaryDb::<D>::data(label, txn, genesis, id, attempt, validator)
+        {
+          data
+        } else {
+          continue;
+        },
+      );
+    }
+    assert_eq!(data.len(), usize::from(needed));
+
+    return Some(data);
+  }
+  None
+}
+
+pub async fn handle_application_tx<D: Db, Pro: Processors>(
+  tx: Transaction,
+  spec: &TributarySpec,
+  processors: &Pro,
+  genesis: [u8; 32],
+  key: &Zeroizing<<Ristretto as Ciphersuite>::F>,
+  recognized_id: &UnboundedSender<([u8; 32], RecognizedIdType, [u8; 32])>,
+  txn: &mut <D as Db>::Transaction<'_>,
+) {
+  match tx {
+    Transaction::DkgCommitments(attempt, bytes, signed) => {
+      if let Some(commitments) = handle(
+        &mut txn,
+        Zone::Dkg,
+        b"dkg_commitments",
+        spec.n(),
+        [0; 32],
+        attempt,
+        bytes,
+        &signed,
+      ) {
+      log::info!("got all DkgCommitments for {}", hex::encode(genesis));
+      processors
+        .send(
+          spec.set().network,
+          CoordinatorMessage::KeyGen(key_gen::CoordinatorMessage::Commitments {
+            id: KeyGenId { set: spec.set(), attempt },
+            commitments,
+          }),
+        )
+        .await;
+    }
+  }
+
+  Transaction::DkgShares { attempt, sender_i, mut shares, confirmation_nonces, signed } => {
+    if sender_i !=
+      spec
+        .i(signed.signer)
+        .expect("transaction added to tributary by signer who isn't a participant")
+    {
+      // TODO: Full slash
+      todo!();
+    }
+
+    if shares.len() != (usize::from(spec.n()) - 1) {
+      // TODO: Full slash
+      todo!();
+    }
+
+    // Only save our share's bytes
+    let our_i = spec
+      .i(Ristretto::generator() * key.deref())
+      .expect("in a tributary we're not a validator for");
+    // This unwrap is safe since the length of shares is checked, the the only missing key
+    // within the valid range will be the sender's i
+    let bytes = if sender_i == our_i { vec![] } else { shares.remove(&our_i).unwrap() };
+
+    let confirmation_nonces = handle(
+      &mut txn,
+      Zone::Dkg,
+      DKG_CONFIRMATION_NONCES,
+      spec.n(),
+      [0; 32],
+      attempt,
+      confirmation_nonces.to_vec(),
+      &signed,
+    );
+    if let Some(shares) =
+      handle(&mut txn, Zone::Dkg, b"dkg_shares", spec.n(), [0; 32], attempt, bytes, &signed)
+    {
+      log::info!("got all DkgShares for {}", hex::encode(genesis));
+      assert!(confirmation_nonces.is_some());
+      processors
+        .send(
+          spec.set().network,
+          CoordinatorMessage::KeyGen(key_gen::CoordinatorMessage::Shares {
+            id: KeyGenId { set: spec.set(), attempt },
+            shares,
+          }),
+        )
+        .await;
+    } else {
+      assert!(confirmation_nonces.is_none());
+    }
+  }
+
+  Transaction::DkgConfirmed(attempt, shares, signed) => {
+    if let Some(shares) = handle(
+      &mut txn,
+      Zone::Dkg,
+      DKG_CONFIRMATION_SHARES,
+      spec.n(),
+      [0; 32],
+      attempt,
+      shares.to_vec(),
+      &signed,
+    ) {
+      log::info!("got all DkgConfirmed for {}", hex::encode(genesis));
+
+      let preprocesses = read_known_to_exist_data::<D, _>(
+        &txn,
+        spec,
+        key,
+        DKG_CONFIRMATION_NONCES,
+        [0; 32],
+        spec.n(),
+        attempt,
+        vec![],
+        None,
+      );
+
+      let key_pair = TributaryDb::<D>::currently_completing_key_pair(&txn, genesis)
+        .unwrap_or_else(|| {
+          panic!(
+            "in DkgConfirmed handling, which happens after everyone {}",
+            "(including us) fires DkgConfirmed, yet no confirming key pair"
+          )
+        });
+      let Ok(sig) = DkgConfirmer::complete(spec, key, preprocesses, &key_pair, shares) else {
+        // TODO: Full slash
+        todo!();
+      };
+
+      publish_serai_tx(
+        spec.set(),
+        Serai::set_validator_set_keys(spec.set().network, key_pair, Signature(sig)),
+      )
+      .await;
+    }
+  }
+
+  let bytes = shares
+    .remove(
+      &spec
+        .i(Ristretto::generator() * key.deref())
+        .expect("in a tributary we're not a validator for"),
+    )
+    .unwrap();
+
+  if let Some(shares) =
+    handle(Zone::Dkg, b"dkg_shares", spec.n(), [0; 32], attempt, bytes, signed)
+  {
+    processors
+      .send(
+        spec.set().network,
+        CoordinatorMessage::KeyGen(key_gen::CoordinatorMessage::Shares {
+          id: KeyGenId { set: spec.set(), attempt },
+          shares,
+        }),
+      )
+      .await;
+  }
+}
+
+Transaction::ExternalBlock(block) => {
+  // Because this external block has been finalized, its batch ID should be authorized
+  TributaryDb::<D>::recognize_id(&mut txn, Zone::Batch.label(), genesis, block);
+  recognized_id
+    .send((genesis, RecognizedIdType::Block, block))
+    .expect("recognized_id_recv was dropped. are we shutting down?");
+}
+
+Transaction::SubstrateBlock(block) => {
+  let plan_ids = TributaryDb::<D>::plan_ids(&txn, genesis, block).expect(
+    "synced a tributary block finalizing a substrate block in a provided transaction \
+    despite us not providing that transaction",
+  );
+
+  for id in plan_ids {
+    TributaryDb::<D>::recognize_id(&mut txn, Zone::Sign.label(), genesis, id);
+    recognized_id
+      .send((genesis, RecognizedIdType::Plan, id))
+      .expect("recognized_id_recv was dropped. are we shutting down?");
+  }
+}
+
+  Transaction::SubstrateBlock(block) => {
+    let plan_ids = TributaryDb::<D>::plan_ids(&txn, genesis, block).expect(
+      "synced a tributary block finalizing a substrate block in a provided transaction \
+      despite us not providing that transaction",
+    );
+
+    for id in plan_ids {
+      TributaryDb::<D>::recognize_id(&mut txn, Zone::Sign.label(), genesis, id);
+      recognized_id
+        .send((genesis, RecognizedIdType::Plan, id))
+        .expect("recognized_id_recv was dropped. are we shutting down?");
+    }
+  }
+
+  Transaction::BatchPreprocess(data) => {
+    if let Some(preprocesses) = handle(
+      &mut txn,
+      Zone::Batch,
+      b"batch_preprocess",
+      spec.t(),
+      data.plan,
+      data.attempt,
+      data.data,
+      &data.signed,
+    ) {
+      processors
+        .send(
+          spec.set().network,
+          CoordinatorMessage::Coordinator(
+            coordinator::CoordinatorMessage::BatchPreprocesses {
+              id: SignId { key: todo!(), id: data.plan, attempt: data.attempt },
+              preprocesses,
+            },
+          ),
+        )
+        .await;
+    }
+  }
+  Transaction::BatchShare(data) => {
+    if let Some(shares) = handle(
+      &mut txn,
+      Zone::Batch,
+      b"batch_share",
+      spec.t(),
+      data.plan,
+      data.attempt,
+      data.data,
+      &data.signed,
+    ) {
+      processors
+        .send(
+          spec.set().network,
+          CoordinatorMessage::Coordinator(coordinator::CoordinatorMessage::BatchShares {
+            id: SignId { key: todo!(), id: data.plan, attempt: data.attempt },
+            shares: shares
+              .drain()
+              .map(|(validator, share)| (validator, share.try_into().unwrap()))
+              .collect(),
+          }),
+        )
+        .await;
+    }
+  }
+
+  Transaction::SignPreprocess(data) => {
+    if let Some(preprocesses) = handle(
+      &mut txn,
+      Zone::Sign,
+      b"sign_preprocess",
+      spec.t(),
+      data.plan,
+      data.attempt,
+      data.data,
+      &data.signed,
+    ) {
+      processors
+        .send(
+          spec.set().network,
+          CoordinatorMessage::Sign(sign::CoordinatorMessage::Preprocesses {
+            id: SignId { key: todo!(), id: data.plan, attempt: data.attempt },
+            preprocesses,
+          },
+        ),
+      )
+      .await;
+  }
+  Transaction::SignShare(data) => {
+    if let Some(shares) = handle(
+      &mut txn,
+      Zone::Sign,
+      b"sign_share",
+      spec.t(),
+      data.plan,
+      data.attempt,
+      data.data,
+      &data.signed,
+    ) {
+      processors
+        .send(
+          spec.set().network,
+          CoordinatorMessage::Sign(sign::CoordinatorMessage::Shares {
+            id: SignId { key: todo!(), id: data.plan, attempt: data.attempt },
+            shares,
+          }),
+        )
+        .await;
+    }
+  }
+  Transaction::SignCompleted(_, _, _) => todo!(),
+}
+}

--- a/coordinator/src/tributary/mod.rs
+++ b/coordinator/src/tributary/mod.rs
@@ -26,7 +26,8 @@ use serai_client::{
 
 #[rustfmt::skip]
 use tributary::{
-  ReadWrite, Signed, TransactionError, TransactionKind, Transaction as TransactionTrait,
+  ReadWrite,
+  transaction::{Signed, TransactionError, TransactionKind, Transaction as TransactionTrait}
 };
 
 mod db;

--- a/coordinator/src/tributary/mod.rs
+++ b/coordinator/src/tributary/mod.rs
@@ -34,6 +34,7 @@ mod db;
 pub use db::*;
 
 mod handle;
+pub use handle::*;
 
 pub mod scanner;
 

--- a/coordinator/src/tributary/mod.rs
+++ b/coordinator/src/tributary/mod.rs
@@ -33,6 +33,8 @@ use tributary::{
 mod db;
 pub use db::*;
 
+mod handle;
+
 pub mod scanner;
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/coordinator/src/tributary/scanner.rs
+++ b/coordinator/src/tributary/scanner.rs
@@ -269,14 +269,13 @@ async fn handle_block<
         TributaryDb::<D>::set_fatally_slashed(&mut txn, genesis, msgs[0].msg.sender);
 
         // TODO: disconnect the node from network
-      },
+      }
       TributaryTransaction::Tendermint(TendermintTx::SlashVote(_, _)) => {
         // TODO: make sure same signer doesn't vote twice
 
         // increment the counter for this vote
         let vote_key = TributaryDb::<D>::slash_vote_key(genesis, vote.id, vote.target);
-        let mut count =
-          txn.get(&vote_key).map_or(0, |c| u32::from_le_bytes(c.try_into().unwrap()));
+        let mut count = txn.get(&vote_key).map_or(0, |c| u32::from_le_bytes(c.try_into().unwrap()));
         count += 1;
         txn.put(vote_key, count.to_le_bytes());
 
@@ -327,7 +326,16 @@ pub async fn handle_new_blocks<
   let mut last_block = db.last_block(genesis);
   while let Some(next) = tributary.block_after(&last_block) {
     let block = tributary.block(&next).unwrap();
-    handle_block<_, _, _, _, P>(db, key, recognized_id, processors, publish_serai_tx.clone(), spec, block).await;
+    handle_block::<_, _, _, _, P>(
+      db,
+      key,
+      recognized_id,
+      processors,
+      publish_serai_tx.clone(),
+      spec,
+      block,
+    )
+    .await;
     last_block = next;
     db.set_last_block(genesis, next);
   }

--- a/coordinator/src/tributary/scanner.rs
+++ b/coordinator/src/tributary/scanner.rs
@@ -1,6 +1,3 @@
-use core::{ops::Deref, future::Future};
-use std::collections::HashMap;
-
 use zeroize::Zeroizing;
 
 use rand_core::SeedableRng;
@@ -24,18 +21,13 @@ use serai_client::{
 
 use tokio::sync::mpsc::UnboundedSender;
 
-use tributary::{Signed, Block, TributaryReader};
-
-use processor_messages::{
-  key_gen::{self, KeyGenId},
-  sign::{self, SignId},
-  coordinator, CoordinatorMessage,
-};
+use tributary::{Transaction as TributaryTransaction, Block, TributaryReader};
 
 use serai_db::{Get, DbTxn};
 
 use crate::{
   Db,
+  tributary::handle::handle_application_tx,
   processors::Processors,
   tributary::{TributaryDb, TributarySpec, Transaction},
 };
@@ -228,8 +220,6 @@ pub enum RecognizedIdType {
   Plan,
 }
 
-use tributary::Transaction as TributaryTransaction;
-
 // Handle a specific Tributary block
 #[allow(clippy::needless_pass_by_ref_mut)] // False positive?
 async fn handle_block<
@@ -251,380 +241,36 @@ async fn handle_block<
   let genesis = spec.genesis();
   let hash = block.hash();
 
-  let mut event_id = 0;
+  let mut event_id = 0; // TODO: should start from -1 so that we need only 1 event_id += 1?
   #[allow(clippy::explicit_counter_loop)] // event_id isn't TX index. It just currently lines up
   for tx in block.transactions {
-    if !TributaryDb::<D>::handled_event(&db.0, hash, event_id) {
-      let mut txn = db.0.txn();
-
-      // Used to determine if an ID is acceptable
-      #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-      enum Zone {
-        Dkg,
-        Batch,
-        Sign,
-      }
-
-      impl Zone {
-        fn label(&self) -> &'static str {
-          match self {
-            Zone::Dkg => {
-              panic!("getting the label for dkg despite dkg code paths not needing a label")
-            }
-            Zone::Batch => "batch",
-            Zone::Sign => "sign",
-          }
-        }
-      }
-
-      let handle =
-        |txn: &mut _, zone: Zone, label, needed, id, attempt, bytes: Vec<u8>, signed: &Signed| {
-          if zone == Zone::Dkg {
-            // Since Dkg doesn't have an ID, solely attempts, this should just be [0; 32]
-            assert_eq!(id, [0; 32], "DKG, which shouldn't have IDs, had a non-0 ID");
-          } else if !TributaryDb::<D>::recognized_id(txn, zone.label(), genesis, id) {
-            // TODO: Full slash
-            todo!();
-          }
-
-          // If they've already published a TX for this attempt, slash
-          if let Some(data) =
-            TributaryDb::<D>::data(label, txn, genesis, id, attempt, signed.signer)
-          {
-            if data != bytes {
-              // TODO: Full slash
-              todo!();
-            }
-
-            // TODO: Slash
-            return None;
-          }
-
-          // If the attempt is lesser than the blockchain's, slash
-          let curr_attempt = TributaryDb::<D>::attempt(txn, genesis, id);
-          if attempt < curr_attempt {
-            // TODO: Slash for being late
-            return None;
-          }
-          if attempt > curr_attempt {
-            // TODO: Full slash
-            todo!();
-          }
-
-          // TODO: We can also full slash if shares before all commitments, or share before the
-          // necessary preprocesses
-
-          // TODO: If this is shares, we need to check they are part of the selected signing set
-
-          // Store this data
-          let received =
-            TributaryDb::<D>::set_data(label, txn, genesis, id, attempt, signed.signer, &bytes);
-
-          // If we have all the needed commitments/preprocesses/shares, tell the processor
-          // TODO: This needs to be coded by weight, not by validator count
-          if received == needed {
-            return Some(read_known_to_exist_data::<D, _>(
-              txn,
-              spec,
-              key,
-              label,
-              id,
-              needed,
-              attempt,
-              bytes,
-              Some(signed),
-            ));
-          }
-          None
-        };
-
-      match tx {
-        TributaryTransaction::Application(tx) => {
-          match tx {
-            Transaction::DkgCommitments(attempt, bytes, signed) => {
-              if let Some(commitments) = handle(
-                &mut txn,
-                Zone::Dkg,
-                b"dkg_commitments",
-                spec.n(),
-                [0; 32],
-                attempt,
-                bytes,
-                &signed,
-              ) {
-                log::info!("got all DkgCommitments for {}", hex::encode(genesis));
-                processors
-                  .send(
-                    spec.set().network,
-                    CoordinatorMessage::KeyGen(key_gen::CoordinatorMessage::Commitments {
-                      id: KeyGenId { set: spec.set(), attempt },
-                      commitments,
-                    }),
-                  )
-                  .await;
-              }
-            }
-
-            Transaction::DkgShares { attempt, sender_i, mut shares, confirmation_nonces, signed } => {
-              if sender_i !=
-                spec
-                  .i(signed.signer)
-                  .expect("transaction added to tributary by signer who isn't a participant")
-              {
-                // TODO: Full slash
-                todo!();
-              }
-
-              if shares.len() != (usize::from(spec.n()) - 1) {
-                // TODO: Full slash
-                todo!();
-              }
-
-              // Only save our share's bytes
-              let our_i = spec
-                .i(Ristretto::generator() * key.deref())
-                .expect("in a tributary we're not a validator for");
-              // This unwrap is safe since the length of shares is checked, the the only missing key
-              // within the valid range will be the sender's i
-              let bytes = if sender_i == our_i { vec![] } else { shares.remove(&our_i).unwrap() };
-
-              let confirmation_nonces = handle(
-                &mut txn,
-                Zone::Dkg,
-                DKG_CONFIRMATION_NONCES,
-                spec.n(),
-                [0; 32],
-                attempt,
-                confirmation_nonces.to_vec(),
-                &signed,
-              );
-              if let Some(shares) =
-                handle(&mut txn, Zone::Dkg, b"dkg_shares", spec.n(), [0; 32], attempt, bytes, &signed)
-              {
-                log::info!("got all DkgShares for {}", hex::encode(genesis));
-                assert!(confirmation_nonces.is_some());
-                processors
-                  .send(
-                    spec.set().network,
-                    CoordinatorMessage::KeyGen(key_gen::CoordinatorMessage::Shares {
-                      id: KeyGenId { set: spec.set(), attempt },
-                      shares,
-                    }),
-                  )
-                  .await;
-              } else {
-                assert!(confirmation_nonces.is_none());
-              }
-            }
-
-            Transaction::DkgConfirmed(attempt, shares, signed) => {
-              if let Some(shares) = handle(
-                &mut txn,
-                Zone::Dkg,
-                DKG_CONFIRMATION_SHARES,
-                spec.n(),
-                [0; 32],
-                attempt,
-                shares.to_vec(),
-                &signed,
-              ) {
-                log::info!("got all DkgConfirmed for {}", hex::encode(genesis));
-
-                let preprocesses = read_known_to_exist_data::<D, _>(
-                  &txn,
-                  spec,
-                  key,
-                  DKG_CONFIRMATION_NONCES,
-                  [0; 32],
-                  spec.n(),
-                  attempt,
-                  vec![],
-                  None,
-                );
-
-                let key_pair = TributaryDb::<D>::currently_completing_key_pair(&txn, genesis)
-                  .unwrap_or_else(|| {
-                    panic!(
-                      "in DkgConfirmed handling, which happens after everyone {}",
-                      "(including us) fires DkgConfirmed, yet no confirming key pair"
-                    )
-                  });
-                let Ok(sig) = DkgConfirmer::complete(spec, key, preprocesses, &key_pair, shares) else {
-                  // TODO: Full slash
-                  todo!();
-                };
-
-                publish_serai_tx(
-                  spec.set(),
-                  Serai::set_validator_set_keys(spec.set().network, key_pair, Signature(sig)),
-                )
-                .await;
-              }
-            }
-
-            let bytes = shares
-              .remove(
-                &spec
-                  .i(Ristretto::generator() * key.deref())
-                  .expect("in a tributary we're not a validator for"),
-              )
-              .unwrap();
-
-            if let Some(shares) =
-              handle(Zone::Dkg, b"dkg_shares", spec.n(), [0; 32], attempt, bytes, signed)
-            {
-              processors
-                .send(
-                  spec.set().network,
-                  CoordinatorMessage::KeyGen(key_gen::CoordinatorMessage::Shares {
-                    id: KeyGenId { set: spec.set(), attempt },
-                    shares,
-                  }),
-                )
-                .await;
-            }
-          }
-
-          Transaction::ExternalBlock(block) => {
-            // Because this external block has been finalized, its batch ID should be authorized
-            TributaryDb::<D>::recognize_id(&mut txn, Zone::Batch.label(), genesis, block);
-            recognized_id
-              .send((genesis, RecognizedIdType::Block, block))
-              .expect("recognized_id_recv was dropped. are we shutting down?");
-          }
-
-          Transaction::SubstrateBlock(block) => {
-            let plan_ids = TributaryDb::<D>::plan_ids(&txn, genesis, block).expect(
-              "synced a tributary block finalizing a substrate block in a provided transaction \
-              despite us not providing that transaction",
-            );
-
-            for id in plan_ids {
-              TributaryDb::<D>::recognize_id(&mut txn, Zone::Sign.label(), genesis, id);
-              recognized_id
-                .send((genesis, RecognizedIdType::Plan, id))
-                .expect("recognized_id_recv was dropped. are we shutting down?");
-            }
-          }
-
-            Transaction::SubstrateBlock(block) => {
-              let plan_ids = TributaryDb::<D>::plan_ids(&txn, genesis, block).expect(
-                "synced a tributary block finalizing a substrate block in a provided transaction \
-                despite us not providing that transaction",
-              );
-
-              for id in plan_ids {
-                TributaryDb::<D>::recognize_id(&mut txn, Zone::Sign.label(), genesis, id);
-                recognized_id
-                  .send((genesis, RecognizedIdType::Plan, id))
-                  .expect("recognized_id_recv was dropped. are we shutting down?");
-              }
-            }
-
-            Transaction::BatchPreprocess(data) => {
-              if let Some(preprocesses) = handle(
-                &mut txn,
-                Zone::Batch,
-                b"batch_preprocess",
-                spec.t(),
-                data.plan,
-                data.attempt,
-                data.data,
-                &data.signed,
-              ) {
-                processors
-                  .send(
-                    spec.set().network,
-                    CoordinatorMessage::Coordinator(
-                      coordinator::CoordinatorMessage::BatchPreprocesses {
-                        id: SignId { key: todo!(), id: data.plan, attempt: data.attempt },
-                        preprocesses,
-                      },
-                    ),
-                  )
-                  .await;
-              }
-            }
-            Transaction::BatchShare(data) => {
-              if let Some(shares) = handle(
-                &mut txn,
-                Zone::Batch,
-                b"batch_share",
-                spec.t(),
-                data.plan,
-                data.attempt,
-                data.data,
-                &data.signed,
-              ) {
-                processors
-                  .send(
-                    spec.set().network,
-                    CoordinatorMessage::Coordinator(coordinator::CoordinatorMessage::BatchShares {
-                      id: SignId { key: todo!(), id: data.plan, attempt: data.attempt },
-                      shares: shares
-                        .drain()
-                        .map(|(validator, share)| (validator, share.try_into().unwrap()))
-                        .collect(),
-                    }),
-                  )
-                  .await;
-              }
-            }
-
-            Transaction::SignPreprocess(data) => {
-              if let Some(preprocesses) = handle(
-                &mut txn,
-                Zone::Sign,
-                b"sign_preprocess",
-                spec.t(),
-                data.plan,
-                data.attempt,
-                data.data,
-                &data.signed,
-              ) {
-                processors
-                  .send(
-                    spec.set().network,
-                    CoordinatorMessage::Sign(sign::CoordinatorMessage::Preprocesses {
-                      id: SignId { key: todo!(), id: data.plan, attempt: data.attempt },
-                      preprocesses,
-                    },
-                  ),
-                )
-                .await;
-            }
-            Transaction::SignShare(data) => {
-              if let Some(shares) = handle(
-                &mut txn,
-                Zone::Sign,
-                b"sign_share",
-                spec.t(),
-                data.plan,
-                data.attempt,
-                data.data,
-                &data.signed,
-              ) {
-                processors
-                  .send(
-                    spec.set().network,
-                    CoordinatorMessage::Sign(sign::CoordinatorMessage::Shares {
-                      id: SignId { key: todo!(), id: data.plan, attempt: data.attempt },
-                      shares,
-                    }),
-                  )
-                  .await;
-              }
-            }
-            Transaction::SignCompleted(_, _, _) => todo!(),
-          }
-          Tendermint(TendermintTx::SlashEvidence(_)) => todo!(),
-          Tendermint(TendermintTx::SlashVote(_, _)) => todo!(),
-        }
-      }
-
-      TributaryDb::<D>::handle_event(&mut txn, hash, event_id);
-      txn.commit();
+    if TributaryDb::<D>::handled_event(&db.0, hash, event_id) {
+      event_id += 1;
+      continue;
     }
+
+    let mut txn = db.0.txn();
+
+    match tx {
+      TributaryTransaction::Tendermint(TendermintTx::SlashEvidence(_)) => todo!(),
+      TributaryTransaction::Tendermint(TendermintTx::SlashVote(_, _)) => todo!(),
+      TributaryTransaction::Application(tx) => {
+        handle_application_tx::<D, Pro>(
+          tx,
+          spec,
+          processors,
+          genesis,
+          key,
+          recognized_id,
+          &mut txn,
+        )
+        .await;
+      }
+    }
+
+    TributaryDb::<D>::handle_event(&mut txn, hash, event_id);
+    txn.commit();
+
     event_id += 1;
   }
 

--- a/coordinator/src/tributary/scanner.rs
+++ b/coordinator/src/tributary/scanner.rs
@@ -266,8 +266,7 @@ async fn handle_block<
         let msgs = decode_evidence::<TendermintNetwork<D, Transaction, P>>(&ev).unwrap();
 
         // mark the node as fatally slashed
-        let id = msgs[0].msg.sender;
-        TributaryDb::<D>::set_fatally_slashed(&mut txn, genesis, id);
+        TributaryDb::<D>::set_fatally_slashed(&mut txn, genesis, msgs[0].msg.sender);
 
         // TODO: disconnect the node from network
       },
@@ -275,7 +274,7 @@ async fn handle_block<
         // TODO: make sure same signer doesn't vote twice
 
         // increment the counter for this vote
-        let vote_key = TributaryDb::<D>::slash_vote_key(genesis, id);
+        let vote_key = TributaryDb::<D>::slash_vote_key(genesis, vote.id, vote.target);
         let mut count =
           txn.get(&vote_key).map_or(0, |c| u32::from_le_bytes(c.try_into().unwrap()));
         count += 1;

--- a/coordinator/src/tributary/scanner.rs
+++ b/coordinator/src/tributary/scanner.rs
@@ -72,7 +72,7 @@ async fn handle_block<
 
         // Since anything with evidence is fundamentally faulty behavior, not just temporal errors,
         // mark the node as fatally slashed
-        TributaryDb::<D>::set_fatally_slashed(&mut txn, genesis, msgs[0].msg.sender);
+        TributaryDb::<D>::set_fatally_slashed(&mut txn, genesis, msgs.0.msg.sender);
 
         // TODO: disconnect the node from network/ban from further participation in Tributary
       }

--- a/coordinator/tributary/Cargo.toml
+++ b/coordinator/tributary/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
+lazy_static = "1"
 thiserror = "1"
 
 subtle = "^2"

--- a/coordinator/tributary/Cargo.toml
+++ b/coordinator/tributary/Cargo.toml
@@ -35,5 +35,8 @@ tendermint = { package = "tendermint-machine", path = "./tendermint" }
 
 tokio = { version = "1", features = ["sync", "time", "rt"] }
 
+[dev-dependencies]
+tokio = { version = "1", features = ["macros"] }
+
 [features]
 tests = []

--- a/coordinator/tributary/Cargo.toml
+++ b/coordinator/tributary/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
-lazy_static = "1"
 thiserror = "1"
 
 subtle = "^2"
@@ -36,6 +35,7 @@ tendermint = { package = "tendermint-machine", path = "./tendermint" }
 tokio = { version = "1", features = ["sync", "time", "rt"] }
 
 [dev-dependencies]
+lazy_static = "1"
 tokio = { version = "1", features = ["macros"] }
 
 [features]

--- a/coordinator/tributary/Cargo.toml
+++ b/coordinator/tributary/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-lazy_static = "1"
 async-trait = "0.1"
 thiserror = "1"
 

--- a/coordinator/tributary/Cargo.toml
+++ b/coordinator/tributary/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
 
 [dependencies]
+lazy_static = "1"
 async-trait = "0.1"
 thiserror = "1"
 
@@ -35,7 +36,6 @@ tendermint = { package = "tendermint-machine", path = "./tendermint" }
 tokio = { version = "1", features = ["sync", "time", "rt"] }
 
 [dev-dependencies]
-lazy_static = "1"
 tokio = { version = "1", features = ["macros"] }
 
 [features]

--- a/coordinator/tributary/src/block.rs
+++ b/coordinator/tributary/src/block.rs
@@ -180,9 +180,18 @@ impl<T: TransactionTrait> Block<T> {
   ) -> Result<(), BlockError> {
     #[derive(Clone, Copy, PartialEq, Eq, Debug)]
     enum Order {
-      Provided = 0,
-      Unsigned = 1,
-      Signed = 2,
+      Provided,
+      Unsigned,
+      Signed,
+    }
+    impl From<Order> for u8 {
+      fn from(order: Order) -> u8 {
+        match order {
+          Order::Provided => 0,
+          Order::Unsigned => 1,
+          Order::Signed => 2,
+        }
+      }
     }
 
     if self.serialize().len() > BLOCK_SIZE_LIMIT {

--- a/coordinator/tributary/src/block.rs
+++ b/coordinator/tributary/src/block.rs
@@ -115,13 +115,20 @@ impl<T: TransactionTrait> Block<T> {
       txs.push(Transaction::Application(tx))
     }
 
+    let mut signed = vec![];
+    let mut unsigned = vec![];
     for tx in mempool {
-      assert!(
-        !matches!(tx.kind(), TransactionKind::Provided(_)),
-        "provided transaction entered mempool"
-      );
-      txs.push(tx);
+      match tx.kind() {
+        TransactionKind::Signed(_) => signed.push(tx),
+        TransactionKind::Unsigned => unsigned.push(tx),
+        TransactionKind::Provided(_) => panic!("provided transaction entered mempool")
+      }
     }
+
+    // unsigned first
+    txs.extend(unsigned);
+    // then signed
+    txs.extend(signed);
 
     // Check TXs are sorted by nonce.
     let nonce = |tx: &Transaction<T>| {

--- a/coordinator/tributary/src/blockchain.rs
+++ b/coordinator/tributary/src/blockchain.rs
@@ -132,7 +132,12 @@ impl<D: Db, T: TransactionTrait> Blockchain<D, T> {
     db.get(Self::block_after_key(&genesis, block)).map(|bytes| bytes.try_into().unwrap())
   }
 
-  pub(crate) fn add_transaction<N: Network>(&mut self, internal: bool, tx: Transaction<T>, schema: N::SignatureScheme) -> bool {
+  pub(crate) fn add_transaction<N: Network>(
+    &mut self,
+    internal: bool,
+    tx: Transaction<T>,
+    schema: N::SignatureScheme,
+  ) -> bool {
     let db = self.db.as_ref().unwrap();
     let genesis = self.genesis;
 
@@ -177,7 +182,11 @@ impl<D: Db, T: TransactionTrait> Blockchain<D, T> {
     block
   }
 
-  pub(crate) fn verify_block<N: Network>(&self, block: &Block<T>, schema: N::SignatureScheme) -> Result<(), BlockError> {
+  pub(crate) fn verify_block<N: Network>(
+    &self,
+    block: &Block<T>,
+    schema: N::SignatureScheme,
+  ) -> Result<(), BlockError> {
     let db = self.db.as_ref().unwrap();
     let unsigned_in_chain = |hash: [u8; 32]| {
       let existing = db.get(Self::unsigned_included_key(&self.genesis)).unwrap_or(vec![]);
@@ -195,12 +204,17 @@ impl<D: Db, T: TransactionTrait> Blockchain<D, T> {
       self.next_nonces.clone(),
       schema,
       &commit,
-      unsigned_in_chain
+      unsigned_in_chain,
     )
   }
 
   /// Add a block.
-  pub(crate) fn add_block<N: Network>(&mut self, block: &Block<T>, commit: Vec<u8>, schema: N::SignatureScheme) -> Result<(), BlockError> {
+  pub(crate) fn add_block<N: Network>(
+    &mut self,
+    block: &Block<T>,
+    commit: Vec<u8>,
+    schema: N::SignatureScheme,
+  ) -> Result<(), BlockError> {
     self.verify_block::<N>(block, schema)?;
 
     log::info!(
@@ -239,7 +253,7 @@ impl<D: Db, T: TransactionTrait> Blockchain<D, T> {
           let hash = tx.hash();
           let key = Self::unsigned_included_key(&self.genesis);
 
-          // add to the included unsigned 
+          // add to the included unsigned
           let mut existing = txn.get(&key).unwrap_or(vec![]);
           existing.extend(hash);
           txn.put(key, existing);

--- a/coordinator/tributary/src/blockchain.rs
+++ b/coordinator/tributary/src/blockchain.rs
@@ -149,9 +149,8 @@ impl<D: Db, T: TransactionTrait> Blockchain<D, T> {
       Some(Commit::<N::SignatureScheme>::decode(&mut commit.as_ref()).unwrap())
     };
 
-    let unsigned_in_chain = |hash: [u8; 32]| {
-      db.get(Self::unsigned_included_key(&self.genesis, &hash)).is_some()
-    };
+    let unsigned_in_chain =
+      |hash: [u8; 32]| db.get(Self::unsigned_included_key(&self.genesis, &hash)).is_some();
     self.mempool.add::<N>(&self.next_nonces, internal, tx, schema, unsigned_in_chain, commit)
   }
 
@@ -166,9 +165,8 @@ impl<D: Db, T: TransactionTrait> Blockchain<D, T> {
 
   pub(crate) fn build_block<N: Network>(&mut self, schema: N::SignatureScheme) -> Block<T> {
     let db = self.db.as_ref().unwrap();
-    let unsigned_in_chain = |hash: [u8; 32]| {
-      db.get(Self::unsigned_included_key(&self.genesis, &hash)).is_some()
-    };
+    let unsigned_in_chain =
+      |hash: [u8; 32]| db.get(Self::unsigned_included_key(&self.genesis, &hash)).is_some();
 
     let block = Block::new(
       self.tip,
@@ -186,9 +184,8 @@ impl<D: Db, T: TransactionTrait> Blockchain<D, T> {
     schema: N::SignatureScheme,
   ) -> Result<(), BlockError> {
     let db = self.db.as_ref().unwrap();
-    let unsigned_in_chain = |hash: [u8; 32]| {
-      db.get(Self::unsigned_included_key(&self.genesis, &hash)).is_some()
-    };
+    let unsigned_in_chain =
+      |hash: [u8; 32]| db.get(Self::unsigned_included_key(&self.genesis, &hash)).is_some();
     let commit = |block: u32| -> Option<Commit<N::SignatureScheme>> {
       let commit = self.commit_by_block_number(block)?;
       // commit has to be valid if it is coming from our db

--- a/coordinator/tributary/src/lib.rs
+++ b/coordinator/tributary/src/lib.rs
@@ -22,8 +22,10 @@ use tokio::sync::RwLock;
 mod merkle;
 pub(crate) use merkle::*;
 
-mod transaction;
-pub use transaction::*;
+pub mod transaction;
+pub use transaction::{TransactionError, Signed, TransactionKind, Transaction as TransactionTrait};
+
+use crate::tendermint::tx::TendermintTx;
 
 mod provided;
 pub(crate) use provided::*;
@@ -38,7 +40,7 @@ pub(crate) use blockchain::*;
 mod mempool;
 pub(crate) use mempool::*;
 
-mod tendermint;
+pub mod tendermint;
 pub(crate) use crate::tendermint::*;
 
 #[cfg(any(test, feature = "tests"))]
@@ -56,6 +58,60 @@ pub const BLOCK_SIZE_LIMIT: usize = 350_000;
 pub(crate) const TENDERMINT_MESSAGE: u8 = 0;
 pub(crate) const BLOCK_MESSAGE: u8 = 1;
 pub(crate) const TRANSACTION_MESSAGE: u8 = 2;
+
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum Transaction<T: TransactionTrait> {
+  Tendermint(TendermintTx),
+  Application(T)
+}
+
+impl<T: TransactionTrait> ReadWrite for Transaction<T>  {
+  fn read<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+    let mut kind = [0];
+    reader.read_exact(&mut kind)?;
+    match kind[0] {
+      0 => {
+        let tx = TendermintTx::read(reader)?;
+        Ok(Transaction::Tendermint(tx))
+      },
+      1 => {
+        let tx = T::read(reader)?;
+        Ok(Transaction::Application(tx))
+      },
+      _ => Err(io::Error::new(io::ErrorKind::Other, "invalid transaction type")),
+    }
+  }
+  fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+    match self {
+      Transaction::Tendermint(tx) => {
+        writer.write_all(&[0])?;
+        tx.write(writer)
+      },
+      Transaction::Application(tx) => {
+        writer.write_all(&[1])?;
+        tx.write(writer)
+      }
+    }
+  }
+}
+
+impl<T: TransactionTrait> Transaction<T> {
+  pub fn hash(&self) -> [u8; 32] {
+    match self {
+      Transaction::Tendermint(tx) => tx.hash(),
+      Transaction::Application(tx) => tx.hash()
+    }
+  }
+  
+  pub fn kind(&self) -> TransactionKind<'_> {
+    match self {
+      Transaction::Tendermint(tx) => tx.kind(),
+      Transaction::Application(tx) => tx.kind()
+    }
+  }
+}
+
 
 /// An item which can be read and written.
 pub trait ReadWrite: Sized {
@@ -83,7 +139,7 @@ impl<P: P2p> P2p for Arc<P> {
 }
 
 #[derive(Clone)]
-pub struct Tributary<D: Db, T: Transaction, P: P2p> {
+pub struct Tributary<D: Db, T: TransactionTrait, P: P2p> {
   db: D,
 
   genesis: [u8; 32],
@@ -94,7 +150,7 @@ pub struct Tributary<D: Db, T: Transaction, P: P2p> {
   messages: Arc<RwLock<MessageSender<TendermintNetwork<D, T, P>>>>,
 }
 
-impl<D: Db, T: Transaction, P: P2p> Tributary<D, T, P> {
+impl<D: Db, T: TransactionTrait, P: P2p> Tributary<D, T, P> {
   pub async fn new(
     db: D,
     genesis: [u8; 32],
@@ -118,7 +174,7 @@ impl<D: Db, T: Transaction, P: P2p> Tributary<D, T, P> {
     } else {
       start_time
     };
-    let proposal = TendermintBlock(blockchain.build_block().serialize());
+    let proposal = TendermintBlock(blockchain.build_block::<TendermintNetwork<D, T, P>>(validators.clone()).serialize());
     let blockchain = Arc::new(RwLock::new(blockchain));
 
     let network = TendermintNetwork { genesis, signer, validators, blockchain, p2p };
@@ -168,9 +224,10 @@ impl<D: Db, T: Transaction, P: P2p> Tributary<D, T, P> {
   // Safe to be &self since the only meaningful usage of self is self.network.blockchain which
   // successfully acquires its own write lock
   pub async fn add_transaction(&self, tx: T) -> bool {
+    let tx = Transaction::Application(tx);
     let mut to_broadcast = vec![TRANSACTION_MESSAGE];
     tx.write(&mut to_broadcast).unwrap();
-    let res = self.network.blockchain.write().await.add_transaction(true, tx);
+    let res = self.network.blockchain.write().await.add_transaction::<TendermintNetwork<D, T, P>>(true, tx, self.network.signature_scheme());
     if res {
       self.network.p2p.broadcast(self.genesis, to_broadcast).await;
     }
@@ -218,14 +275,14 @@ impl<D: Db, T: Transaction, P: P2p> Tributary<D, T, P> {
   pub async fn handle_message(&mut self, msg: &[u8]) -> bool {
     match msg.first() {
       Some(&TRANSACTION_MESSAGE) => {
-        let Ok(tx) = T::read::<&[u8]>(&mut &msg[1 ..]) else {
+        let Ok(tx) = Transaction::read::<&[u8]>(&mut &msg[1 ..]) else {
           log::error!("received invalid transaction message");
           return false;
         };
 
         // TODO: Sync mempools with fellow peers
         // Can we just rebroadcast transactions not included for at least two blocks?
-        let res = self.network.blockchain.write().await.add_transaction(false, tx);
+        let res = self.network.blockchain.write().await.add_transaction::<TendermintNetwork<D, T, P>>(false, tx, self.network.signature_scheme());
         log::debug!("received transaction message. valid new transaction: {res}");
         res
       }
@@ -261,8 +318,8 @@ impl<D: Db, T: Transaction, P: P2p> Tributary<D, T, P> {
 }
 
 #[derive(Clone)]
-pub struct TributaryReader<D: Db, T: Transaction>(D, [u8; 32], PhantomData<T>);
-impl<D: Db, T: Transaction> TributaryReader<D, T> {
+pub struct TributaryReader<D: Db, T: TransactionTrait>(D, [u8; 32], PhantomData<T>);
+impl<D: Db, T: TransactionTrait> TributaryReader<D, T> {
   pub fn genesis(&self) -> [u8; 32] {
     self.1
   }

--- a/coordinator/tributary/src/lib.rs
+++ b/coordinator/tributary/src/lib.rs
@@ -60,6 +60,7 @@ pub(crate) const BLOCK_MESSAGE: u8 = 1;
 pub(crate) const TRANSACTION_MESSAGE: u8 = 2;
 
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Transaction<T: TransactionTrait> {
   Tendermint(TendermintTx),

--- a/coordinator/tributary/src/mempool.rs
+++ b/coordinator/tributary/src/mempool.rs
@@ -3,19 +3,26 @@ use std::collections::HashMap;
 use ciphersuite::{Ciphersuite, Ristretto};
 
 use serai_db::{DbTxn, Db};
+use tendermint::ext::Network;
 
-use crate::{ACCOUNT_MEMPOOL_LIMIT, Signed, TransactionKind, Transaction, verify_transaction};
+use crate::{
+  Transaction,
+  ACCOUNT_MEMPOOL_LIMIT, tendermint::tx::verify_tendermint_tx,
+  transaction::{Signed, TransactionKind, Transaction as TransactionTrait, verify_transaction},
+};
+
+use crate::ReadWrite;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub(crate) struct Mempool<D: Db, T: Transaction> {
+pub(crate) struct Mempool<D: Db, T: TransactionTrait> {
   db: D,
   genesis: [u8; 32],
 
-  txs: HashMap<[u8; 32], T>,
+  txs: HashMap<[u8; 32], Transaction<T>>,
   next_nonces: HashMap<<Ristretto as Ciphersuite>::G, u32>,
 }
 
-impl<D: Db, T: Transaction> Mempool<D, T> {
+impl<D: Db, T: TransactionTrait> Mempool<D, T> {
   fn transaction_key(&self, hash: &[u8]) -> Vec<u8> {
     D::key(b"tributary_mempool", b"transaction", [self.genesis.as_ref(), hash].concat())
   }
@@ -23,29 +30,52 @@ impl<D: Db, T: Transaction> Mempool<D, T> {
     D::key(b"tributary_mempool", b"current", self.genesis)
   }
 
+  fn save_tx(&mut self, tx: Transaction<T>) {
+    let tx_hash = tx.hash();
+    let transaction_key = self.transaction_key(&tx_hash);
+    let current_mempool_key = self.current_mempool_key();
+    let mut current_mempool = self.db.get(&current_mempool_key).unwrap_or(vec![]);
+
+    let mut txn = self.db.txn();
+    txn.put(transaction_key, tx.serialize());
+    current_mempool.extend(tx_hash);
+    txn.put(current_mempool_key, current_mempool);
+    txn.commit();
+
+    self.txs.insert(tx_hash, tx);
+  }
+
   pub(crate) fn new(db: D, genesis: [u8; 32]) -> Self {
-    let mut res = Mempool { db, genesis, txs: HashMap::new(), next_nonces: HashMap::new() };
+    let mut res = Mempool { db, genesis, txs: HashMap::<[u8; 32], Transaction<T>>::new(), next_nonces: HashMap::new() };
 
     let current_mempool = res.db.get(res.current_mempool_key()).unwrap_or(vec![]);
     let mut hash = [0; 32];
     let mut i = 0;
     while i < current_mempool.len() {
       hash.copy_from_slice(&current_mempool[i .. (i + 32)]);
-      let tx =
-        T::read::<&[u8]>(&mut res.db.get(res.transaction_key(&hash)).unwrap().as_ref()).unwrap();
-
-      match tx.kind() {
-        TransactionKind::Signed(Signed { signer, nonce, .. }) => {
-          if let Some(prev) = res.next_nonces.insert(*signer, nonce + 1) {
-            // These mempool additions should've been ordered
-            assert!(prev < *nonce);
-          }
-        }
-        _ => panic!("mempool database had a non-signed transaction"),
-      }
+      let tx: Transaction<T> =
+        Transaction::read::<&[u8]>(&mut res.db.get(res.transaction_key(&hash)).unwrap().as_ref()).unwrap();
 
       debug_assert_eq!(tx.hash(), hash);
-      res.txs.insert(hash, tx);
+      match tx {
+        Transaction::Tendermint(tx) => {
+          // TODO: verify that we have only one evidence tx?
+          res.txs.insert(hash, Transaction::Tendermint(tx));
+        },
+        Transaction::Application(tx) => {
+          match tx.kind() {
+            TransactionKind::Signed(Signed { signer, nonce, .. }) => {
+              if let Some(prev) = res.next_nonces.insert(*signer, nonce + 1) {
+                // These mempool additions should've been ordered
+                assert!(prev < *nonce);
+              }
+              res.txs.insert(hash, Transaction::Application(tx));
+            }
+            _ => panic!("mempool database had a non-signed application transaction"),
+          }
+        }
+      }
+
       i += 32;
     }
 
@@ -53,59 +83,64 @@ impl<D: Db, T: Transaction> Mempool<D, T> {
   }
 
   /// Returns true if this is a valid, new transaction.
-  pub(crate) fn add(
+  pub(crate) fn add<N: Network>(
     &mut self,
     blockchain_next_nonces: &HashMap<<Ristretto as Ciphersuite>::G, u32>,
     internal: bool,
-    tx: T,
+    tx: Transaction<T>,
+    schema: N::SignatureScheme
   ) -> bool {
-    match tx.kind() {
-      TransactionKind::Signed(Signed { signer, nonce, .. }) => {
-        // Get the nonce from the blockchain
-        let Some(blockchain_next_nonce) = blockchain_next_nonces.get(signer).cloned() else {
-          // Not a participant
-          return false;
-        };
-
-        // If the blockchain's nonce is greater than the mempool's, use it
-        // Default to true so if the mempool hasn't tracked this nonce yet, it'll be inserted
-        let mut blockchain_is_greater = true;
-        if let Some(mempool_next_nonce) = self.next_nonces.get(signer) {
-          blockchain_is_greater = blockchain_next_nonce > *mempool_next_nonce;
-        }
-
-        if blockchain_is_greater {
-          self.next_nonces.insert(*signer, blockchain_next_nonce);
-        }
-
-        // If we have too many transactions from this sender, don't add this yet UNLESS we are
-        // this sender
-        if !internal && (nonce >= &(blockchain_next_nonce + ACCOUNT_MEMPOOL_LIMIT)) {
+    match tx {
+      Transaction::Tendermint(tx) => {
+        // verify the tx
+        if verify_tendermint_tx::<N>(&tx, self.genesis, schema).is_err() {
           return false;
         }
 
-        if verify_transaction(&tx, self.genesis, &mut self.next_nonces).is_err() {
-          return false;
-        }
-        assert_eq!(self.next_nonces[signer], nonce + 1);
-
-        let tx_hash = tx.hash();
-
-        let transaction_key = self.transaction_key(&tx_hash);
-        let current_mempool_key = self.current_mempool_key();
-        let mut current_mempool = self.db.get(&current_mempool_key).unwrap_or(vec![]);
-
-        let mut txn = self.db.txn();
-        txn.put(transaction_key, tx.serialize());
-        current_mempool.extend(tx_hash);
-        txn.put(current_mempool_key, current_mempool);
-        txn.commit();
-
-        self.txs.insert(tx_hash, tx);
+        // save the tx.
+        self.save_tx(Transaction::Tendermint(tx));
 
         true
+      },
+      Transaction::Application(tx) => {
+        match tx.kind() {
+          TransactionKind::Signed(Signed { signer, nonce, .. }) => {
+            // Get the nonce from the blockchain
+            let Some(blockchain_next_nonce) = blockchain_next_nonces.get(signer).cloned() else {
+              // Not a participant
+              return false;
+            };
+
+            // If the blockchain's nonce is greater than the mempool's, use it
+            // Default to true so if the mempool hasn't tracked this nonce yet, it'll be inserted
+            let mut blockchain_is_greater = true;
+            if let Some(mempool_next_nonce) = self.next_nonces.get(signer) {
+              blockchain_is_greater = blockchain_next_nonce > *mempool_next_nonce;
+            }
+    
+            if blockchain_is_greater {
+              self.next_nonces.insert(*signer, blockchain_next_nonce);
+            }
+
+            // If we have too many transactions from this sender, don't add this yet UNLESS we are
+            // this sender
+            if !internal && (nonce >= &(blockchain_next_nonce + ACCOUNT_MEMPOOL_LIMIT)) {
+              return false;
+            }
+
+            if verify_transaction(&tx, self.genesis, &mut self.next_nonces).is_err() {
+              return false;
+            }
+            assert_eq!(self.next_nonces[signer], nonce + 1);
+
+            // save the tx.
+            self.save_tx(Transaction::Application(tx));
+
+            true
+          }
+          _ => false,
+        }
       }
-      _ => false,
     }
   }
 
@@ -118,27 +153,31 @@ impl<D: Db, T: Transaction> Mempool<D, T> {
   pub(crate) fn block(
     &mut self,
     blockchain_next_nonces: &HashMap<<Ristretto as Ciphersuite>::G, u32>,
-  ) -> Vec<T> {
+  ) -> Vec<Transaction<T>> {
     let mut res = vec![];
     for hash in self.txs.keys().cloned().collect::<Vec<_>>() {
       let tx = &self.txs[&hash];
+
       // Verify this hasn't gone stale
-      match tx.kind() {
-        TransactionKind::Signed(Signed { signer, nonce, .. }) => {
-          if blockchain_next_nonces[signer] > *nonce {
-            self.remove(&hash);
-            continue;
+      if let Transaction::Application(tx) =  tx {
+        match tx.kind() {
+          TransactionKind::Signed(Signed { signer, nonce, .. }) => {
+            if blockchain_next_nonces[signer] > *nonce {
+              self.remove(&hash);
+              continue;
+            }
           }
+          _ => panic!("non-signed transaction entered mempool"),
         }
-        _ => panic!("non-signed transaction entered mempool"),
       }
 
       // Since this TX isn't stale, include it
+      // TODO: This also includes non-signed Tendermint Evidence txs. should it?
       res.push(tx.clone());
     }
 
     // Sort res by nonce.
-    let nonce = |tx: &T| {
+    let nonce = |tx: &Transaction<T>| {
       if let TransactionKind::Signed(Signed { nonce, .. }) = tx.kind() {
         *nonce
       } else {
@@ -177,7 +216,7 @@ impl<D: Db, T: Transaction> Mempool<D, T> {
   }
 
   #[cfg(test)]
-  pub(crate) fn txs(&self) -> &HashMap<[u8; 32], T> {
+  pub(crate) fn txs(&self) -> &HashMap<[u8; 32], Transaction<T>> {
     &self.txs
   }
 }

--- a/coordinator/tributary/src/mempool.rs
+++ b/coordinator/tributary/src/mempool.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 use ciphersuite::{Ciphersuite, Ristretto};
 
 use serai_db::{DbTxn, Db};
-use tendermint::ext::Network;
+
+use tendermint::ext::{Network, Commit};
 
 use crate::{
   Transaction,
@@ -101,7 +102,8 @@ impl<D: Db, T: TransactionTrait> Mempool<D, T> {
     unsigned_included: &[[u8; 32]],
     internal: bool,
     tx: Transaction<T>,
-    schema: N::SignatureScheme
+    schema: N::SignatureScheme,
+    commit: impl Fn (u32) -> Option<Commit<N::SignatureScheme>>
   ) -> bool {
     match &tx {
       Transaction::Tendermint(tendermint_tx) => {
@@ -115,7 +117,7 @@ impl<D: Db, T: TransactionTrait> Mempool<D, T> {
         }
 
         // verify the tx
-        if verify_tendermint_tx::<N>(tendermint_tx, self.genesis, schema).is_err() {
+        if verify_tendermint_tx::<N>(tendermint_tx, self.genesis, schema, commit).is_err() {
           return false;
         }
 

--- a/coordinator/tributary/src/mempool.rs
+++ b/coordinator/tributary/src/mempool.rs
@@ -7,8 +7,7 @@ use serai_db::{DbTxn, Db};
 use tendermint::ext::{Network, Commit};
 
 use crate::{
-  ACCOUNT_MEMPOOL_LIMIT,
-  ReadWrite,
+  ACCOUNT_MEMPOOL_LIMIT, ReadWrite,
   transaction::{Signed, TransactionKind, Transaction as TransactionTrait, verify_transaction},
   tendermint::tx::verify_tendermint_tx,
   Transaction,
@@ -56,12 +55,7 @@ impl<D: Db, T: TransactionTrait> Mempool<D, T> {
   }
 
   pub(crate) fn new(db: D, genesis: [u8; 32]) -> Self {
-    let mut res = Mempool {
-      db,
-      genesis,
-      txs: HashMap::new(),
-      next_nonces: HashMap::new(),
-    };
+    let mut res = Mempool { db, genesis, txs: HashMap::new(), next_nonces: HashMap::new() };
 
     let current_mempool = res.db.get(res.current_mempool_key()).unwrap_or(vec![]);
 

--- a/coordinator/tributary/src/provided.rs
+++ b/coordinator/tributary/src/provided.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 use serai_db::{Get, DbTxn, Db};
 
-use crate::{TransactionKind, TransactionError, Transaction, verify_transaction};
+use crate::transaction::{TransactionKind, TransactionError, Transaction, verify_transaction};
 
 #[derive(Clone, PartialEq, Eq, Debug, Error)]
 pub enum ProvidedError {

--- a/coordinator/tributary/src/tendermint/mod.rs
+++ b/coordinator/tributary/src/tendermint/mod.rs
@@ -40,8 +40,7 @@ use tokio::{
 use crate::{
   TENDERMINT_MESSAGE, TRANSACTION_MESSAGE, BLOCK_MESSAGE, ReadWrite,
   transaction::Transaction as TransactionTrait, Transaction, BlockHeader, Block, BlockError,
-  Blockchain, P2p,
-  tendermint::tx::SlashVote,
+  Blockchain, P2p, tendermint::tx::SlashVote,
 };
 
 pub mod tx;

--- a/coordinator/tributary/src/tendermint/mod.rs
+++ b/coordinator/tributary/src/tendermint/mod.rs
@@ -227,7 +227,7 @@ impl Weights for Validators {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Encode, Decode)]
-pub(crate) struct TendermintBlock(pub Vec<u8>);
+pub struct TendermintBlock(pub Vec<u8>);
 impl BlockTrait for TendermintBlock {
   type Id = [u8; 32];
   fn id(&self) -> Self::Id {
@@ -236,7 +236,7 @@ impl BlockTrait for TendermintBlock {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct TendermintNetwork<D: Db, T: TransactionTrait, P: P2p> {
+pub struct TendermintNetwork<D: Db, T: TransactionTrait, P: P2p> {
   pub(crate) genesis: [u8; 32],
 
   pub(crate) signer: Arc<Signer>,

--- a/coordinator/tributary/src/tendermint/mod.rs
+++ b/coordinator/tributary/src/tendermint/mod.rs
@@ -120,10 +120,7 @@ impl SignerTrait for Signer {
   }
 
   async fn empty_signature(&self) -> Self::Signature {
-    let sig = SchnorrSignature::<Ristretto>::default().serialize();
-    let mut res = [0; 64];
-    res.copy_from_slice(&sig);
-    res
+    [0; 64]
   }
 }
 

--- a/coordinator/tributary/src/tendermint/mod.rs
+++ b/coordinator/tributary/src/tendermint/mod.rs
@@ -274,17 +274,9 @@ impl<D: Db, T: TransactionTrait, P: P2p> Network for TendermintNetwork<D, T, P> 
 
   async fn slash(&mut self, validator: Self::ValidatorId, slash_event: SlashEvent<Self>) {
     let mut tx = match slash_event {
-      SlashEvent::WithEvidence(ev) => {
+      SlashEvent::WithEvidence(m1, m2) => {
         // create an unsigned evidence tx
-        let mut data = vec![];
-        // size is 2 at most for now.
-        data.extend(u8::to_le_bytes(u8::try_from(ev.len()).unwrap()));
-        for msg in ev {
-          let encoded = msg.encode();
-          data.extend(u32::to_le_bytes(u32::try_from(encoded.len()).unwrap()));
-          data.extend(encoded);
-        }
-        TendermintTx::SlashEvidence(data)
+        TendermintTx::SlashEvidence((m1, m2).encode())
       }
       SlashEvent::Id(reason, block, round) => {
         // create a signed vote tx

--- a/coordinator/tributary/src/tendermint/mod.rs
+++ b/coordinator/tributary/src/tendermint/mod.rs
@@ -283,7 +283,9 @@ impl<D: Db, T: TransactionTrait, P: P2p> Network for TendermintNetwork<D, T, P> 
         // size is 2 at most for now.
         data.extend(u8::to_le_bytes(u8::try_from(ev.len()).unwrap()));
         for msg in ev {
-          data.extend(msg.encode());
+          let encoded = msg.encode();
+          data.extend(u32::to_le_bytes(u32::try_from(encoded.len()).unwrap()));
+          data.extend(encoded);
         }
         TendermintTx::SlashEvidence(data)
       },

--- a/coordinator/tributary/src/tendermint/mod.rs
+++ b/coordinator/tributary/src/tendermint/mod.rs
@@ -40,7 +40,7 @@ use tokio::{
 use crate::{
   transaction::Transaction as TransactionTrait, 
   TENDERMINT_MESSAGE, TRANSACTION_MESSAGE, BLOCK_MESSAGE, ReadWrite, BlockHeader, Block, BlockError,
-  Blockchain, P2p, Transaction
+  Blockchain, P2p, Transaction, tendermint::tx::SlashVote
 };
 
 pub mod tx;
@@ -289,7 +289,8 @@ impl<D: Db, T: TransactionTrait, P: P2p> Network for TendermintNetwork<D, T, P> 
       },
       SlashEvent::Id(id) => {
         // create a signed vote tx
-        TendermintTx::SlashVote(id, VoteSignature::default())
+        let target = validator.encode().try_into().unwrap();
+        TendermintTx::SlashVote(SlashVote{id, target, sig: VoteSignature::default()})
       }
     };
 

--- a/coordinator/tributary/src/tendermint/mod.rs
+++ b/coordinator/tributary/src/tendermint/mod.rs
@@ -118,10 +118,6 @@ impl SignerTrait for Signer {
     res.copy_from_slice(&sig);
     res
   }
-
-  async fn empty_signature(&self) -> Self::Signature {
-    [0; 64]
-  }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/coordinator/tributary/src/tendermint/mod.rs
+++ b/coordinator/tributary/src/tendermint/mod.rs
@@ -286,10 +286,14 @@ impl<D: Db, T: TransactionTrait, P: P2p> Network for TendermintNetwork<D, T, P> 
         }
         TendermintTx::SlashEvidence(data)
       }
-      SlashEvent::Id(id) => {
+      SlashEvent::Id(reason, block, round) => {
         // create a signed vote tx
         let target = validator.encode().try_into().unwrap();
-        TendermintTx::SlashVote(SlashVote { id, target, sig: VoteSignature::default() })
+        TendermintTx::SlashVote(SlashVote {
+          id: (reason, block, round).encode().try_into().unwrap(),
+          target,
+          sig: VoteSignature::default(),
+        })
       }
     };
 

--- a/coordinator/tributary/src/tendermint/tx.rs
+++ b/coordinator/tributary/src/tendermint/tx.rs
@@ -58,6 +58,7 @@ impl Default for VoteSignature {
   }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum TendermintTx {
   SlashEvidence(Vec<u8>),

--- a/coordinator/tributary/src/tendermint/tx.rs
+++ b/coordinator/tributary/src/tendermint/tx.rs
@@ -61,14 +61,14 @@ impl Default for VoteSignature {
 /// Data for a signed transaction.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct SlashVote {
-  pub id: [u8; 32],       // vote id(slash event id)
+  pub id: [u8; 13],       // vote id(slash event id)
   pub target: [u8; 32],   // who to slash
   pub sig: VoteSignature, // signature
 }
 
 impl ReadWrite for SlashVote {
   fn read<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-    let mut id = [0; 32];
+    let mut id = [0; 13];
     let mut target = [0; 32];
     reader.read_exact(&mut id)?;
     reader.read_exact(&mut target)?;

--- a/coordinator/tributary/src/tendermint/tx.rs
+++ b/coordinator/tributary/src/tendermint/tx.rs
@@ -168,7 +168,7 @@ impl TendermintTx {
 }
 
 
-fn decode_evidence<N: Network>(ev: &[u8]) -> Result<Vec<SignedMessageFor<N>>, TransactionError> {
+pub fn decode_evidence<N: Network>(ev: &[u8]) -> Result<Vec<SignedMessageFor<N>>, TransactionError> {
   let mut res = vec![];
   let msg_size = size_of::<SignedMessageFor<N>>();
   

--- a/coordinator/tributary/src/tendermint/tx.rs
+++ b/coordinator/tributary/src/tendermint/tx.rs
@@ -1,0 +1,211 @@
+use core::ops::Deref;
+use std::{io, vec, default::Default};
+
+use scale::Decode;
+
+use zeroize::Zeroizing;
+
+use blake2::{Digest, Blake2s256};
+
+use rand::{RngCore, CryptoRng};
+
+use ciphersuite::{
+  group::{
+    GroupEncoding,
+    ff::Field,
+  },
+  Ciphersuite, Ristretto,
+};
+use schnorr::SchnorrSignature;
+
+use crate::{
+  transaction::{Transaction, TransactionKind, TransactionError},
+  ReadWrite
+};
+
+use tendermint::{ext::Network, SignedMessageFor};
+
+/// Data for a signed transaction.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct VoteSignature {
+  pub signer: <Ristretto as Ciphersuite>::G,
+  pub signature: SchnorrSignature<Ristretto>,
+}
+
+impl ReadWrite for VoteSignature {
+  fn read<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+    let signer = Ristretto::read_G(reader)?;
+    let signature = SchnorrSignature::<Ristretto>::read(reader)?;
+
+    Ok(VoteSignature { signer, signature })
+  }
+
+  fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+    writer.write_all(&self.signer.to_bytes())?;
+    self.signature.write(writer)
+  }
+}
+
+impl Default for VoteSignature {
+  fn default() -> Self {
+    VoteSignature {
+      signer: Ristretto::generator(),
+      signature: SchnorrSignature::<Ristretto>::default(),
+    }
+  }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum TendermintTx {
+  SlashEvidence(Vec<u8>),
+  SlashVote([u8; 32], VoteSignature)
+}
+
+impl ReadWrite for TendermintTx {
+  fn read<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+    let mut kind = [0];
+    reader.read_exact(&mut kind)?;
+    match kind[0] {
+      0 => {
+        let mut len = [0; 4];
+        reader.read_exact(&mut len)?;
+        let mut data = vec![0; usize::try_from(u32::from_le_bytes(len)).unwrap()];
+        reader.read_exact(&mut data)?;
+        Ok(TendermintTx::SlashEvidence(data))
+      }
+      1 => {
+        let mut id = [0; 32];
+        reader.read_exact(&mut id)?;
+        let sig = VoteSignature::read(reader)?;
+        Ok(TendermintTx::SlashVote(id, sig))
+      },
+      _ => Err(io::Error::new(io::ErrorKind::Other, "invalid transaction type")),
+    }
+  }
+
+  fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+    match self {
+      TendermintTx::SlashEvidence(ev) => {
+        writer.write_all(&[0])?;
+        writer.write_all(&u32::try_from(ev.len()).unwrap().to_le_bytes())?;
+        writer.write_all(ev)
+      },
+      TendermintTx::SlashVote(vote, sig) => {
+        writer.write_all(&[1])?;
+        writer.write_all(vote)?;
+        sig.write(writer)
+      }
+    }
+  }
+}
+
+impl Transaction for TendermintTx {
+  fn kind(&self) -> TransactionKind<'_> {
+    match self {
+      TendermintTx::SlashEvidence(_) => TransactionKind::Unsigned,
+      TendermintTx::SlashVote(_, _) => TransactionKind::Unsigned
+    }
+  }
+
+  fn hash(&self) -> [u8; 32] {
+    let tx = self.serialize();
+    Blake2s256::digest(tx).into()
+  }
+
+  fn verify(&self) -> Result<(), TransactionError> {
+    match self {
+      TendermintTx::SlashEvidence(_) => {
+        // TODO: verify that vec len contains 1 or 2 signedmessage.
+
+        // let size = evidence.0.len();
+        // if size <= 0 || size > 2 {
+        //   Err(TransactionError::InvalidContent)?;
+        // }
+
+        Ok(())
+      },
+      TendermintTx::SlashVote(_, _) => {
+        Ok(())
+      }
+    }
+  }
+}
+
+impl TendermintTx {
+
+  // Sign a transaction
+  pub fn sign<R: RngCore + CryptoRng>(
+    &mut self,
+    rng: &mut R,
+    genesis: [u8; 32],
+    key: &Zeroizing<<Ristretto as Ciphersuite>::F>,
+  ) {
+    fn signature(tx: &mut TendermintTx) -> Option<&mut VoteSignature> {
+      match tx {
+        TendermintTx::SlashVote(_, sig) => {
+          Some(sig)
+        },
+        _ => None
+      }
+    }
+
+    let sig_hash = self.sig_hash(genesis);
+    if let Some(sig) = signature(self) {
+      sig.signer = Ristretto::generator() * key.deref();
+      sig.signature = SchnorrSignature::<Ristretto>::sign(
+        key,
+        Zeroizing::new(<Ristretto as Ciphersuite>::F::random(rng)),
+        sig_hash,
+      );
+    }
+  }
+}
+
+
+fn decode_evidence<N: Network>(ev: &Vec<u8>) -> Result<Vec<SignedMessageFor<N>>, TransactionError> {
+  let mut res = vec![];
+
+  // first byte is the length of the message vector
+  // how many messages we are supposed to have in the vector.
+  let size = u8::from_le_bytes([ev[0]]);
+  for _ in 0..size {
+    let Ok(msg) = SignedMessageFor::<N>::decode::<&[u8]>(
+      &mut &ev[1 ..]
+    ) else {
+      Err(TransactionError::InvalidContent)?
+    };
+    res.push(msg);
+  }
+  Ok(res)
+}
+
+
+// This will only cause mutations when the transaction is valid
+pub(crate) fn verify_tendermint_tx<N: Network>(
+  tx: &TendermintTx,
+  genesis: [u8; 32],
+  schema: N::SignatureScheme
+) -> Result<(), TransactionError> {
+
+  match tx {
+    TendermintTx::SlashEvidence(ev) => {
+      let msgs = decode_evidence::<N>(ev)?;
+      
+      // verify that evidence messages are signed correctly
+      for msg in msgs {
+        if !msg.verify_signature(&schema) {
+          Err(TransactionError::InvalidSignature)?
+        }
+      }
+    },
+    TendermintTx::SlashVote(_, sig) => {
+      // verify the tx signature
+      // TODO: Use Schnorr half-aggregation and a batch verification here 
+      if !sig.signature.verify(sig.signer, tx.sig_hash(genesis)) {
+        Err(TransactionError::InvalidSignature)?;
+      }
+    }
+  }
+
+  Ok(())
+}

--- a/coordinator/tributary/src/tendermint/tx.rs
+++ b/coordinator/tributary/src/tendermint/tx.rs
@@ -53,7 +53,7 @@ impl Default for VoteSignature {
   fn default() -> Self {
     VoteSignature {
       signer: Ristretto::generator(),
-      signature: SchnorrSignature::<Ristretto>::default(),
+      signature: SchnorrSignature::<Ristretto>::read(&mut [0; 64].as_slice()).unwrap(),
     }
   }
 }

--- a/coordinator/tributary/src/tendermint/tx.rs
+++ b/coordinator/tributary/src/tendermint/tx.rs
@@ -1,5 +1,5 @@
 use core::ops::Deref;
-use std::{io, vec, default::Default};
+use std::{io, vec, default::Default, mem::size_of};
 
 use scale::Decode;
 
@@ -23,7 +23,10 @@ use crate::{
   ReadWrite
 };
 
-use tendermint::{ext::Network, SignedMessageFor};
+use tendermint::{
+  SignedMessageFor, Data, round::RoundData, time::CanonicalInstant, commit_msg,
+  ext::{Network, Commit, RoundNumber, SignatureScheme}
+};
 
 /// Data for a signed transaction.
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -102,8 +105,8 @@ impl ReadWrite for TendermintTx {
 impl Transaction for TendermintTx {
   fn kind(&self) -> TransactionKind<'_> {
     match self {
-      TendermintTx::SlashEvidence(_) => TransactionKind::Unsigned,
-      TendermintTx::SlashVote(_, _) => TransactionKind::Unsigned
+      TendermintTx::SlashEvidence(..) => TransactionKind::Unsigned,
+      TendermintTx::SlashVote(..) => TransactionKind::Unsigned
     }
   }
 
@@ -114,17 +117,19 @@ impl Transaction for TendermintTx {
 
   fn verify(&self) -> Result<(), TransactionError> {
     match self {
-      TendermintTx::SlashEvidence(_) => {
-        // TODO: verify that vec len contains 1 or 2 signedmessage.
+      TendermintTx::SlashEvidence(ev) => {
+        // TODO: is this check really useful? at the end this can be any number
+        // that isn't related to how many SignedMessages we have in the vector.
 
-        // let size = evidence.0.len();
-        // if size <= 0 || size > 2 {
-        //   Err(TransactionError::InvalidContent)?;
-        // }
+        // verify that vec len contains 1 or 2 SignedMessage.
+        let size = u8::from_le_bytes([ev[0]]);
+        if size == 0 || size > 2 {
+          Err(TransactionError::InvalidContent)?;
+        }
 
         Ok(())
       },
-      TendermintTx::SlashVote(_, _) => {
+      TendermintTx::SlashVote(..) => {
         Ok(())
       }
     }
@@ -162,39 +167,120 @@ impl TendermintTx {
 }
 
 
-fn decode_evidence<N: Network>(ev: &Vec<u8>) -> Result<Vec<SignedMessageFor<N>>, TransactionError> {
+fn decode_evidence<N: Network>(ev: &[u8]) -> Result<Vec<SignedMessageFor<N>>, TransactionError> {
   let mut res = vec![];
-
+  let msg_size = size_of::<SignedMessageFor<N>>();
+  
   // first byte is the length of the message vector
-  // how many messages we are supposed to have in the vector.
-  let size = u8::from_le_bytes([ev[0]]);
-  for _ in 0..size {
+  let len = u8::from_le_bytes([ev[0]]);
+  let mut start: usize = 1;
+  let mut stop = 1 + msg_size;
+  for _ in 0..len {
     let Ok(msg) = SignedMessageFor::<N>::decode::<&[u8]>(
-      &mut &ev[1 ..]
+      &mut &ev[start..stop]
     ) else {
       Err(TransactionError::InvalidContent)?
     };
+    start = stop;
+    stop = start + msg_size;
     res.push(msg);
   }
   Ok(res)
 }
 
-
-// This will only cause mutations when the transaction is valid
 pub(crate) fn verify_tendermint_tx<N: Network>(
   tx: &TendermintTx,
   genesis: [u8; 32],
-  schema: N::SignatureScheme
+  schema: N::SignatureScheme,
+  commit: impl Fn (u32) -> Option<Commit<N::SignatureScheme>>
 ) -> Result<(), TransactionError> {
+
+  tx.verify()?;
 
   match tx {
     TendermintTx::SlashEvidence(ev) => {
       let msgs = decode_evidence::<N>(ev)?;
-      
+
       // verify that evidence messages are signed correctly
-      for msg in msgs {
+      for msg in &msgs {
         if !msg.verify_signature(&schema) {
           Err(TransactionError::InvalidSignature)?
+        }
+      }
+
+      // verify that the evidence is actually malicious
+      match msgs.len() {
+        1 => {
+          // 2 types of evidence can be here
+          // 1- invalid commit signature
+          // 2- vr number that was greater than the current round
+          let msg = &msgs[0].msg;
+
+          // check the vr
+          if let Data::Proposal(vr, _) = &msg.data {
+            if vr.is_none() || vr.unwrap().0 < msg.round.0 {
+              Err(TransactionError::InvalidContent)?
+            }
+          }
+
+          // check whether the commit was actually invalid
+          if let Data::Precommit(Some((id, sig))) = &msg.data {
+            let bl_no = u32::try_from(msg.block.0 - 1);
+            if bl_no.is_err() {
+              Err(TransactionError::InvalidContent)? 
+            }
+
+            let prior_commit = commit(bl_no.unwrap());
+            if prior_commit.is_none() {
+              Err(TransactionError::InvalidContent)? 
+            }
+
+            // calculate the end time till the msg round
+            let mut last_end_time = CanonicalInstant::new(prior_commit.unwrap().end_time);
+            for r in 0 ..= msg.round.0 {
+              last_end_time = RoundData::<N>::new(RoundNumber(r), last_end_time).end_time();
+            }
+
+            // verify that the commit was actually invalid
+            if schema.verify(msg.sender, &commit_msg(last_end_time.canonical(), id.as_ref()), sig) {
+              Err(TransactionError::InvalidContent)?
+            }
+          }
+
+        },
+        2 => {
+          // 2 types of evidence here
+          // 1- multiple distinct messages for the same block + round + step
+          // 2- precommitted to multiple blocks
+          let first = &msgs[0].msg;
+          let second = &msgs[1].msg;
+
+          // conflicting messages must be for the same block
+          if first.block != second.block {
+            Err(TransactionError::InvalidContent)? 
+          }
+
+          // verify it is from the same node
+          if first.sender != second.sender {
+            Err(TransactionError::InvalidContent)?
+          }
+
+          // check whether messages are precommits to different blocks
+          if let Data::Precommit(Some((h1, _))) = first.data {
+            if let Data::Precommit(Some((h2, _))) = second.data {
+              if h1 == h2 {
+                Err(TransactionError::InvalidContent)?
+              }
+            }
+          }
+
+          // verify that msgs are for the same round + step but has distinct data
+          if first.round != second.round || first.data.step() != second.data.step() || first.data == second.data {
+            Err(TransactionError::InvalidContent)?
+          }
+        },
+        _ => {
+          Err(TransactionError::InvalidContent)?
         }
       }
     },

--- a/coordinator/tributary/src/tendermint/tx.rs
+++ b/coordinator/tributary/src/tendermint/tx.rs
@@ -368,10 +368,12 @@ pub(crate) fn verify_tendermint_tx<N: Network>(
       }
     },
     TendermintTx::SlashVote(vote) => {
-      
+
       // TODO: verify the target is actually one of our validators?
       // this shouldn't be a problem because if the target isn't valid, no one else
       // gonna vote on it. But we still have to think about spam votes.
+
+      // TODO: we should check signer is a participant?
 
       let sig = &vote.sig;
       // verify the tx signature

--- a/coordinator/tributary/src/tests/block.rs
+++ b/coordinator/tributary/src/tests/block.rs
@@ -1,6 +1,6 @@
-use std::{io, collections::HashMap, sync::Arc, fmt::Debug};
+use std::{sync::Arc, io, collections::HashMap, fmt::Debug};
 
-use blake2::{Blake2s256, Digest};
+use blake2::{Digest, Blake2s256};
 use ciphersuite::{
   group::{ff::Field, Group},
   Ciphersuite, Ristretto,

--- a/coordinator/tributary/src/tests/block.rs
+++ b/coordinator/tributary/src/tests/block.rs
@@ -12,12 +12,12 @@ use tendermint::ext::Commit;
 
 use crate::{
   ReadWrite, BlockError, Block, Transaction,
-  tests::p2p::LocalP2p,
+  tests::p2p::DummyP2p,
   transaction::{TransactionError, Signed, TransactionKind, Transaction as TransactionTrait},
   tendermint::{TendermintNetwork, Validators},
 };
 
-type N = TendermintNetwork<MemDb, NonceTransaction, LocalP2p>;
+type N = TendermintNetwork<MemDb, NonceTransaction, DummyP2p>;
 
 // A transaction solely defined by its nonce and a distinguisher (to allow creating distinct TXs
 // sharing a nonce).

--- a/coordinator/tributary/src/tests/block.rs
+++ b/coordinator/tributary/src/tests/block.rs
@@ -81,9 +81,10 @@ fn empty_block() {
   let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
     Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
   };
+  let unsigned_in_chain = |_: [u8; 32]| {false};
   Block::<NonceTransaction>::new(LAST, vec![], vec![])
     .verify::<N>(
-      GENESIS, LAST, HashMap::new(), HashMap::new(), validators, commit
+      GENESIS, LAST, HashMap::new(), HashMap::new(), validators, commit, unsigned_in_chain
     ).unwrap();
 }
 
@@ -105,6 +106,7 @@ fn duplicate_nonces() {
     let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
       Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
     };
+    let unsigned_in_chain = |_: [u8; 32]| {false};
 
     let res = Block::new(LAST, vec![], mempool).verify::<N>(
       GENESIS,
@@ -112,7 +114,8 @@ fn duplicate_nonces() {
       HashMap::new(),
       HashMap::from([(<Ristretto as Ciphersuite>::G::identity(), 0)]),
       validators.clone(),
-      commit
+      commit,
+      unsigned_in_chain
     );
     if i == 1 {
       res.unwrap();

--- a/coordinator/tributary/src/tests/block.rs
+++ b/coordinator/tributary/src/tests/block.rs
@@ -14,7 +14,7 @@ use crate::{
   ReadWrite, BlockError, Block, Transaction,
   tests::p2p::LocalP2p,
   transaction::{TransactionError, Signed, TransactionKind, Transaction as TransactionTrait},
-  tendermint::{TendermintNetwork, Validators}
+  tendermint::{TendermintNetwork, Validators},
 };
 
 type N = TendermintNetwork<MemDb, NonceTransaction, LocalP2p>;
@@ -79,13 +79,20 @@ fn empty_block() {
   const LAST: [u8; 32] = [0x01; 32];
   let validators = Arc::new(Validators::new(GENESIS, vec![]).unwrap());
   let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
-    Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
+    Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
   };
-  let unsigned_in_chain = |_: [u8; 32]| {false};
+  let unsigned_in_chain = |_: [u8; 32]| false;
   Block::<NonceTransaction>::new(LAST, vec![], vec![])
     .verify::<N>(
-      GENESIS, LAST, HashMap::new(), HashMap::new(), validators, commit, unsigned_in_chain
-    ).unwrap();
+      GENESIS,
+      LAST,
+      HashMap::new(),
+      HashMap::new(),
+      validators,
+      commit,
+      unsigned_in_chain,
+    )
+    .unwrap();
 }
 
 #[test]
@@ -104,9 +111,9 @@ fn duplicate_nonces() {
     insert(NonceTransaction::new(i, 1));
 
     let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
-      Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
+      Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
     };
-    let unsigned_in_chain = |_: [u8; 32]| {false};
+    let unsigned_in_chain = |_: [u8; 32]| false;
 
     let res = Block::new(LAST, vec![], mempool).verify::<N>(
       GENESIS,
@@ -115,7 +122,7 @@ fn duplicate_nonces() {
       HashMap::from([(<Ristretto as Ciphersuite>::G::identity(), 0)]),
       validators.clone(),
       commit,
-      unsigned_in_chain
+      unsigned_in_chain,
     );
     if i == 1 {
       res.unwrap();

--- a/coordinator/tributary/src/tests/blockchain.rs
+++ b/coordinator/tributary/src/tests/blockchain.rs
@@ -1,4 +1,4 @@
-use std::collections::{VecDeque, HashMap};
+use std::{collections::{VecDeque, HashMap}, sync::Arc};
 
 use zeroize::Zeroizing;
 use rand::{RngCore, rngs::OsRng};
@@ -10,9 +10,12 @@ use ciphersuite::{group::ff::Field, Ciphersuite, Ristretto};
 use serai_db::{DbTxn, Db, MemDb};
 
 use crate::{
-  merkle, Transaction, ProvidedError, ProvidedTransactions, Block, Blockchain,
-  tests::{ProvidedTransaction, SignedTransaction, random_provided_transaction},
+  transaction::Transaction as TransactionTrait,
+  merkle, ProvidedError, ProvidedTransactions, Block, Blockchain, Transaction,
+  tests::{ProvidedTransaction, SignedTransaction, random_provided_transaction, p2p::LocalP2p}, tendermint::{TendermintNetwork, Validators},
 };
+
+type N = TendermintNetwork<MemDb, ProvidedTransaction, LocalP2p>;
 
 fn new_genesis() -> [u8; 32] {
   let mut genesis = [0; 32];
@@ -20,7 +23,7 @@ fn new_genesis() -> [u8; 32] {
   genesis
 }
 
-fn new_blockchain<T: Transaction>(
+fn new_blockchain<T: TransactionTrait>(
   genesis: [u8; 32],
   participants: &[<Ristretto as Ciphersuite>::G],
 ) -> (MemDb, Blockchain<MemDb, T>) {
@@ -34,12 +37,14 @@ fn new_blockchain<T: Transaction>(
 #[test]
 fn block_addition() {
   let genesis = new_genesis();
+  let validators = Arc::new(Validators::new(genesis, vec![]).unwrap());
   let (db, mut blockchain) = new_blockchain::<SignedTransaction>(genesis, &[]);
-  let block = blockchain.build_block();
+  let block = blockchain.build_block::<N>(validators.clone());
+
   assert_eq!(block.header.parent, genesis);
   assert_eq!(block.header.transactions, [0; 32]);
-  blockchain.verify_block(&block).unwrap();
-  assert!(blockchain.add_block(&block, vec![]).is_ok());
+  blockchain.verify_block::<N>(&block, validators.clone()).unwrap();
+  assert!(blockchain.add_block::<N>(&block, vec![], validators).is_ok());
   assert_eq!(blockchain.tip(), block.hash());
   assert_eq!(blockchain.block_number(), 1);
   assert_eq!(
@@ -51,23 +56,24 @@ fn block_addition() {
 #[test]
 fn invalid_block() {
   let genesis = new_genesis();
+  let validators = Arc::new(Validators::new(genesis, vec![]).unwrap());
   let (_, mut blockchain) = new_blockchain::<SignedTransaction>(genesis, &[]);
 
-  let block = blockchain.build_block();
+  let block = blockchain.build_block::<N>(validators.clone());
 
   // Mutate parent
   {
     #[allow(clippy::redundant_clone)] // False positive
     let mut block = block.clone();
     block.header.parent = Blake2s256::digest(block.header.parent).into();
-    assert!(blockchain.verify_block(&block).is_err());
+    assert!(blockchain.verify_block::<N>(&block, validators.clone()).is_err());
   }
 
   // Mutate tranactions merkle
   {
     let mut block = block;
     block.header.transactions = Blake2s256::digest(block.header.transactions).into();
-    assert!(blockchain.verify_block(&block).is_err());
+    assert!(blockchain.verify_block::<N>(&block, validators.clone()).is_err());
   }
 
   let key = Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng));
@@ -76,9 +82,9 @@ fn invalid_block() {
   // Not a participant
   {
     // Manually create the block to bypass build_block's checks
-    let block = Block::new(blockchain.tip(), vec![], vec![tx.clone()]);
+    let block = Block::new(blockchain.tip(), vec![], vec![Transaction::Application(tx.clone())]);
     assert_eq!(block.header.transactions, merkle(&[tx.hash()]));
-    assert!(blockchain.verify_block(&block).is_err());
+    assert!(blockchain.verify_block::<N>(&block, validators.clone()).is_err());
   }
 
   // Run the rest of the tests with them as a participant
@@ -86,40 +92,45 @@ fn invalid_block() {
 
   // Re-run the not a participant block to make sure it now works
   {
-    let block = Block::new(blockchain.tip(), vec![], vec![tx.clone()]);
+    let block = Block::new(blockchain.tip(), vec![], vec![Transaction::Application(tx.clone())]);
     assert_eq!(block.header.transactions, merkle(&[tx.hash()]));
-    blockchain.verify_block(&block).unwrap();
+    blockchain.verify_block::<N>(&block, validators.clone()).unwrap();
   }
 
   {
     // Add a valid transaction
     let mut blockchain = blockchain.clone();
-    assert!(blockchain.add_transaction(true, tx.clone()));
-    let mut block = blockchain.build_block();
+    assert!(blockchain.add_transaction::<N>(true, Transaction::Application(tx.clone()), validators.clone()));
+    let mut block = blockchain.build_block::<N>(validators.clone());
     assert_eq!(block.header.transactions, merkle(&[tx.hash()]));
-    blockchain.verify_block(&block).unwrap();
+    blockchain.verify_block::<N>(&block, validators.clone()).unwrap();
 
     // And verify mutating the transactions merkle now causes a failure
     block.header.transactions = merkle(&[]);
-    assert!(blockchain.verify_block(&block).is_err());
+    assert!(blockchain.verify_block::<N>(&block, validators.clone()).is_err());
   }
 
   {
     // Invalid nonce
     let tx = crate::tests::signed_transaction(&mut OsRng, genesis, &key, 5);
     // Manually create the block to bypass build_block's checks
-    let block = Block::new(blockchain.tip(), vec![], vec![tx]);
-    assert!(blockchain.verify_block(&block).is_err());
+    let block = Block::new(blockchain.tip(), vec![], vec![Transaction::Application(tx)]);
+    assert!(blockchain.verify_block::<N>(&block, validators.clone()).is_err());
   }
 
   {
     // Invalid signature
     let mut blockchain = blockchain;
-    assert!(blockchain.add_transaction(true, tx));
-    let mut block = blockchain.build_block();
-    blockchain.verify_block(&block).unwrap();
-    block.transactions[0].1.signature.s += <Ristretto as Ciphersuite>::F::ONE;
-    assert!(blockchain.verify_block(&block).is_err());
+    assert!(blockchain.add_transaction::<N>(true, Transaction::Application(tx), validators.clone()));
+    let mut block = blockchain.build_block::<N>(validators.clone());
+    blockchain.verify_block::<N>(&block, validators.clone()).unwrap();
+    match &mut block.transactions[0] {
+      Transaction::Application(tx) => {
+        tx.1.signature.s += <Ristretto as Ciphersuite>::F::ONE;
+      },
+      _ => panic!("non-signed tx found")
+    }
+    assert!(blockchain.verify_block::<N>(&block, validators.clone()).is_err());
 
     // Make sure this isn't because the merkle changed due to the transaction hash including the
     // signature (which it explicitly isn't allowed to anyways)
@@ -130,7 +141,7 @@ fn invalid_block() {
 #[test]
 fn signed_transaction() {
   let genesis = new_genesis();
-
+  let validators = Arc::new(Validators::new(genesis, vec![]).unwrap());
   let key = Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng));
   let tx = crate::tests::signed_transaction(&mut OsRng, genesis, &key, 0);
   let signer = tx.1.signer;
@@ -139,14 +150,15 @@ fn signed_transaction() {
   assert_eq!(blockchain.next_nonce(signer), Some(0));
 
   let test = |blockchain: &mut Blockchain<MemDb, SignedTransaction>,
-              mempool: Vec<SignedTransaction>| {
+              mempool: Vec<Transaction<SignedTransaction>>| {
     let tip = blockchain.tip();
     for tx in mempool.clone() {
+      let Transaction::Application(tx) = tx else { panic!("tendermint tx found"); };
       let next_nonce = blockchain.next_nonce(signer).unwrap();
-      assert!(blockchain.add_transaction(true, tx));
+      assert!(blockchain.add_transaction::<N>(true, Transaction::Application(tx), validators.clone()));
       assert_eq!(next_nonce + 1, blockchain.next_nonce(signer).unwrap());
     }
-    let block = blockchain.build_block();
+    let block = blockchain.build_block::<N>(validators.clone());
     assert_eq!(block, Block::new(blockchain.tip(), vec![], mempool.clone()));
     assert_eq!(blockchain.tip(), tip);
     assert_eq!(block.header.parent, tip);
@@ -160,19 +172,19 @@ fn signed_transaction() {
     );
 
     // Verify and add the block
-    blockchain.verify_block(&block).unwrap();
-    assert!(blockchain.add_block(&block, vec![]).is_ok());
+    blockchain.verify_block::<N>(&block, validators.clone()).unwrap();
+    assert!(blockchain.add_block::<N>(&block, vec![], validators.clone()).is_ok());
     assert_eq!(blockchain.tip(), block.hash());
   };
 
   // Test with a single nonce
-  test(&mut blockchain, vec![tx]);
+  test(&mut blockchain, vec![Transaction::Application(tx)]);
   assert_eq!(blockchain.next_nonce(signer), Some(1));
 
   // Test with a flood of nonces
   let mut mempool = vec![];
   for nonce in 1 .. 64 {
-    mempool.push(crate::tests::signed_transaction(&mut OsRng, genesis, &key, nonce));
+    mempool.push(Transaction::Application(crate::tests::signed_transaction(&mut OsRng, genesis, &key, nonce)));
   }
   test(&mut blockchain, mempool);
   assert_eq!(blockchain.next_nonce(signer), Some(64));
@@ -181,6 +193,7 @@ fn signed_transaction() {
 #[test]
 fn provided_transaction() {
   let genesis = new_genesis();
+  let validators = Arc::new(Validators::new(genesis, vec![]).unwrap());
   let (_, mut blockchain) = new_blockchain::<ProvidedTransaction>(genesis, &[]);
 
   let tx = random_provided_transaction(&mut OsRng);
@@ -203,18 +216,18 @@ fn provided_transaction() {
 
   // Non-provided transactions should fail verification
   let block = Block::new(blockchain.tip(), vec![tx.clone()], vec![]);
-  assert!(blockchain.verify_block(&block).is_err());
+  assert!(blockchain.verify_block::<N>(&block, validators.clone()).is_err());
 
   // Provided transactions should pass verification
   blockchain.provide_transaction(tx.clone()).unwrap();
-  blockchain.verify_block(&block).unwrap();
+  blockchain.verify_block::<N>(&block, validators.clone()).unwrap();
 
   // add_block should work for verified blocks
-  assert!(blockchain.add_block(&block, vec![]).is_ok());
+  assert!(blockchain.add_block::<N>(&block, vec![], validators.clone()).is_ok());
 
   let block = Block::new(blockchain.tip(), vec![tx], vec![]);
   // The provided transaction should no longer considered provided, causing this error
-  assert!(blockchain.verify_block(&block).is_err());
+  assert!(blockchain.verify_block::<N>(&block, validators.clone()).is_err());
   // add_block should fail for unverified provided transactions if told to add them
-  assert!(blockchain.add_block(&block, vec![]).is_err());
+  assert!(blockchain.add_block::<N>(&block, vec![], validators.clone()).is_err());
 }

--- a/coordinator/tributary/src/tests/blockchain.rs
+++ b/coordinator/tributary/src/tests/blockchain.rs
@@ -516,7 +516,7 @@ fn block_tx_ordering() {
   // should fail
   assert_eq!(
     blockchain.verify_block::<N>(&block, validators.clone()).unwrap_err(),
-    BlockError::WrongTxOrder
+    BlockError::WrongTransactionOrder
   );
 
   // reset
@@ -528,7 +528,7 @@ fn block_tx_ordering() {
   // should fail
   assert_eq!(
     blockchain.verify_block::<N>(&block, validators.clone()).unwrap_err(),
-    BlockError::WrongTxOrder
+    BlockError::WrongTransactionOrder
   );
 
   // reset
@@ -540,7 +540,7 @@ fn block_tx_ordering() {
   // should fail
   assert_eq!(
     blockchain.verify_block::<N>(&block, validators.clone()).unwrap_err(),
-    BlockError::WrongTxOrder
+    BlockError::WrongTransactionOrder
   );
 
   // reset

--- a/coordinator/tributary/src/tests/blockchain.rs
+++ b/coordinator/tributary/src/tests/blockchain.rs
@@ -15,7 +15,7 @@ use crate::{
   tests::{ProvidedTransaction, SignedTransaction, random_provided_transaction, p2p::LocalP2p}, tendermint::{TendermintNetwork, Validators},
 };
 
-type N = TendermintNetwork<MemDb, ProvidedTransaction, LocalP2p>;
+type N = TendermintNetwork<MemDb, SignedTransaction, LocalP2p>;
 
 fn new_genesis() -> [u8; 32] {
   let mut genesis = [0; 32];

--- a/coordinator/tributary/src/tests/mempool.rs
+++ b/coordinator/tributary/src/tests/mempool.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use zeroize::Zeroizing;
 use rand::{RngCore, rngs::OsRng};
@@ -8,11 +8,15 @@ use ciphersuite::{group::ff::Field, Ciphersuite, Ristretto};
 use serai_db::MemDb;
 
 use crate::{
-  ACCOUNT_MEMPOOL_LIMIT, Transaction, Mempool,
-  tests::{SignedTransaction, signed_transaction},
+  ACCOUNT_MEMPOOL_LIMIT, Mempool, Transaction,
+  tendermint::{TendermintNetwork, Validators},
+  transaction::Transaction as TransactionTrait,
+  tests::{SignedTransaction, signed_transaction, p2p::LocalP2p},
 };
 
-fn new_mempool<T: Transaction>() -> ([u8; 32], MemDb, Mempool<MemDb, T>) {
+type N = TendermintNetwork<MemDb, SignedTransaction, LocalP2p>;
+
+fn new_mempool<T: TransactionTrait>() -> ([u8; 32], MemDb, Mempool<MemDb, T>) {
   let mut genesis = [0; 32];
   OsRng.fill_bytes(&mut genesis);
   let db = MemDb::new();
@@ -22,7 +26,7 @@ fn new_mempool<T: Transaction>() -> ([u8; 32], MemDb, Mempool<MemDb, T>) {
 #[test]
 fn mempool_addition() {
   let (genesis, db, mut mempool) = new_mempool::<SignedTransaction>();
-
+  let validators = Arc::new(Validators::new(genesis, vec![]).unwrap());
   let key = Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng));
 
   let first_tx = signed_transaction(&mut OsRng, genesis, &key, 0);
@@ -31,20 +35,20 @@ fn mempool_addition() {
 
   // Add TX 0
   let mut blockchain_next_nonces = HashMap::from([(signer, 0)]);
-  assert!(mempool.add(&blockchain_next_nonces, true, first_tx.clone()));
+  assert!(mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(first_tx.clone()), validators.clone()));
   assert_eq!(mempool.next_nonce(&signer), Some(1));
 
   // Test reloading works
   assert_eq!(mempool, Mempool::new(db, genesis));
 
   // Adding it again should fail
-  assert!(!mempool.add(&blockchain_next_nonces, true, first_tx.clone()));
+  assert!(!mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(first_tx.clone()), validators.clone()));
 
   // Do the same with the next nonce
   let second_tx = signed_transaction(&mut OsRng, genesis, &key, 1);
-  assert!(mempool.add(&blockchain_next_nonces, true, second_tx.clone()));
+  assert!(mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(second_tx.clone()), validators.clone()));
   assert_eq!(mempool.next_nonce(&signer), Some(2));
-  assert!(!mempool.add(&blockchain_next_nonces, true, second_tx.clone()));
+  assert!(!mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(second_tx.clone()), validators.clone()));
 
   // If the mempool doesn't have a nonce for an account, it should successfully use the
   // blockchain's
@@ -53,7 +57,7 @@ fn mempool_addition() {
   let second_signer = tx.1.signer;
   assert_eq!(mempool.next_nonce(&second_signer), None);
   blockchain_next_nonces.insert(second_signer, 2);
-  assert!(mempool.add(&blockchain_next_nonces, true, tx.clone()));
+  assert!(mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(tx.clone()), validators.clone()));
   assert_eq!(mempool.next_nonce(&second_signer), Some(3));
 
   // Getting a block should work
@@ -68,28 +72,30 @@ fn mempool_addition() {
 
   // Removing should also successfully prune
   mempool.remove(&tx.hash());
-  assert_eq!(mempool.txs(), &HashMap::from([(second_tx.hash(), second_tx)]));
+  assert_eq!(mempool.txs(), &HashMap::from([(second_tx.hash(), Transaction::Application(second_tx))]));
 }
 
 #[test]
 fn too_many_mempool() {
   let (genesis, _, mut mempool) = new_mempool::<SignedTransaction>();
-
+  let validators = Arc::new(Validators::new(genesis, vec![]).unwrap());
   let key = Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng));
   let signer = signed_transaction(&mut OsRng, genesis, &key, 0).1.signer;
 
   // We should be able to add transactions up to the limit
   for i in 0 .. ACCOUNT_MEMPOOL_LIMIT {
-    assert!(mempool.add(
+    assert!(mempool.add::<N>(
       &HashMap::from([(signer, 0)]),
       false,
-      signed_transaction(&mut OsRng, genesis, &key, i)
+      Transaction::Application(signed_transaction(&mut OsRng, genesis, &key, i)),
+      validators.clone()
     ));
   }
   // Yet adding more should fail
-  assert!(!mempool.add(
+  assert!(!mempool.add::<N>(
     &HashMap::from([(signer, 0)]),
     false,
-    signed_transaction(&mut OsRng, genesis, &key, ACCOUNT_MEMPOOL_LIMIT)
+    Transaction::Application(signed_transaction(&mut OsRng, genesis, &key, ACCOUNT_MEMPOOL_LIMIT)),
+    validators.clone()
   ));
 }

--- a/coordinator/tributary/src/tests/mempool.rs
+++ b/coordinator/tributary/src/tests/mempool.rs
@@ -10,9 +10,10 @@ use serai_db::MemDb;
 
 use crate::{
   ACCOUNT_MEMPOOL_LIMIT, Mempool, Transaction,
-  tendermint::{TendermintNetwork, Validators},
+  tendermint::{TendermintNetwork, Validators, TendermintBlock, Signer},
   transaction::Transaction as TransactionTrait,
-  tests::{SignedTransaction, signed_transaction, p2p::LocalP2p},
+  tests::{SignedTransaction, signed_transaction, p2p::LocalP2p, random_vote_tx, random_evidence_tx},
+  async_sequential
 };
 
 type N = TendermintNetwork<MemDb, SignedTransaction, LocalP2p>;
@@ -24,61 +25,83 @@ fn new_mempool<T: TransactionTrait>() -> ([u8; 32], MemDb, Mempool<MemDb, T>) {
   (genesis, db.clone(), Mempool::new(db, genesis))
 }
 
-#[test]
-fn mempool_addition() {
-  let (genesis, db, mut mempool) = new_mempool::<SignedTransaction>();
-  let validators = Arc::new(Validators::new(genesis, vec![]).unwrap());
-  let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
-    Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
-  };
-  let unsigned_in_chain = |_: [u8; 32]| {false};
-  let key = Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng));
+async_sequential!(
+  async fn mempool_addition() {
+    let (genesis, db, mut mempool) = new_mempool::<SignedTransaction>();
+    let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
+      Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
+    };
+    let unsigned_in_chain = |_: [u8; 32]| {false};
+    let key = Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng));
 
-  let first_tx = signed_transaction(&mut OsRng, genesis, &key, 0);
-  let signer = first_tx.1.signer;
-  assert_eq!(mempool.next_nonce(&signer), None);
+    let first_tx = signed_transaction(&mut OsRng, genesis, &key, 0);
+    let signer = first_tx.1.signer;
+    assert_eq!(mempool.next_nonce(&signer), None);
 
-  // Add TX 0
-  let mut blockchain_next_nonces = HashMap::from([(signer, 0)]);
-  assert!(mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(first_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
-  assert_eq!(mempool.next_nonce(&signer), Some(1));
+    // validators
+    let validators = Arc::new(Validators::new(genesis, vec![(signer, 1)]).unwrap());
 
-  // Test reloading works
-  assert_eq!(mempool, Mempool::new(db, genesis));
+    // Add TX 0
+    let mut blockchain_next_nonces = HashMap::from([(signer, 0)]);
+    assert!(mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(first_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
+    assert_eq!(mempool.next_nonce(&signer), Some(1));
 
-  // Adding it again should fail
-  assert!(!mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(first_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
+    // add a tendermint vote tx
+    let vote_tx = random_vote_tx(&mut OsRng, genesis);
+    assert!(mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Tendermint(vote_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
 
-  // Do the same with the next nonce
-  let second_tx = signed_transaction(&mut OsRng, genesis, &key, 1);
-  assert!(mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(second_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
-  assert_eq!(mempool.next_nonce(&signer), Some(2));
-  assert!(!mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(second_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
+    // add a tendermint evidence tx
+    let evidence_tx = random_evidence_tx::<N>(
+      Signer::new(genesis, key.clone()).into(),
+      TendermintBlock(vec![])
+    ).await;
+    assert!(mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Tendermint(evidence_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
 
-  // If the mempool doesn't have a nonce for an account, it should successfully use the
-  // blockchain's
-  let second_key = Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng));
-  let tx = signed_transaction(&mut OsRng, genesis, &second_key, 2);
-  let second_signer = tx.1.signer;
-  assert_eq!(mempool.next_nonce(&second_signer), None);
-  blockchain_next_nonces.insert(second_signer, 2);
-  assert!(mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(tx.clone()), validators.clone(), unsigned_in_chain, commit));
-  assert_eq!(mempool.next_nonce(&second_signer), Some(3));
+    // Test reloading works
+    assert_eq!(mempool, Mempool::new(db, genesis));
 
-  // Getting a block should work
-  assert_eq!(mempool.block(&blockchain_next_nonces, unsigned_in_chain.clone()).len(), 3);
+    // Adding it again should fail
+    assert!(!mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(first_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
+    assert!(!mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Tendermint(vote_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
+    assert!(!mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Tendermint(evidence_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
 
-  // If the blockchain says an account had its nonce updated, it should cause a prune
-  blockchain_next_nonces.insert(signer, 1);
-  let mut block = mempool.block(&blockchain_next_nonces, unsigned_in_chain.clone());
-  assert_eq!(block.len(), 2);
-  assert!(!block.iter().any(|tx| tx.hash() == first_tx.hash()));
-  assert_eq!(mempool.txs(), &block.drain(..).map(|tx| (tx.hash(), tx)).collect::<HashMap<_, _>>());
+    // Do the same with the next nonce
+    let second_tx = signed_transaction(&mut OsRng, genesis, &key, 1);
+    assert!(mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(second_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
+    assert_eq!(mempool.next_nonce(&signer), Some(2));
+    assert!(!mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(second_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
 
-  // Removing should also successfully prune
-  mempool.remove(&tx.hash());
-  assert_eq!(mempool.txs(), &HashMap::from([(second_tx.hash(), Transaction::Application(second_tx))]));
-}
+    // If the mempool doesn't have a nonce for an account, it should successfully use the
+    // blockchain's
+    let second_key = Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng));
+    let tx = signed_transaction(&mut OsRng, genesis, &second_key, 2);
+    let second_signer = tx.1.signer;
+    assert_eq!(mempool.next_nonce(&second_signer), None);
+    blockchain_next_nonces.insert(second_signer, 2);
+    assert!(mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(tx.clone()), validators.clone(), unsigned_in_chain, commit));
+    assert_eq!(mempool.next_nonce(&second_signer), Some(3));
+
+    // Getting a block should work
+    assert_eq!(mempool.block(&blockchain_next_nonces, unsigned_in_chain.clone()).len(), 5);
+
+    // If the blockchain says an account had its nonce updated, it should cause a prune
+    blockchain_next_nonces.insert(signer, 1);
+    let mut block = mempool.block(&blockchain_next_nonces, unsigned_in_chain.clone());
+    assert_eq!(block.len(), 4);
+    assert!(!block.iter().any(|tx| tx.hash() == first_tx.hash()));
+    assert_eq!(mempool.txs(), &block.drain(..).map(|tx| (tx.hash(), tx)).collect::<HashMap<_, _>>());
+
+    // Removing should also successfully prune
+    mempool.remove(&tx.hash());
+
+    // remove tendermint txs
+    mempool.remove(&vote_tx.hash());
+    mempool.remove(&evidence_tx.hash());
+
+    assert_eq!(mempool.txs(), &HashMap::from([(second_tx.hash(), Transaction::Application(second_tx))]));
+  }
+);
+
 
 #[test]
 fn too_many_mempool() {

--- a/coordinator/tributary/src/tests/mempool.rs
+++ b/coordinator/tributary/src/tests/mempool.rs
@@ -15,7 +15,6 @@ use crate::{
   tests::{
     SignedTransaction, signed_transaction, p2p::DummyP2p, random_vote_tx, random_evidence_tx,
   },
-  async_sequential,
 };
 
 type N = TendermintNetwork<MemDb, SignedTransaction, DummyP2p>;
@@ -27,150 +26,146 @@ fn new_mempool<T: TransactionTrait>() -> ([u8; 32], MemDb, Mempool<MemDb, T>) {
   (genesis, db.clone(), Mempool::new(db, genesis))
 }
 
-async_sequential!(
-  async fn mempool_addition() {
-    let (genesis, db, mut mempool) = new_mempool::<SignedTransaction>();
-    let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
-      Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
-    };
-    let unsigned_in_chain = |_: [u8; 32]| false;
-    let key = Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng));
+#[tokio::test]
+async fn mempool_addition() {
+  let (genesis, db, mut mempool) = new_mempool::<SignedTransaction>();
+  let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
+    Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
+  };
+  let unsigned_in_chain = |_: [u8; 32]| false;
+  let key = Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng));
 
-    let first_tx = signed_transaction(&mut OsRng, genesis, &key, 0);
-    let signer = first_tx.1.signer;
-    assert_eq!(mempool.next_nonce(&signer), None);
+  let first_tx = signed_transaction(&mut OsRng, genesis, &key, 0);
+  let signer = first_tx.1.signer;
+  assert_eq!(mempool.next_nonce(&signer), None);
 
-    // validators
-    let validators = Arc::new(Validators::new(genesis, vec![(signer, 1)]).unwrap());
+  // validators
+  let validators = Arc::new(Validators::new(genesis, vec![(signer, 1)]).unwrap());
 
-    // Add TX 0
-    let mut blockchain_next_nonces = HashMap::from([(signer, 0)]);
-    assert!(mempool.add::<N>(
-      &blockchain_next_nonces,
-      true,
-      Transaction::Application(first_tx.clone()),
-      validators.clone(),
-      unsigned_in_chain,
-      commit,
-    ));
-    assert_eq!(mempool.next_nonce(&signer), Some(1));
+  // Add TX 0
+  let mut blockchain_next_nonces = HashMap::from([(signer, 0)]);
+  assert!(mempool.add::<N>(
+    &blockchain_next_nonces,
+    true,
+    Transaction::Application(first_tx.clone()),
+    validators.clone(),
+    unsigned_in_chain,
+    commit,
+  ));
+  assert_eq!(mempool.next_nonce(&signer), Some(1));
 
-    // add a tendermint vote tx
-    let vote_tx = random_vote_tx(&mut OsRng, genesis);
-    assert!(mempool.add::<N>(
-      &blockchain_next_nonces,
-      true,
-      Transaction::Tendermint(vote_tx.clone()),
-      validators.clone(),
-      unsigned_in_chain,
-      commit,
-    ));
+  // add a tendermint vote tx
+  let vote_tx = random_vote_tx(&mut OsRng, genesis);
+  assert!(mempool.add::<N>(
+    &blockchain_next_nonces,
+    true,
+    Transaction::Tendermint(vote_tx.clone()),
+    validators.clone(),
+    unsigned_in_chain,
+    commit,
+  ));
 
-    // add a tendermint evidence tx
-    let evidence_tx =
-      random_evidence_tx::<N>(Signer::new(genesis, key.clone()).into(), TendermintBlock(vec![]))
-        .await;
-    assert!(mempool.add::<N>(
-      &blockchain_next_nonces,
-      true,
-      Transaction::Tendermint(evidence_tx.clone()),
-      validators.clone(),
-      unsigned_in_chain,
-      commit,
-    ));
+  // add a tendermint evidence tx
+  let evidence_tx =
+    random_evidence_tx::<N>(Signer::new(genesis, key.clone()).into(), TendermintBlock(vec![]))
+      .await;
+  assert!(mempool.add::<N>(
+    &blockchain_next_nonces,
+    true,
+    Transaction::Tendermint(evidence_tx.clone()),
+    validators.clone(),
+    unsigned_in_chain,
+    commit,
+  ));
 
-    // Test reloading works
-    assert_eq!(mempool, Mempool::new(db, genesis));
+  // Test reloading works
+  assert_eq!(mempool, Mempool::new(db, genesis));
 
-    // Adding it again should fail
-    assert!(!mempool.add::<N>(
-      &blockchain_next_nonces,
-      true,
-      Transaction::Application(first_tx.clone()),
-      validators.clone(),
-      unsigned_in_chain,
-      commit,
-    ));
-    assert!(!mempool.add::<N>(
-      &blockchain_next_nonces,
-      true,
-      Transaction::Tendermint(vote_tx.clone()),
-      validators.clone(),
-      unsigned_in_chain,
-      commit,
-    ));
-    assert!(!mempool.add::<N>(
-      &blockchain_next_nonces,
-      true,
-      Transaction::Tendermint(evidence_tx.clone()),
-      validators.clone(),
-      unsigned_in_chain,
-      commit,
-    ));
+  // Adding it again should fail
+  assert!(!mempool.add::<N>(
+    &blockchain_next_nonces,
+    true,
+    Transaction::Application(first_tx.clone()),
+    validators.clone(),
+    unsigned_in_chain,
+    commit,
+  ));
+  assert!(!mempool.add::<N>(
+    &blockchain_next_nonces,
+    true,
+    Transaction::Tendermint(vote_tx.clone()),
+    validators.clone(),
+    unsigned_in_chain,
+    commit,
+  ));
+  assert!(!mempool.add::<N>(
+    &blockchain_next_nonces,
+    true,
+    Transaction::Tendermint(evidence_tx.clone()),
+    validators.clone(),
+    unsigned_in_chain,
+    commit,
+  ));
 
-    // Do the same with the next nonce
-    let second_tx = signed_transaction(&mut OsRng, genesis, &key, 1);
-    assert!(mempool.add::<N>(
-      &blockchain_next_nonces,
-      true,
-      Transaction::Application(second_tx.clone()),
-      validators.clone(),
-      unsigned_in_chain,
-      commit,
-    ));
-    assert_eq!(mempool.next_nonce(&signer), Some(2));
-    assert!(!mempool.add::<N>(
-      &blockchain_next_nonces,
-      true,
-      Transaction::Application(second_tx.clone()),
-      validators.clone(),
-      unsigned_in_chain,
-      commit,
-    ));
+  // Do the same with the next nonce
+  let second_tx = signed_transaction(&mut OsRng, genesis, &key, 1);
+  assert!(mempool.add::<N>(
+    &blockchain_next_nonces,
+    true,
+    Transaction::Application(second_tx.clone()),
+    validators.clone(),
+    unsigned_in_chain,
+    commit,
+  ));
+  assert_eq!(mempool.next_nonce(&signer), Some(2));
+  assert!(!mempool.add::<N>(
+    &blockchain_next_nonces,
+    true,
+    Transaction::Application(second_tx.clone()),
+    validators.clone(),
+    unsigned_in_chain,
+    commit,
+  ));
 
-    // If the mempool doesn't have a nonce for an account, it should successfully use the
-    // blockchain's
-    let second_key = Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng));
-    let tx = signed_transaction(&mut OsRng, genesis, &second_key, 2);
-    let second_signer = tx.1.signer;
-    assert_eq!(mempool.next_nonce(&second_signer), None);
-    blockchain_next_nonces.insert(second_signer, 2);
-    assert!(mempool.add::<N>(
-      &blockchain_next_nonces,
-      true,
-      Transaction::Application(tx.clone()),
-      validators.clone(),
-      unsigned_in_chain,
-      commit
-    ));
-    assert_eq!(mempool.next_nonce(&second_signer), Some(3));
+  // If the mempool doesn't have a nonce for an account, it should successfully use the
+  // blockchain's
+  let second_key = Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng));
+  let tx = signed_transaction(&mut OsRng, genesis, &second_key, 2);
+  let second_signer = tx.1.signer;
+  assert_eq!(mempool.next_nonce(&second_signer), None);
+  blockchain_next_nonces.insert(second_signer, 2);
+  assert!(mempool.add::<N>(
+    &blockchain_next_nonces,
+    true,
+    Transaction::Application(tx.clone()),
+    validators.clone(),
+    unsigned_in_chain,
+    commit
+  ));
+  assert_eq!(mempool.next_nonce(&second_signer), Some(3));
 
-    // Getting a block should work
-    assert_eq!(mempool.block(&blockchain_next_nonces, unsigned_in_chain).len(), 5);
+  // Getting a block should work
+  assert_eq!(mempool.block(&blockchain_next_nonces, unsigned_in_chain).len(), 5);
 
-    // If the blockchain says an account had its nonce updated, it should cause a prune
-    blockchain_next_nonces.insert(signer, 1);
-    let mut block = mempool.block(&blockchain_next_nonces, unsigned_in_chain);
-    assert_eq!(block.len(), 4);
-    assert!(!block.iter().any(|tx| tx.hash() == first_tx.hash()));
-    assert_eq!(
-      mempool.txs(),
-      &block.drain(..).map(|tx| (tx.hash(), tx)).collect::<HashMap<_, _>>()
-    );
+  // If the blockchain says an account had its nonce updated, it should cause a prune
+  blockchain_next_nonces.insert(signer, 1);
+  let mut block = mempool.block(&blockchain_next_nonces, unsigned_in_chain);
+  assert_eq!(block.len(), 4);
+  assert!(!block.iter().any(|tx| tx.hash() == first_tx.hash()));
+  assert_eq!(mempool.txs(), &block.drain(..).map(|tx| (tx.hash(), tx)).collect::<HashMap<_, _>>());
 
-    // Removing should also successfully prune
-    mempool.remove(&tx.hash());
+  // Removing should also successfully prune
+  mempool.remove(&tx.hash());
 
-    // remove tendermint txs
-    mempool.remove(&vote_tx.hash());
-    mempool.remove(&evidence_tx.hash());
+  // remove tendermint txs
+  mempool.remove(&vote_tx.hash());
+  mempool.remove(&evidence_tx.hash());
 
-    assert_eq!(
-      mempool.txs(),
-      &HashMap::from([(second_tx.hash(), Transaction::Application(second_tx))])
-    );
-  }
-);
+  assert_eq!(
+    mempool.txs(),
+    &HashMap::from([(second_tx.hash(), Transaction::Application(second_tx))])
+  );
+}
 
 #[test]
 fn too_many_mempool() {

--- a/coordinator/tributary/src/tests/mempool.rs
+++ b/coordinator/tributary/src/tests/mempool.rs
@@ -12,8 +12,10 @@ use crate::{
   ACCOUNT_MEMPOOL_LIMIT, Mempool, Transaction,
   tendermint::{TendermintNetwork, Validators, TendermintBlock, Signer},
   transaction::Transaction as TransactionTrait,
-  tests::{SignedTransaction, signed_transaction, p2p::LocalP2p, random_vote_tx, random_evidence_tx},
-  async_sequential
+  tests::{
+    SignedTransaction, signed_transaction, p2p::LocalP2p, random_vote_tx, random_evidence_tx,
+  },
+  async_sequential,
 };
 
 type N = TendermintNetwork<MemDb, SignedTransaction, LocalP2p>;
@@ -29,9 +31,9 @@ async_sequential!(
   async fn mempool_addition() {
     let (genesis, db, mut mempool) = new_mempool::<SignedTransaction>();
     let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
-      Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
+      Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
     };
-    let unsigned_in_chain = |_: [u8; 32]| {false};
+    let unsigned_in_chain = |_: [u8; 32]| false;
     let key = Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng));
 
     let first_tx = signed_transaction(&mut OsRng, genesis, &key, 0);
@@ -43,33 +45,88 @@ async_sequential!(
 
     // Add TX 0
     let mut blockchain_next_nonces = HashMap::from([(signer, 0)]);
-    assert!(mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(first_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
+    assert!(mempool.add::<N>(
+      &blockchain_next_nonces,
+      true,
+      Transaction::Application(first_tx.clone()),
+      validators.clone(),
+      unsigned_in_chain.clone(),
+      commit.clone()
+    ));
     assert_eq!(mempool.next_nonce(&signer), Some(1));
 
     // add a tendermint vote tx
     let vote_tx = random_vote_tx(&mut OsRng, genesis);
-    assert!(mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Tendermint(vote_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
+    assert!(mempool.add::<N>(
+      &blockchain_next_nonces,
+      true,
+      Transaction::Tendermint(vote_tx.clone()),
+      validators.clone(),
+      unsigned_in_chain.clone(),
+      commit.clone()
+    ));
 
     // add a tendermint evidence tx
-    let evidence_tx = random_evidence_tx::<N>(
-      Signer::new(genesis, key.clone()).into(),
-      TendermintBlock(vec![])
-    ).await;
-    assert!(mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Tendermint(evidence_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
+    let evidence_tx =
+      random_evidence_tx::<N>(Signer::new(genesis, key.clone()).into(), TendermintBlock(vec![]))
+        .await;
+    assert!(mempool.add::<N>(
+      &blockchain_next_nonces,
+      true,
+      Transaction::Tendermint(evidence_tx.clone()),
+      validators.clone(),
+      unsigned_in_chain.clone(),
+      commit.clone()
+    ));
 
     // Test reloading works
     assert_eq!(mempool, Mempool::new(db, genesis));
 
     // Adding it again should fail
-    assert!(!mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(first_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
-    assert!(!mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Tendermint(vote_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
-    assert!(!mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Tendermint(evidence_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
+    assert!(!mempool.add::<N>(
+      &blockchain_next_nonces,
+      true,
+      Transaction::Application(first_tx.clone()),
+      validators.clone(),
+      unsigned_in_chain.clone(),
+      commit.clone()
+    ));
+    assert!(!mempool.add::<N>(
+      &blockchain_next_nonces,
+      true,
+      Transaction::Tendermint(vote_tx.clone()),
+      validators.clone(),
+      unsigned_in_chain.clone(),
+      commit.clone()
+    ));
+    assert!(!mempool.add::<N>(
+      &blockchain_next_nonces,
+      true,
+      Transaction::Tendermint(evidence_tx.clone()),
+      validators.clone(),
+      unsigned_in_chain.clone(),
+      commit.clone()
+    ));
 
     // Do the same with the next nonce
     let second_tx = signed_transaction(&mut OsRng, genesis, &key, 1);
-    assert!(mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(second_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
+    assert!(mempool.add::<N>(
+      &blockchain_next_nonces,
+      true,
+      Transaction::Application(second_tx.clone()),
+      validators.clone(),
+      unsigned_in_chain.clone(),
+      commit.clone()
+    ));
     assert_eq!(mempool.next_nonce(&signer), Some(2));
-    assert!(!mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(second_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
+    assert!(!mempool.add::<N>(
+      &blockchain_next_nonces,
+      true,
+      Transaction::Application(second_tx.clone()),
+      validators.clone(),
+      unsigned_in_chain.clone(),
+      commit.clone()
+    ));
 
     // If the mempool doesn't have a nonce for an account, it should successfully use the
     // blockchain's
@@ -78,7 +135,14 @@ async_sequential!(
     let second_signer = tx.1.signer;
     assert_eq!(mempool.next_nonce(&second_signer), None);
     blockchain_next_nonces.insert(second_signer, 2);
-    assert!(mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(tx.clone()), validators.clone(), unsigned_in_chain, commit));
+    assert!(mempool.add::<N>(
+      &blockchain_next_nonces,
+      true,
+      Transaction::Application(tx.clone()),
+      validators.clone(),
+      unsigned_in_chain,
+      commit
+    ));
     assert_eq!(mempool.next_nonce(&second_signer), Some(3));
 
     // Getting a block should work
@@ -89,7 +153,10 @@ async_sequential!(
     let mut block = mempool.block(&blockchain_next_nonces, unsigned_in_chain.clone());
     assert_eq!(block.len(), 4);
     assert!(!block.iter().any(|tx| tx.hash() == first_tx.hash()));
-    assert_eq!(mempool.txs(), &block.drain(..).map(|tx| (tx.hash(), tx)).collect::<HashMap<_, _>>());
+    assert_eq!(
+      mempool.txs(),
+      &block.drain(..).map(|tx| (tx.hash(), tx)).collect::<HashMap<_, _>>()
+    );
 
     // Removing should also successfully prune
     mempool.remove(&tx.hash());
@@ -98,19 +165,21 @@ async_sequential!(
     mempool.remove(&vote_tx.hash());
     mempool.remove(&evidence_tx.hash());
 
-    assert_eq!(mempool.txs(), &HashMap::from([(second_tx.hash(), Transaction::Application(second_tx))]));
+    assert_eq!(
+      mempool.txs(),
+      &HashMap::from([(second_tx.hash(), Transaction::Application(second_tx))])
+    );
   }
 );
-
 
 #[test]
 fn too_many_mempool() {
   let (genesis, _, mut mempool) = new_mempool::<SignedTransaction>();
   let validators = Arc::new(Validators::new(genesis, vec![]).unwrap());
   let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
-    Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
+    Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
   };
-  let unsigned_in_chain = |_: [u8; 32]| {false};
+  let unsigned_in_chain = |_: [u8; 32]| false;
   let key = Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng));
   let signer = signed_transaction(&mut OsRng, genesis, &key, 0).1.signer;
 

--- a/coordinator/tributary/src/tests/mempool.rs
+++ b/coordinator/tributary/src/tests/mempool.rs
@@ -1,17 +1,18 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{sync::Arc, collections::HashMap};
 
-use tendermint::ext::Commit;
 use zeroize::Zeroizing;
 use rand::{RngCore, rngs::OsRng};
 
 use ciphersuite::{group::ff::Field, Ciphersuite, Ristretto};
 
+use tendermint::ext::Commit;
+
 use serai_db::MemDb;
 
 use crate::{
-  ACCOUNT_MEMPOOL_LIMIT, Mempool, Transaction,
-  tendermint::{TendermintNetwork, Validators, TendermintBlock, Signer},
   transaction::Transaction as TransactionTrait,
+  tendermint::{TendermintBlock, Validators, Signer, TendermintNetwork},
+  ACCOUNT_MEMPOOL_LIMIT, Transaction, Mempool,
   tests::{
     SignedTransaction, signed_transaction, p2p::DummyP2p, random_vote_tx, random_evidence_tx,
   },

--- a/coordinator/tributary/src/tests/mempool.rs
+++ b/coordinator/tributary/src/tests/mempool.rs
@@ -157,14 +157,14 @@ async fn mempool_addition() {
 
   // Removing should also successfully prune
   mempool.remove(&tx.hash());
-
-  // remove tendermint txs
   mempool.remove(&vote_tx.hash());
-  mempool.remove(&evidence_tx.hash());
 
   assert_eq!(
     mempool.txs(),
-    &HashMap::from([(second_tx.hash(), Transaction::Application(second_tx))])
+    &HashMap::from([
+      (second_tx.hash(), Transaction::Application(second_tx)),
+      (evidence_tx.hash(), Transaction::Tendermint(evidence_tx))
+    ])
   );
 }
 

--- a/coordinator/tributary/src/tests/mempool.rs
+++ b/coordinator/tributary/src/tests/mempool.rs
@@ -31,6 +31,7 @@ fn mempool_addition() {
   let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
     Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
   };
+  let unsigned_in_chain = |_: [u8; 32]| {false};
   let key = Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng));
 
   let first_tx = signed_transaction(&mut OsRng, genesis, &key, 0);
@@ -39,21 +40,20 @@ fn mempool_addition() {
 
   // Add TX 0
   let mut blockchain_next_nonces = HashMap::from([(signer, 0)]);
-  let unsigned_included: Vec<[u8; 32]> = vec![];
-  assert!(mempool.add::<N>(&blockchain_next_nonces, &unsigned_included, true, Transaction::Application(first_tx.clone()), validators.clone(), commit.clone()));
+  assert!(mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(first_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
   assert_eq!(mempool.next_nonce(&signer), Some(1));
 
   // Test reloading works
   assert_eq!(mempool, Mempool::new(db, genesis));
 
   // Adding it again should fail
-  assert!(!mempool.add::<N>(&blockchain_next_nonces, &unsigned_included, true, Transaction::Application(first_tx.clone()), validators.clone(), commit.clone()));
+  assert!(!mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(first_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
 
   // Do the same with the next nonce
   let second_tx = signed_transaction(&mut OsRng, genesis, &key, 1);
-  assert!(mempool.add::<N>(&blockchain_next_nonces, &unsigned_included, true, Transaction::Application(second_tx.clone()), validators.clone(), commit.clone()));
+  assert!(mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(second_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
   assert_eq!(mempool.next_nonce(&signer), Some(2));
-  assert!(!mempool.add::<N>(&blockchain_next_nonces, &unsigned_included, true, Transaction::Application(second_tx.clone()), validators.clone(), commit.clone()));
+  assert!(!mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(second_tx.clone()), validators.clone(), unsigned_in_chain.clone(), commit.clone()));
 
   // If the mempool doesn't have a nonce for an account, it should successfully use the
   // blockchain's
@@ -62,7 +62,7 @@ fn mempool_addition() {
   let second_signer = tx.1.signer;
   assert_eq!(mempool.next_nonce(&second_signer), None);
   blockchain_next_nonces.insert(second_signer, 2);
-  assert!(mempool.add::<N>(&blockchain_next_nonces, &unsigned_included, true, Transaction::Application(tx.clone()), validators.clone(), commit));
+  assert!(mempool.add::<N>(&blockchain_next_nonces, true, Transaction::Application(tx.clone()), validators.clone(), unsigned_in_chain, commit));
   assert_eq!(mempool.next_nonce(&second_signer), Some(3));
 
   // Getting a block should work
@@ -87,28 +87,28 @@ fn too_many_mempool() {
   let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
     Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
   };
+  let unsigned_in_chain = |_: [u8; 32]| {false};
   let key = Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng));
   let signer = signed_transaction(&mut OsRng, genesis, &key, 0).1.signer;
-  let unsigned_included: Vec<[u8; 32]> = vec![];
 
   // We should be able to add transactions up to the limit
   for i in 0 .. ACCOUNT_MEMPOOL_LIMIT {
     assert!(mempool.add::<N>(
       &HashMap::from([(signer, 0)]),
-      &unsigned_included,
       false,
       Transaction::Application(signed_transaction(&mut OsRng, genesis, &key, i)),
       validators.clone(),
+      unsigned_in_chain.clone(),
       commit.clone()
     ));
   }
   // Yet adding more should fail
   assert!(!mempool.add::<N>(
     &HashMap::from([(signer, 0)]),
-    &unsigned_included,
     false,
     Transaction::Application(signed_transaction(&mut OsRng, genesis, &key, ACCOUNT_MEMPOOL_LIMIT)),
     validators.clone(),
+    unsigned_in_chain.clone(),
     commit.clone()
   ));
 }

--- a/coordinator/tributary/src/tests/mempool.rs
+++ b/coordinator/tributary/src/tests/mempool.rs
@@ -66,11 +66,11 @@ fn mempool_addition() {
   assert_eq!(mempool.next_nonce(&second_signer), Some(3));
 
   // Getting a block should work
-  assert_eq!(mempool.block(&blockchain_next_nonces).len(), 3);
+  assert_eq!(mempool.block(&blockchain_next_nonces, unsigned_in_chain.clone()).len(), 3);
 
   // If the blockchain says an account had its nonce updated, it should cause a prune
   blockchain_next_nonces.insert(signer, 1);
-  let mut block = mempool.block(&blockchain_next_nonces);
+  let mut block = mempool.block(&blockchain_next_nonces, unsigned_in_chain.clone());
   assert_eq!(block.len(), 2);
   assert!(!block.iter().any(|tx| tx.hash() == first_tx.hash()));
   assert_eq!(mempool.txs(), &block.drain(..).map(|tx| (tx.hash(), tx)).collect::<HashMap<_, _>>());

--- a/coordinator/tributary/src/tests/mod.rs
+++ b/coordinator/tributary/src/tests/mod.rs
@@ -10,3 +10,5 @@ mod block;
 mod blockchain;
 #[cfg(test)]
 mod mempool;
+#[cfg(test)]
+mod p2p;

--- a/coordinator/tributary/src/tests/p2p.rs
+++ b/coordinator/tributary/src/tests/p2p.rs
@@ -1,157 +1,16 @@
 // TODO: this file is a copy of coordinator/p2p.rs
 
-use core::fmt::Debug;
-use std::{sync::Arc, io::Read, collections::VecDeque};
-
 use async_trait::async_trait;
 
-use tokio::sync::RwLock;
+pub use crate::P2p;
 
-pub use crate::P2p as TributaryP2p;
-
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub enum P2pMessageKind {
-  Tributary([u8; 32]),
-  Heartbeat([u8; 32]),
-  Block([u8; 32]),
-}
-
-impl P2pMessageKind {
-  fn serialize(&self) -> Vec<u8> {
-    match self {
-      P2pMessageKind::Tributary(genesis) => {
-        let mut res = vec![0];
-        res.extend(genesis);
-        res
-      }
-      P2pMessageKind::Heartbeat(genesis) => {
-        let mut res = vec![1];
-        res.extend(genesis);
-        res
-      }
-      P2pMessageKind::Block(genesis) => {
-        let mut res = vec![2];
-        res.extend(genesis);
-        res
-      }
-    }
-  }
-
-  fn read<R: Read>(reader: &mut R) -> Option<P2pMessageKind> {
-    let mut kind = [0; 1];
-    reader.read_exact(&mut kind).ok()?;
-    match kind[0] {
-      0 => Some({
-        let mut genesis = [0; 32];
-        reader.read_exact(&mut genesis).ok()?;
-        P2pMessageKind::Tributary(genesis)
-      }),
-      1 => Some({
-        let mut genesis = [0; 32];
-        reader.read_exact(&mut genesis).ok()?;
-        P2pMessageKind::Heartbeat(genesis)
-      }),
-      2 => Some({
-        let mut genesis = [0; 32];
-        reader.read_exact(&mut genesis).ok()?;
-        P2pMessageKind::Block(genesis)
-      }),
-      _ => None,
-    }
-  }
-}
-
-#[derive(Clone, Debug)]
-pub struct Message<P: P2p> {
-  pub sender: P::Id,
-  pub kind: P2pMessageKind,
-  pub msg: Vec<u8>,
-}
-
-#[async_trait]
-pub trait P2p: Send + Sync + Clone + Debug + TributaryP2p {
-  type Id: Send + Sync + Clone + Copy + Debug;
-
-  async fn send_raw(&self, to: Self::Id, msg: Vec<u8>);
-  async fn broadcast_raw(&self, msg: Vec<u8>);
-  async fn receive_raw(&self) -> (Self::Id, Vec<u8>);
-
-  async fn send(&self, to: Self::Id, kind: P2pMessageKind, msg: Vec<u8>) {
-    let mut actual_msg = kind.serialize();
-    actual_msg.extend(msg);
-    self.send_raw(to, actual_msg).await;
-  }
-  async fn broadcast(&self, kind: P2pMessageKind, msg: Vec<u8>) {
-    let mut actual_msg = kind.serialize();
-    actual_msg.extend(msg);
-    self.broadcast_raw(actual_msg).await;
-  }
-  async fn receive(&self) -> Message<Self> {
-    let (sender, kind, msg) = loop {
-      let (sender, msg) = self.receive_raw().await;
-      if msg.is_empty() {
-        log::error!("empty p2p message from {sender:?}");
-        continue;
-      }
-
-      let mut msg_ref = msg.as_ref();
-      let Some(kind) = P2pMessageKind::read::<&[u8]>(&mut msg_ref) else {
-        log::error!("invalid p2p message kind from {sender:?}");
-        continue;
-      };
-      break (sender, kind, msg_ref.to_vec());
-    };
-    Message { sender, kind, msg }
-  }
-}
-
-// TODO: Move this to tests
 #[allow(clippy::type_complexity)]
 #[derive(Clone, Debug)]
-pub struct LocalP2p(usize, pub Arc<RwLock<Vec<VecDeque<(usize, Vec<u8>)>>>>);
-
-impl LocalP2p {
-  pub fn new(validators: usize) -> Vec<LocalP2p> {
-    let shared = Arc::new(RwLock::new(vec![VecDeque::new(); validators]));
-    let mut res = vec![];
-    for i in 0 .. validators {
-      res.push(LocalP2p(i, shared.clone()));
-    }
-    res
-  }
-}
+pub struct DummyP2p;
 
 #[async_trait]
-impl P2p for LocalP2p {
-  type Id = usize;
-
-  async fn send_raw(&self, to: Self::Id, msg: Vec<u8>) {
-    self.1.write().await[to].push_back((self.0, msg));
-  }
-
-  async fn broadcast_raw(&self, msg: Vec<u8>) {
-    for (i, msg_queue) in self.1.write().await.iter_mut().enumerate() {
-      if i == self.0 {
-        continue;
-      }
-      msg_queue.push_back((self.0, msg.clone()));
-    }
-  }
-
-  async fn receive_raw(&self) -> (Self::Id, Vec<u8>) {
-    // This is a cursed way to implement an async read from a Vec
-    loop {
-      if let Some(res) = self.1.write().await[self.0].pop_front() {
-        return res;
-      }
-      tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
-  }
-}
-
-#[async_trait]
-impl TributaryP2p for LocalP2p {
-  async fn broadcast(&self, genesis: [u8; 32], msg: Vec<u8>) {
-    <Self as P2p>::broadcast(self, P2pMessageKind::Tributary(genesis), msg).await
+impl P2p for DummyP2p {
+  async fn broadcast(&self, _: [u8; 32], _: Vec<u8>) {
+    unimplemented!()
   }
 }

--- a/coordinator/tributary/src/tests/p2p.rs
+++ b/coordinator/tributary/src/tests/p2p.rs
@@ -1,14 +1,9 @@
-// TODO: this file is a copy of coordinator/p2p.rs
-
-use async_trait::async_trait;
-
 pub use crate::P2p;
 
-#[allow(clippy::type_complexity)]
 #[derive(Clone, Debug)]
 pub struct DummyP2p;
 
-#[async_trait]
+#[async_trait::async_trait]
 impl P2p for DummyP2p {
   async fn broadcast(&self, _: [u8; 32], _: Vec<u8>) {
     unimplemented!()

--- a/coordinator/tributary/src/tests/p2p.rs
+++ b/coordinator/tributary/src/tests/p2p.rs
@@ -1,0 +1,157 @@
+// TODO: this file is a copy of coordinator/p2p.rs
+
+use core::fmt::Debug;
+use std::{sync::Arc, io::Read, collections::VecDeque};
+
+use async_trait::async_trait;
+
+use tokio::sync::RwLock;
+
+pub use crate::P2p as TributaryP2p;
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum P2pMessageKind {
+  Tributary([u8; 32]),
+  Heartbeat([u8; 32]),
+  Block([u8; 32]),
+}
+
+impl P2pMessageKind {
+  fn serialize(&self) -> Vec<u8> {
+    match self {
+      P2pMessageKind::Tributary(genesis) => {
+        let mut res = vec![0];
+        res.extend(genesis);
+        res
+      }
+      P2pMessageKind::Heartbeat(genesis) => {
+        let mut res = vec![1];
+        res.extend(genesis);
+        res
+      }
+      P2pMessageKind::Block(genesis) => {
+        let mut res = vec![2];
+        res.extend(genesis);
+        res
+      }
+    }
+  }
+
+  fn read<R: Read>(reader: &mut R) -> Option<P2pMessageKind> {
+    let mut kind = [0; 1];
+    reader.read_exact(&mut kind).ok()?;
+    match kind[0] {
+      0 => Some({
+        let mut genesis = [0; 32];
+        reader.read_exact(&mut genesis).ok()?;
+        P2pMessageKind::Tributary(genesis)
+      }),
+      1 => Some({
+        let mut genesis = [0; 32];
+        reader.read_exact(&mut genesis).ok()?;
+        P2pMessageKind::Heartbeat(genesis)
+      }),
+      2 => Some({
+        let mut genesis = [0; 32];
+        reader.read_exact(&mut genesis).ok()?;
+        P2pMessageKind::Block(genesis)
+      }),
+      _ => None,
+    }
+  }
+}
+
+#[derive(Clone, Debug)]
+pub struct Message<P: P2p> {
+  pub sender: P::Id,
+  pub kind: P2pMessageKind,
+  pub msg: Vec<u8>,
+}
+
+#[async_trait]
+pub trait P2p: Send + Sync + Clone + Debug + TributaryP2p {
+  type Id: Send + Sync + Clone + Copy + Debug;
+
+  async fn send_raw(&self, to: Self::Id, msg: Vec<u8>);
+  async fn broadcast_raw(&self, msg: Vec<u8>);
+  async fn receive_raw(&self) -> (Self::Id, Vec<u8>);
+
+  async fn send(&self, to: Self::Id, kind: P2pMessageKind, msg: Vec<u8>) {
+    let mut actual_msg = kind.serialize();
+    actual_msg.extend(msg);
+    self.send_raw(to, actual_msg).await;
+  }
+  async fn broadcast(&self, kind: P2pMessageKind, msg: Vec<u8>) {
+    let mut actual_msg = kind.serialize();
+    actual_msg.extend(msg);
+    self.broadcast_raw(actual_msg).await;
+  }
+  async fn receive(&self) -> Message<Self> {
+    let (sender, kind, msg) = loop {
+      let (sender, msg) = self.receive_raw().await;
+      if msg.is_empty() {
+        log::error!("empty p2p message from {sender:?}");
+        continue;
+      }
+
+      let mut msg_ref = msg.as_ref();
+      let Some(kind) = P2pMessageKind::read::<&[u8]>(&mut msg_ref) else {
+        log::error!("invalid p2p message kind from {sender:?}");
+        continue;
+      };
+      break (sender, kind, msg_ref.to_vec());
+    };
+    Message { sender, kind, msg }
+  }
+}
+
+// TODO: Move this to tests
+#[allow(clippy::type_complexity)]
+#[derive(Clone, Debug)]
+pub struct LocalP2p(usize, pub Arc<RwLock<Vec<VecDeque<(usize, Vec<u8>)>>>>);
+
+impl LocalP2p {
+  pub fn new(validators: usize) -> Vec<LocalP2p> {
+    let shared = Arc::new(RwLock::new(vec![VecDeque::new(); validators]));
+    let mut res = vec![];
+    for i in 0 .. validators {
+      res.push(LocalP2p(i, shared.clone()));
+    }
+    res
+  }
+}
+
+#[async_trait]
+impl P2p for LocalP2p {
+  type Id = usize;
+
+  async fn send_raw(&self, to: Self::Id, msg: Vec<u8>) {
+    self.1.write().await[to].push_back((self.0, msg));
+  }
+
+  async fn broadcast_raw(&self, msg: Vec<u8>) {
+    for (i, msg_queue) in self.1.write().await.iter_mut().enumerate() {
+      if i == self.0 {
+        continue;
+      }
+      msg_queue.push_back((self.0, msg.clone()));
+    }
+  }
+
+  async fn receive_raw(&self) -> (Self::Id, Vec<u8>) {
+    // This is a cursed way to implement an async read from a Vec
+    loop {
+      if let Some(res) = self.1.write().await[self.0].pop_front() {
+        return res;
+      }
+      tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+  }
+}
+
+#[async_trait]
+impl TributaryP2p for LocalP2p {
+  async fn broadcast(&self, genesis: [u8; 32], msg: Vec<u8>) {
+    <Self as P2p>::broadcast(self, P2pMessageKind::Tributary(genesis), msg).await
+  }
+}

--- a/coordinator/tributary/src/tests/transaction/mod.rs
+++ b/coordinator/tributary/src/tests/transaction/mod.rs
@@ -249,7 +249,7 @@ pub fn random_vote_tx<R: RngCore + CryptoRng>(rng: &mut R, genesis: [u8; 32]) ->
   let key = Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut *rng));
 
   // vote data
-  let mut id = [0u8; 32];
+  let mut id = [0u8; 13];
   let mut target = [0u8; 32];
   rng.fill_bytes(&mut id);
   rng.fill_bytes(&mut target);

--- a/coordinator/tributary/src/tests/transaction/mod.rs
+++ b/coordinator/tributary/src/tests/transaction/mod.rs
@@ -12,7 +12,10 @@ use ciphersuite::{
 };
 use schnorr::SchnorrSignature;
 
-use crate::{ReadWrite, Signed, TransactionError, TransactionKind, Transaction, verify_transaction};
+use crate::{
+  transaction::{Signed, TransactionError, TransactionKind, Transaction, verify_transaction},
+  ReadWrite
+};
 
 #[cfg(test)]
 mod signed;

--- a/coordinator/tributary/src/tests/transaction/mod.rs
+++ b/coordinator/tributary/src/tests/transaction/mod.rs
@@ -201,20 +201,10 @@ pub async fn signer() -> ([u8; 32], Signer, [u8; 32], Arc<Validators>) {
   (genesis, signer, validator_id, validators)
 }
 
-pub fn encode_evidence<N: Network>(ev: Vec<SignedMessageFor<N>>) -> Vec<u8> {
-  let mut data = vec![];
-  data.extend(u8::to_le_bytes(u8::try_from(ev.len()).unwrap()));
-  for msg in ev {
-    let encoded = msg.encode();
-    data.extend(u32::to_le_bytes(u32::try_from(encoded.len()).unwrap()));
-    data.extend(encoded);
-  }
-  data
-}
-
-pub fn tx_from_evidence<N: Network>(ev: Vec<SignedMessageFor<N>>) -> TendermintTx {
-  let evidence = encode_evidence::<N>(ev);
-  TendermintTx::SlashEvidence(evidence)
+pub fn tx_from_evidence<N: Network>(mut ev: Vec<SignedMessageFor<N>>) -> TendermintTx {
+  assert!(!ev.is_empty());
+  assert!(ev.len() <= 2);
+  TendermintTx::SlashEvidence((ev.remove(0), ev.get(0)).encode())
 }
 
 pub async fn signed_from_data<N: Network>(

--- a/coordinator/tributary/src/tests/transaction/signed.rs
+++ b/coordinator/tributary/src/tests/transaction/signed.rs
@@ -7,7 +7,8 @@ use blake2::{Digest, Blake2s256};
 use ciphersuite::{group::ff::Field, Ciphersuite, Ristretto};
 
 use crate::{
-  ReadWrite, Signed, Transaction, verify_transaction,
+  ReadWrite,
+  transaction::{Signed, Transaction, verify_transaction},
   tests::{random_signed, random_signed_transaction},
 };
 

--- a/coordinator/tributary/src/tests/transaction/tendermint.rs
+++ b/coordinator/tributary/src/tests/transaction/tendermint.rs
@@ -1,0 +1,347 @@
+use std::sync::Arc;
+
+use crate::{
+  tendermint::{tx::{TendermintTx, verify_tendermint_tx}, Validators, TendermintNetwork, TendermintBlock, Signer}, ReadWrite,
+  tests::{random_evidence_tx, random_vote_tx, SignedTransaction, p2p::LocalP2p}
+};
+
+use ciphersuite::{Ristretto, Ciphersuite, group::ff::Field};
+use blake2::{Blake2s256, Digest};
+use rand::{RngCore, rngs::OsRng};
+use scale::Encode;
+
+use schnorr::SchnorrSignature;
+use zeroize::Zeroizing;
+
+use serai_db::MemDb;
+
+use tendermint::{
+  SignedMessage, Message, Data, DataFor,
+  ext::{RoundNumber, BlockNumber, Signer as SignerTrait, Commit, Network, SignatureScheme},
+  SignedMessageFor, commit_msg, round::RoundData, time::CanonicalInstant
+};
+
+use lazy_static::lazy_static;
+
+use tokio::sync::Mutex;
+
+type N = TendermintNetwork<MemDb, SignedTransaction, LocalP2p>;
+
+lazy_static! {
+  pub static ref SEQUENTIAL: Mutex<()> = Mutex::new(());
+}
+
+macro_rules! async_sequential {
+  ($(async fn $name: ident() $body: block)*) => {
+    $(
+      #[tokio::test]
+      async fn $name() {
+        let guard = SEQUENTIAL.lock().await;
+        let local = tokio::task::LocalSet::new();
+        local.run_until(async move {
+          if let Err(err) = tokio::task::spawn_local(async move { $body }).await {
+            drop(guard);
+            Err(err).unwrap()
+          }
+        }).await;
+      }
+    )*
+  }
+}
+
+async fn signer() -> ([u8; 32], Signer, [u8; 32], Arc<Validators>) {
+  // signer
+  let mut genesis = [0; 32];
+  OsRng.fill_bytes(&mut genesis);
+  let signer = Signer::new(genesis, Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng)));
+  let validator_id = signer.validator_id().await.unwrap();
+
+  // schema
+  let signer_g = <Ristretto as Ciphersuite>::read_G::<&[u8]>(&mut validator_id.as_slice()).unwrap();
+  let validators = Arc::new(Validators::new(genesis, vec![(signer_g, 1)]).unwrap());
+
+  (genesis, signer, validator_id, validators)
+}
+
+fn encode_evidence<N: Network>(ev: Vec<SignedMessageFor<N>>) -> Vec<u8> {
+  let mut data = vec![];
+  data.extend(u8::to_le_bytes(u8::try_from(ev.len()).unwrap()));
+  for msg in ev {
+    let encoded = msg.encode();
+    data.extend(u32::to_le_bytes(u32::try_from(encoded.len()).unwrap()));
+    data.extend(encoded);
+  }
+  data
+}
+
+fn tx_from_evidence<N: Network>(ev: Vec<SignedMessageFor<N>>) -> TendermintTx {
+  let evidence = encode_evidence::<N>(ev);
+  TendermintTx::SlashEvidence(evidence)
+}
+
+async fn signed_from_data<N: Network>(
+  signer: <N::SignatureScheme as SignatureScheme>::Signer,
+  signer_id: N::ValidatorId,
+  block_number: u64,
+  round_number: u32,
+  data: DataFor<N>
+) -> SignedMessageFor<N> {
+  let msg = Message{ sender: signer_id, block: BlockNumber(block_number), round: RoundNumber(round_number), data };
+  let sig = signer.sign(&msg.encode()).await;
+  SignedMessage{ msg, sig }
+}
+
+#[test]
+fn serialize_tendermint() {
+  // make a tendermint tx with random evidence
+  let tx = random_evidence_tx(&mut OsRng);
+  let res = TendermintTx::read::<&[u8]>(&mut  tx.serialize().as_ref()).unwrap();
+  assert_eq!(res, tx);
+
+  // with vote tx
+  let (_, vote_tx) = random_vote_tx(&mut OsRng);
+  let vote_res = TendermintTx::read::<&[u8]>(&mut  vote_tx.serialize().as_ref()).unwrap();
+  assert_eq!(vote_res, vote_tx);
+}
+
+#[test]
+fn vote_tx() {
+  let (genesis, mut tx) = random_vote_tx(&mut OsRng);
+
+  let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
+    Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
+  };
+  let validators = Arc::new(Validators::new(genesis, vec![]).unwrap());
+
+  // should pass
+  assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_ok());
+  
+  if let TendermintTx::SlashVote(vote) = &mut tx {
+    vote.sig.signature = SchnorrSignature::default();
+  }
+  
+  // should fail
+  assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
+}
+
+async_sequential!(
+
+  async fn msg_signature() {
+    // signer
+    let (genesis, signer, signer_id, validators) = signer().await;
+    let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
+      Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
+    };
+
+    // msg
+    let data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
+    let mut signed = signed_from_data::<N>(signer.into(), signer_id, 0, 0, data).await;
+    let mut tx = tx_from_evidence::<N>(vec![signed.clone()]);
+
+    // should pass
+    assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_ok());
+
+    // change the signature
+    let mut random_sig = [0u8; 64];
+    OsRng.fill_bytes(&mut random_sig);
+    signed.sig = random_sig;
+    tx = tx_from_evidence::<N>(vec![signed]);
+
+    // should fail
+    assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
+  }
+
+  async fn proposal_evidence_tx() {
+    // signer
+    let (genesis, signer, signer_id, validators) = signer().await;
+    let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
+      Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
+    };
+
+    // msg as valid evidence
+    let mut data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
+    let mut signed = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, data).await;
+    let mut tx = tx_from_evidence::<N>(vec![signed]);
+
+    // should pass
+    assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_ok());
+
+    // invalid evidence(msg round number is bigger than vr)
+    data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
+    signed = signed_from_data::<N>(signer.into(), signer_id, 0, 1, data).await;
+    tx = tx_from_evidence::<N>(vec![signed]);
+
+    // should fail
+    assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
+  }
+
+  async fn precommit_evidence_tx() {
+    let (genesis, signer, signer_id, validators) = signer().await;
+    let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
+      Some(Commit::<Arc<Validators>> {end_time: 1686040916, validators: vec![], signature: vec![] })
+    };
+    let block_id = [0u8; 32];
+
+    // calculate the end time of the round 0
+    let last_end_time = RoundData::<N>::new(RoundNumber(0), CanonicalInstant::new(commit(0).unwrap().end_time)).end_time();
+    let commit_msg = commit_msg(last_end_time.canonical(), block_id.as_ref());
+
+    // valid precommit msg should fail.
+    {
+      let sig = signer.sign(&commit_msg).await;
+      let signed = signed_from_data::<N>(signer.clone().into(), signer_id, 1, 0,  Data::Precommit(Some((block_id, sig)))).await;
+      let tx = tx_from_evidence::<N>(vec![signed]);
+
+      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
+    }
+
+    // any other commit(invalid) can be used as evidence.
+    {
+      let sig = signer.sign(&Blake2s256::digest(commit_msg).to_vec()).await;
+      let signed = signed_from_data::<N>(signer.clone().into(), signer_id, 1, 0,  Data::Precommit(Some((block_id, sig)))).await;
+      let tx = tx_from_evidence::<N>(vec![signed]);
+
+      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_ok());
+    }
+
+    // Empty Precommit should fail.
+    {
+      let signed = signed_from_data::<N>(signer.into(), signer_id, 1, 0, Data::Precommit(None)).await;
+      let tx = tx_from_evidence::<N>(vec![signed]);
+
+      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
+    }
+  }
+
+  async fn prevote_evidence_tx() {
+    let (genesis, signer, signer_id, validators) = signer().await;
+    let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
+      Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
+    };
+    let block_id = [0u8; 32];
+
+    let signed = signed_from_data::<N>(signer.into(), signer_id, 0, 0, Data::Prevote(Some(block_id))).await;
+    let tx = tx_from_evidence::<N>(vec![signed]);
+
+    // prevote can't be used as evidence
+    assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
+  }
+
+  async fn conflicting_msgs_evidence_tx() {
+    let (genesis, signer, signer_id, validators) = signer().await;
+    let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
+      Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
+    };
+
+    // non-conflicting data should fail(Proposal)
+    {
+      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x11]))).await;
+      let signed_2 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x11]))).await;
+      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+
+      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
+    }
+
+    // conflicting data should pass(Proposal)
+    {
+      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x11]))).await;
+      let signed_2 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x22]))).await;
+      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+
+      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_ok());
+    }
+
+    // non-conflicting data should fail(Prevote)
+    {
+      let block_id_1 = [0u8; 32];
+      let block_id_2 = block_id_1.clone();
+      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Prevote(Some(block_id_1))).await;
+      let signed_2 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Prevote(Some(block_id_2))).await;
+      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+
+      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
+    }
+
+    // conflicting data should pass(Prevote)
+    {
+      let block_id_1 = [0u8; 32];
+      let block_id_2 = [1u8; 32];
+      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Prevote(Some(block_id_1))).await;
+      let signed_2 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Prevote(Some(block_id_2))).await;
+      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+
+      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_ok());
+    }
+
+    // non-conflicting data should fail irrespective of round number(Precommit)
+    {
+      let block_id_1 = [0u8; 32];
+      let block_id_2 = block_id_1.clone();
+      let sig = signer.sign(&block_id_1).await; // signature doesn't matter
+      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Precommit(Some((block_id_1, sig)))).await;
+      let signed_2 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 1, Data::Precommit(Some((block_id_2, sig)))).await;
+      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+
+      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
+    }
+
+    // conflicting data should pass irrespective of round number(Precommit)
+    {
+      let block_id_1 = [0u8; 32];
+      let block_id_2 = [1u8; 32];
+      let sig = signer.sign(&block_id_1).await; // signature doesn't matter
+      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Precommit(Some((block_id_1, sig)))).await;
+      let signed_2 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 1, Data::Precommit(Some((block_id_2, sig)))).await;
+      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+
+      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_ok());
+    }
+
+    // msgs to different block numbers should fail
+    {
+      let data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
+      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, data.clone()).await;
+      let signed_2 = signed_from_data::<N>(signer.clone().into(), signer_id, 1, 0, data.clone()).await;
+      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+
+      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
+    }
+
+    // msgs from different senders should fail
+    {
+      let data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
+      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, data.clone()).await;
+
+      let signer_2 = Signer::new(genesis, Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng)));
+      let signed_id_2 = signer_2.validator_id().await.unwrap();
+      let signed_2 = signed_from_data::<N>(signer_2.into(), signed_id_2, 0, 0, data.clone()).await;
+
+      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+
+      // update schema so that we don't fail due to invalid signature
+      let signer_g = <Ristretto as Ciphersuite>::read_G::<&[u8]>(&mut signer_id.as_slice()).unwrap();
+      let signer_g_2 = <Ristretto as Ciphersuite>::read_G::<&[u8]>(&mut signed_id_2.as_slice()).unwrap();
+      let validators = Arc::new(Validators::new(genesis, vec![(signer_g, 1), (signer_g_2, 1)]).unwrap());
+
+      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
+    }
+
+    //  msgs with different round number should fail even with conflicting data
+    {
+      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Prevote(Some([0u8; 32]))).await;
+      let signed_2 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 1, Data::Prevote(Some([1u8; 32]))).await;
+      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+
+      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
+    }
+
+    // msgs with different steps should fail
+    {
+      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]))).await;
+      let signed_2 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Prevote(Some([0u8; 32]))).await;
+      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+
+      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
+    }
+  }
+);

--- a/coordinator/tributary/src/tests/transaction/tendermint.rs
+++ b/coordinator/tributary/src/tests/transaction/tendermint.rs
@@ -10,7 +10,6 @@ use crate::{
     random_evidence_tx, random_vote_tx, SignedTransaction, p2p::DummyP2p, new_genesis, signer,
     tx_from_evidence, signed_from_data,
   },
-  async_sequential,
 };
 
 use ciphersuite::{Ristretto, Ciphersuite, group::ff::Field};
@@ -56,377 +55,360 @@ fn vote_tx() {
   assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
 }
 
-async_sequential!(
-  async fn serialize_tendermint() {
-    // make a tendermint tx with random evidence
-    let (genesis, signer, _, _) = signer().await;
-    let tx = random_evidence_tx::<N>(signer.into(), TendermintBlock(vec![])).await;
-    let res = TendermintTx::read::<&[u8]>(&mut tx.serialize().as_ref()).unwrap();
-    assert_eq!(res, tx);
+#[tokio::test]
+async fn serialize_tendermint() {
+  // make a tendermint tx with random evidence
+  let (genesis, signer, _, _) = signer().await;
+  let tx = random_evidence_tx::<N>(signer.into(), TendermintBlock(vec![])).await;
+  let res = TendermintTx::read::<&[u8]>(&mut tx.serialize().as_ref()).unwrap();
+  assert_eq!(res, tx);
 
-    // with vote tx
-    let vote_tx = random_vote_tx(&mut OsRng, genesis);
-    let vote_res = TendermintTx::read::<&[u8]>(&mut vote_tx.serialize().as_ref()).unwrap();
-    assert_eq!(vote_res, vote_tx);
-  }
+  // with vote tx
+  let vote_tx = random_vote_tx(&mut OsRng, genesis);
+  let vote_res = TendermintTx::read::<&[u8]>(&mut vote_tx.serialize().as_ref()).unwrap();
+  assert_eq!(vote_res, vote_tx);
+}
 
-  async fn msg_signature() {
-    // signer
-    let (genesis, signer, signer_id, validators) = signer().await;
-    let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
-      Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
-    };
+#[tokio::test]
+async fn msg_signature() {
+  // signer
+  let (genesis, signer, signer_id, validators) = signer().await;
+  let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
+    Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
+  };
 
-    // msg
-    let data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
-    let mut signed = signed_from_data::<N>(signer.into(), signer_id, 0, 0, data).await;
-    let mut tx = tx_from_evidence::<N>(vec![signed.clone()]);
+  // msg
+  let data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
+  let mut signed = signed_from_data::<N>(signer.into(), signer_id, 0, 0, data).await;
+  let mut tx = tx_from_evidence::<N>(vec![signed.clone()]);
 
-    // should pass
-    verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
+  // should pass
+  verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
 
-    // change the signature
-    let mut random_sig = [0u8; 64];
-    OsRng.fill_bytes(&mut random_sig);
-    signed.sig = random_sig;
-    tx = tx_from_evidence::<N>(vec![signed]);
+  // change the signature
+  let mut random_sig = [0u8; 64];
+  OsRng.fill_bytes(&mut random_sig);
+  signed.sig = random_sig;
+  tx = tx_from_evidence::<N>(vec![signed]);
 
-    // should fail
-    assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
-  }
+  // should fail
+  assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
+}
 
-  async fn proposal_evidence_tx() {
-    // signer
-    let (genesis, signer, signer_id, validators) = signer().await;
-    let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
-      Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
-    };
+#[tokio::test]
+async fn proposal_evidence_tx() {
+  // signer
+  let (genesis, signer, signer_id, validators) = signer().await;
+  let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
+    Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
+  };
 
-    // msg as valid evidence
-    let mut data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
-    let mut signed = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, data).await;
-    let mut tx = tx_from_evidence::<N>(vec![signed]);
+  // msg as valid evidence
+  let mut data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
+  let mut signed = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, data).await;
+  let mut tx = tx_from_evidence::<N>(vec![signed]);
 
-    // should pass
-    verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
+  // should pass
+  verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
 
-    // invalid evidence(msg round number is bigger than vr)
-    data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
-    signed = signed_from_data::<N>(signer.into(), signer_id, 0, 1, data).await;
-    tx = tx_from_evidence::<N>(vec![signed]);
+  // invalid evidence(msg round number is bigger than vr)
+  data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
+  signed = signed_from_data::<N>(signer.into(), signer_id, 0, 1, data).await;
+  tx = tx_from_evidence::<N>(vec![signed]);
 
-    // should fail
-    assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
-  }
+  // should fail
+  assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
+}
 
-  async fn precommit_evidence_tx() {
-    let (genesis, signer, signer_id, validators) = signer().await;
-    let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
-      Some(Commit::<Arc<Validators>> {
-        end_time: 1686040916,
-        validators: vec![],
-        signature: vec![],
-      })
-    };
-    let block_id = [0u8; 32];
+#[tokio::test]
+async fn precommit_evidence_tx() {
+  let (genesis, signer, signer_id, validators) = signer().await;
+  let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
+    Some(Commit::<Arc<Validators>> { end_time: 1686040916, validators: vec![], signature: vec![] })
+  };
+  let block_id = [0u8; 32];
 
-    // calculate the end time of the round 0
-    let last_end_time =
-      RoundData::<N>::new(RoundNumber(0), CanonicalInstant::new(commit(0).unwrap().end_time))
-        .end_time();
-    let commit_msg = commit_msg(last_end_time.canonical(), block_id.as_ref());
+  // calculate the end time of the round 0
+  let last_end_time =
+    RoundData::<N>::new(RoundNumber(0), CanonicalInstant::new(commit(0).unwrap().end_time))
+      .end_time();
+  let commit_msg = commit_msg(last_end_time.canonical(), block_id.as_ref());
 
-    // valid precommit msg should fail.
-    {
-      let sig = signer.sign(&commit_msg).await;
-      let signed = signed_from_data::<N>(
-        signer.clone().into(),
-        signer_id,
-        1,
-        0,
-        Data::Precommit(Some((block_id, sig))),
-      )
-      .await;
-      let tx = tx_from_evidence::<N>(vec![signed]);
-
-      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
-    }
-
-    // any other commit(invalid) can be used as evidence.
-    {
-      let sig = signer.sign(&Blake2s256::digest(commit_msg)).await;
-      let signed = signed_from_data::<N>(
-        signer.clone().into(),
-        signer_id,
-        1,
-        0,
-        Data::Precommit(Some((block_id, sig))),
-      )
-      .await;
-      let tx = tx_from_evidence::<N>(vec![signed]);
-
-      verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
-    }
-
-    // Empty Precommit should fail.
-    {
-      let signed =
-        signed_from_data::<N>(signer.into(), signer_id, 1, 0, Data::Precommit(None)).await;
-      let tx = tx_from_evidence::<N>(vec![signed]);
-
-      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
-    }
-  }
-
-  async fn prevote_evidence_tx() {
-    let (genesis, signer, signer_id, validators) = signer().await;
-    let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
-      Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
-    };
-    let block_id = [0u8; 32];
-
-    let signed =
-      signed_from_data::<N>(signer.into(), signer_id, 0, 0, Data::Prevote(Some(block_id))).await;
+  // valid precommit msg should fail.
+  {
+    let sig = signer.sign(&commit_msg).await;
+    let signed = signed_from_data::<N>(
+      signer.clone().into(),
+      signer_id,
+      1,
+      0,
+      Data::Precommit(Some((block_id, sig))),
+    )
+    .await;
     let tx = tx_from_evidence::<N>(vec![signed]);
 
-    // prevote can't be used as evidence
+    assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
+  }
+
+  // any other commit(invalid) can be used as evidence.
+  {
+    let sig = signer.sign(&Blake2s256::digest(commit_msg)).await;
+    let signed = signed_from_data::<N>(
+      signer.clone().into(),
+      signer_id,
+      1,
+      0,
+      Data::Precommit(Some((block_id, sig))),
+    )
+    .await;
+    let tx = tx_from_evidence::<N>(vec![signed]);
+
+    verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
+  }
+
+  // Empty Precommit should fail.
+  {
+    let signed = signed_from_data::<N>(signer.into(), signer_id, 1, 0, Data::Precommit(None)).await;
+    let tx = tx_from_evidence::<N>(vec![signed]);
+
+    assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
+  }
+}
+
+#[tokio::test]
+async fn prevote_evidence_tx() {
+  let (genesis, signer, signer_id, validators) = signer().await;
+  let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
+    Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
+  };
+  let block_id = [0u8; 32];
+
+  let signed =
+    signed_from_data::<N>(signer.into(), signer_id, 0, 0, Data::Prevote(Some(block_id))).await;
+  let tx = tx_from_evidence::<N>(vec![signed]);
+
+  // prevote can't be used as evidence
+  assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
+}
+
+#[tokio::test]
+async fn conflicting_msgs_evidence_tx() {
+  let (genesis, signer, signer_id, validators) = signer().await;
+  let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
+    Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
+  };
+
+  // non-conflicting data should fail(Proposal)
+  {
+    let signed_1 = signed_from_data::<N>(
+      signer.clone().into(),
+      signer_id,
+      0,
+      0,
+      Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x11])),
+    )
+    .await;
+    let signed_2 = signed_from_data::<N>(
+      signer.clone().into(),
+      signer_id,
+      0,
+      0,
+      Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x11])),
+    )
+    .await;
+    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+
+    assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
+  }
+
+  // conflicting data should pass(Proposal)
+  {
+    let signed_1 = signed_from_data::<N>(
+      signer.clone().into(),
+      signer_id,
+      0,
+      0,
+      Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x11])),
+    )
+    .await;
+    let signed_2 = signed_from_data::<N>(
+      signer.clone().into(),
+      signer_id,
+      0,
+      0,
+      Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x22])),
+    )
+    .await;
+    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+
+    verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
+  }
+
+  // non-conflicting data should fail(Prevote)
+  {
+    let block_id_1 = [0u8; 32];
+    let block_id_2 = block_id_1;
+    let signed_1 = signed_from_data::<N>(
+      signer.clone().into(),
+      signer_id,
+      0,
+      0,
+      Data::Prevote(Some(block_id_1)),
+    )
+    .await;
+    let signed_2 = signed_from_data::<N>(
+      signer.clone().into(),
+      signer_id,
+      0,
+      0,
+      Data::Prevote(Some(block_id_2)),
+    )
+    .await;
+    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+
+    assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
+  }
+
+  // conflicting data should pass(Prevote)
+  {
+    let block_id_1 = [0u8; 32];
+    let block_id_2 = [1u8; 32];
+    let signed_1 = signed_from_data::<N>(
+      signer.clone().into(),
+      signer_id,
+      0,
+      0,
+      Data::Prevote(Some(block_id_1)),
+    )
+    .await;
+    let signed_2 = signed_from_data::<N>(
+      signer.clone().into(),
+      signer_id,
+      0,
+      0,
+      Data::Prevote(Some(block_id_2)),
+    )
+    .await;
+    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+
+    verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
+  }
+
+  // non-conflicting data should fail irrespective of round number(Precommit)
+  {
+    let block_id_1 = [0u8; 32];
+    let block_id_2 = block_id_1;
+    let sig = signer.sign(&block_id_1).await; // signature doesn't matter
+    let signed_1 = signed_from_data::<N>(
+      signer.clone().into(),
+      signer_id,
+      0,
+      0,
+      Data::Precommit(Some((block_id_1, sig))),
+    )
+    .await;
+    let signed_2 = signed_from_data::<N>(
+      signer.clone().into(),
+      signer_id,
+      0,
+      1,
+      Data::Precommit(Some((block_id_2, sig))),
+    )
+    .await;
+    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+
+    assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
+  }
+
+  // conflicting data should pass irrespective of round number(Precommit)
+  {
+    let block_id_1 = [0u8; 32];
+    let block_id_2 = [1u8; 32];
+    let sig = signer.sign(&block_id_1).await; // signature doesn't matter
+    let signed_1 = signed_from_data::<N>(
+      signer.clone().into(),
+      signer_id,
+      0,
+      0,
+      Data::Precommit(Some((block_id_1, sig))),
+    )
+    .await;
+    let signed_2 = signed_from_data::<N>(
+      signer.clone().into(),
+      signer_id,
+      0,
+      1,
+      Data::Precommit(Some((block_id_2, sig))),
+    )
+    .await;
+    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+
+    verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
+  }
+
+  // msgs to different block numbers should fail
+  {
+    let data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
+    let signed_1 =
+      signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, data.clone()).await;
+    let signed_2 =
+      signed_from_data::<N>(signer.clone().into(), signer_id, 1, 0, data.clone()).await;
+    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+
+    assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
+  }
+
+  // msgs from different senders should fail
+  {
+    let data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
+    let signed_1 =
+      signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, data.clone()).await;
+
+    let signer_2 =
+      Signer::new(genesis, Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng)));
+    let signed_id_2 = signer_2.validator_id().await.unwrap();
+    let signed_2 = signed_from_data::<N>(signer_2.into(), signed_id_2, 0, 0, data.clone()).await;
+
+    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+
+    // update schema so that we don't fail due to invalid signature
+    let signer_g = <Ristretto as Ciphersuite>::read_G::<&[u8]>(&mut signer_id.as_slice()).unwrap();
+    let signer_g_2 =
+      <Ristretto as Ciphersuite>::read_G::<&[u8]>(&mut signed_id_2.as_slice()).unwrap();
+    let validators =
+      Arc::new(Validators::new(genesis, vec![(signer_g, 1), (signer_g_2, 1)]).unwrap());
+
     assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
   }
 
-  async fn conflicting_msgs_evidence_tx() {
-    let (genesis, signer, signer_id, validators) = signer().await;
-    let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
-      Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
-    };
+  //  msgs with different round number should fail even with conflicting data
+  {
+    let signed_1 =
+      signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Prevote(Some([0u8; 32])))
+        .await;
+    let signed_2 =
+      signed_from_data::<N>(signer.clone().into(), signer_id, 0, 1, Data::Prevote(Some([1u8; 32])))
+        .await;
+    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
 
-    // non-conflicting data should fail(Proposal)
-    {
-      let signed_1 = signed_from_data::<N>(
-        signer.clone().into(),
-        signer_id,
-        0,
-        0,
-        Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x11])),
-      )
-      .await;
-      let signed_2 = signed_from_data::<N>(
-        signer.clone().into(),
-        signer_id,
-        0,
-        0,
-        Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x11])),
-      )
-      .await;
-      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
-
-      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
-    }
-
-    // conflicting data should pass(Proposal)
-    {
-      let signed_1 = signed_from_data::<N>(
-        signer.clone().into(),
-        signer_id,
-        0,
-        0,
-        Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x11])),
-      )
-      .await;
-      let signed_2 = signed_from_data::<N>(
-        signer.clone().into(),
-        signer_id,
-        0,
-        0,
-        Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x22])),
-      )
-      .await;
-      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
-
-      verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
-    }
-
-    // non-conflicting data should fail(Prevote)
-    {
-      let block_id_1 = [0u8; 32];
-      let block_id_2 = block_id_1;
-      let signed_1 = signed_from_data::<N>(
-        signer.clone().into(),
-        signer_id,
-        0,
-        0,
-        Data::Prevote(Some(block_id_1)),
-      )
-      .await;
-      let signed_2 = signed_from_data::<N>(
-        signer.clone().into(),
-        signer_id,
-        0,
-        0,
-        Data::Prevote(Some(block_id_2)),
-      )
-      .await;
-      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
-
-      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
-    }
-
-    // conflicting data should pass(Prevote)
-    {
-      let block_id_1 = [0u8; 32];
-      let block_id_2 = [1u8; 32];
-      let signed_1 = signed_from_data::<N>(
-        signer.clone().into(),
-        signer_id,
-        0,
-        0,
-        Data::Prevote(Some(block_id_1)),
-      )
-      .await;
-      let signed_2 = signed_from_data::<N>(
-        signer.clone().into(),
-        signer_id,
-        0,
-        0,
-        Data::Prevote(Some(block_id_2)),
-      )
-      .await;
-      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
-
-      verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
-    }
-
-    // non-conflicting data should fail irrespective of round number(Precommit)
-    {
-      let block_id_1 = [0u8; 32];
-      let block_id_2 = block_id_1;
-      let sig = signer.sign(&block_id_1).await; // signature doesn't matter
-      let signed_1 = signed_from_data::<N>(
-        signer.clone().into(),
-        signer_id,
-        0,
-        0,
-        Data::Precommit(Some((block_id_1, sig))),
-      )
-      .await;
-      let signed_2 = signed_from_data::<N>(
-        signer.clone().into(),
-        signer_id,
-        0,
-        1,
-        Data::Precommit(Some((block_id_2, sig))),
-      )
-      .await;
-      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
-
-      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
-    }
-
-    // conflicting data should pass irrespective of round number(Precommit)
-    {
-      let block_id_1 = [0u8; 32];
-      let block_id_2 = [1u8; 32];
-      let sig = signer.sign(&block_id_1).await; // signature doesn't matter
-      let signed_1 = signed_from_data::<N>(
-        signer.clone().into(),
-        signer_id,
-        0,
-        0,
-        Data::Precommit(Some((block_id_1, sig))),
-      )
-      .await;
-      let signed_2 = signed_from_data::<N>(
-        signer.clone().into(),
-        signer_id,
-        0,
-        1,
-        Data::Precommit(Some((block_id_2, sig))),
-      )
-      .await;
-      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
-
-      verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
-    }
-
-    // msgs to different block numbers should fail
-    {
-      let data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
-      let signed_1 =
-        signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, data.clone()).await;
-      let signed_2 =
-        signed_from_data::<N>(signer.clone().into(), signer_id, 1, 0, data.clone()).await;
-      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
-
-      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
-    }
-
-    // msgs from different senders should fail
-    {
-      let data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
-      let signed_1 =
-        signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, data.clone()).await;
-
-      let signer_2 =
-        Signer::new(genesis, Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng)));
-      let signed_id_2 = signer_2.validator_id().await.unwrap();
-      let signed_2 = signed_from_data::<N>(signer_2.into(), signed_id_2, 0, 0, data.clone()).await;
-
-      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
-
-      // update schema so that we don't fail due to invalid signature
-      let signer_g =
-        <Ristretto as Ciphersuite>::read_G::<&[u8]>(&mut signer_id.as_slice()).unwrap();
-      let signer_g_2 =
-        <Ristretto as Ciphersuite>::read_G::<&[u8]>(&mut signed_id_2.as_slice()).unwrap();
-      let validators =
-        Arc::new(Validators::new(genesis, vec![(signer_g, 1), (signer_g_2, 1)]).unwrap());
-
-      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
-    }
-
-    //  msgs with different round number should fail even with conflicting data
-    {
-      let signed_1 = signed_from_data::<N>(
-        signer.clone().into(),
-        signer_id,
-        0,
-        0,
-        Data::Prevote(Some([0u8; 32])),
-      )
-      .await;
-      let signed_2 = signed_from_data::<N>(
-        signer.clone().into(),
-        signer_id,
-        0,
-        1,
-        Data::Prevote(Some([1u8; 32])),
-      )
-      .await;
-      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
-
-      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
-    }
-
-    // msgs with different steps should fail
-    {
-      let signed_1 = signed_from_data::<N>(
-        signer.clone().into(),
-        signer_id,
-        0,
-        0,
-        Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![])),
-      )
-      .await;
-      let signed_2 = signed_from_data::<N>(
-        signer.clone().into(),
-        signer_id,
-        0,
-        0,
-        Data::Prevote(Some([0u8; 32])),
-      )
-      .await;
-      let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
-
-      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
-    }
+    assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
   }
-);
+
+  // msgs with different steps should fail
+  {
+    let signed_1 = signed_from_data::<N>(
+      signer.clone().into(),
+      signer_id,
+      0,
+      0,
+      Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![])),
+    )
+    .await;
+    let signed_2 =
+      signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Prevote(Some([0u8; 32])))
+        .await;
+    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+
+    assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
+  }
+}

--- a/coordinator/tributary/src/tests/transaction/tendermint.rs
+++ b/coordinator/tributary/src/tests/transaction/tendermint.rs
@@ -44,7 +44,7 @@ fn vote_tx() {
   let validators = Arc::new(Validators::new(genesis, vec![]).unwrap());
 
   // should pass
-  assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_ok());
+  verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
 
   if let TendermintTx::SlashVote(vote) = &mut tx {
     vote.sig.signature = SchnorrSignature::read(&mut [0; 64].as_slice()).unwrap();
@@ -83,7 +83,7 @@ async_sequential!(
     let mut tx = tx_from_evidence::<N>(vec![signed.clone()]);
 
     // should pass
-    assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_ok());
+    verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
 
     // change the signature
     let mut random_sig = [0u8; 64];
@@ -108,7 +108,7 @@ async_sequential!(
     let mut tx = tx_from_evidence::<N>(vec![signed]);
 
     // should pass
-    assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_ok());
+    verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
 
     // invalid evidence(msg round number is bigger than vr)
     data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
@@ -165,7 +165,7 @@ async_sequential!(
       .await;
       let tx = tx_from_evidence::<N>(vec![signed]);
 
-      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_ok());
+      verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
     }
 
     // Empty Precommit should fail.
@@ -242,7 +242,7 @@ async_sequential!(
       .await;
       let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
 
-      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_ok());
+      verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
     }
 
     // non-conflicting data should fail(Prevote)
@@ -292,7 +292,7 @@ async_sequential!(
       .await;
       let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
 
-      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_ok());
+      verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
     }
 
     // non-conflicting data should fail irrespective of round number(Precommit)
@@ -344,7 +344,7 @@ async_sequential!(
       .await;
       let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
 
-      assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_ok());
+      verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
     }
 
     // msgs to different block numbers should fail

--- a/coordinator/tributary/src/tests/transaction/tendermint.rs
+++ b/coordinator/tributary/src/tests/transaction/tendermint.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 use crate::{
   tendermint::{
     tx::{TendermintTx, verify_tendermint_tx},
-    Validators, TendermintNetwork, TendermintBlock, Signer
+    Validators, TendermintNetwork, TendermintBlock, Signer,
   },
   ReadWrite,
   tests::{
-    random_evidence_tx, random_vote_tx, SignedTransaction, p2p::LocalP2p,
-    new_genesis, signer, tx_from_evidence, signed_from_data
+    random_evidence_tx, random_vote_tx, SignedTransaction, p2p::LocalP2p, new_genesis, signer,
+    tx_from_evidence, signed_from_data,
   },
-  async_sequential
+  async_sequential,
 };
 
 use ciphersuite::{Ristretto, Ciphersuite, group::ff::Field};
@@ -23,8 +23,12 @@ use zeroize::Zeroizing;
 
 use serai_db::MemDb;
 
-use tendermint::{Data, ext::{RoundNumber, Commit, Signer as SignerTrait},
-  commit_msg, round::RoundData, time::CanonicalInstant
+use tendermint::{
+  Data,
+  ext::{RoundNumber, Commit, Signer as SignerTrait},
+  commit_msg,
+  round::RoundData,
+  time::CanonicalInstant,
 };
 
 type N = TendermintNetwork<MemDb, SignedTransaction, LocalP2p>;
@@ -35,7 +39,7 @@ fn vote_tx() {
   let mut tx = random_vote_tx(&mut OsRng, genesis);
 
   let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
-    Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
+    Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
   };
   let validators = Arc::new(Validators::new(genesis, vec![]).unwrap());
 
@@ -53,17 +57,16 @@ fn vote_tx() {
 }
 
 async_sequential!(
-
   async fn serialize_tendermint() {
     // make a tendermint tx with random evidence
     let (genesis, signer, _, _) = signer().await;
     let tx = random_evidence_tx::<N>(signer.into(), TendermintBlock(vec![])).await;
-    let res = TendermintTx::read::<&[u8]>(&mut  tx.serialize().as_ref()).unwrap();
+    let res = TendermintTx::read::<&[u8]>(&mut tx.serialize().as_ref()).unwrap();
     assert_eq!(res, tx);
 
     // with vote tx
     let vote_tx = random_vote_tx(&mut OsRng, genesis);
-    let vote_res = TendermintTx::read::<&[u8]>(&mut  vote_tx.serialize().as_ref()).unwrap();
+    let vote_res = TendermintTx::read::<&[u8]>(&mut vote_tx.serialize().as_ref()).unwrap();
     assert_eq!(vote_res, vote_tx);
   }
 
@@ -71,7 +74,7 @@ async_sequential!(
     // signer
     let (genesis, signer, signer_id, validators) = signer().await;
     let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
-      Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
+      Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
     };
 
     // msg
@@ -96,7 +99,7 @@ async_sequential!(
     // signer
     let (genesis, signer, signer_id, validators) = signer().await;
     let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
-      Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
+      Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
     };
 
     // msg as valid evidence
@@ -119,18 +122,31 @@ async_sequential!(
   async fn precommit_evidence_tx() {
     let (genesis, signer, signer_id, validators) = signer().await;
     let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
-      Some(Commit::<Arc<Validators>> {end_time: 1686040916, validators: vec![], signature: vec![] })
+      Some(Commit::<Arc<Validators>> {
+        end_time: 1686040916,
+        validators: vec![],
+        signature: vec![],
+      })
     };
     let block_id = [0u8; 32];
 
     // calculate the end time of the round 0
-    let last_end_time = RoundData::<N>::new(RoundNumber(0), CanonicalInstant::new(commit(0).unwrap().end_time)).end_time();
+    let last_end_time =
+      RoundData::<N>::new(RoundNumber(0), CanonicalInstant::new(commit(0).unwrap().end_time))
+        .end_time();
     let commit_msg = commit_msg(last_end_time.canonical(), block_id.as_ref());
 
     // valid precommit msg should fail.
     {
       let sig = signer.sign(&commit_msg).await;
-      let signed = signed_from_data::<N>(signer.clone().into(), signer_id, 1, 0,  Data::Precommit(Some((block_id, sig)))).await;
+      let signed = signed_from_data::<N>(
+        signer.clone().into(),
+        signer_id,
+        1,
+        0,
+        Data::Precommit(Some((block_id, sig))),
+      )
+      .await;
       let tx = tx_from_evidence::<N>(vec![signed]);
 
       assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
@@ -139,7 +155,14 @@ async_sequential!(
     // any other commit(invalid) can be used as evidence.
     {
       let sig = signer.sign(&Blake2s256::digest(commit_msg).to_vec()).await;
-      let signed = signed_from_data::<N>(signer.clone().into(), signer_id, 1, 0,  Data::Precommit(Some((block_id, sig)))).await;
+      let signed = signed_from_data::<N>(
+        signer.clone().into(),
+        signer_id,
+        1,
+        0,
+        Data::Precommit(Some((block_id, sig))),
+      )
+      .await;
       let tx = tx_from_evidence::<N>(vec![signed]);
 
       assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_ok());
@@ -147,7 +170,8 @@ async_sequential!(
 
     // Empty Precommit should fail.
     {
-      let signed = signed_from_data::<N>(signer.into(), signer_id, 1, 0, Data::Precommit(None)).await;
+      let signed =
+        signed_from_data::<N>(signer.into(), signer_id, 1, 0, Data::Precommit(None)).await;
       let tx = tx_from_evidence::<N>(vec![signed]);
 
       assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
@@ -157,11 +181,12 @@ async_sequential!(
   async fn prevote_evidence_tx() {
     let (genesis, signer, signer_id, validators) = signer().await;
     let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
-      Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
+      Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
     };
     let block_id = [0u8; 32];
 
-    let signed = signed_from_data::<N>(signer.into(), signer_id, 0, 0, Data::Prevote(Some(block_id))).await;
+    let signed =
+      signed_from_data::<N>(signer.into(), signer_id, 0, 0, Data::Prevote(Some(block_id))).await;
     let tx = tx_from_evidence::<N>(vec![signed]);
 
     // prevote can't be used as evidence
@@ -171,13 +196,27 @@ async_sequential!(
   async fn conflicting_msgs_evidence_tx() {
     let (genesis, signer, signer_id, validators) = signer().await;
     let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
-      Some(Commit::<Arc<Validators>> {end_time: 0, validators: vec![], signature: vec![] })
+      Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
     };
 
     // non-conflicting data should fail(Proposal)
     {
-      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x11]))).await;
-      let signed_2 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x11]))).await;
+      let signed_1 = signed_from_data::<N>(
+        signer.clone().into(),
+        signer_id,
+        0,
+        0,
+        Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x11])),
+      )
+      .await;
+      let signed_2 = signed_from_data::<N>(
+        signer.clone().into(),
+        signer_id,
+        0,
+        0,
+        Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x11])),
+      )
+      .await;
       let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
 
       assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
@@ -185,8 +224,22 @@ async_sequential!(
 
     // conflicting data should pass(Proposal)
     {
-      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x11]))).await;
-      let signed_2 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x22]))).await;
+      let signed_1 = signed_from_data::<N>(
+        signer.clone().into(),
+        signer_id,
+        0,
+        0,
+        Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x11])),
+      )
+      .await;
+      let signed_2 = signed_from_data::<N>(
+        signer.clone().into(),
+        signer_id,
+        0,
+        0,
+        Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x22])),
+      )
+      .await;
       let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
 
       assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_ok());
@@ -196,8 +249,22 @@ async_sequential!(
     {
       let block_id_1 = [0u8; 32];
       let block_id_2 = block_id_1.clone();
-      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Prevote(Some(block_id_1))).await;
-      let signed_2 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Prevote(Some(block_id_2))).await;
+      let signed_1 = signed_from_data::<N>(
+        signer.clone().into(),
+        signer_id,
+        0,
+        0,
+        Data::Prevote(Some(block_id_1)),
+      )
+      .await;
+      let signed_2 = signed_from_data::<N>(
+        signer.clone().into(),
+        signer_id,
+        0,
+        0,
+        Data::Prevote(Some(block_id_2)),
+      )
+      .await;
       let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
 
       assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
@@ -207,8 +274,22 @@ async_sequential!(
     {
       let block_id_1 = [0u8; 32];
       let block_id_2 = [1u8; 32];
-      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Prevote(Some(block_id_1))).await;
-      let signed_2 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Prevote(Some(block_id_2))).await;
+      let signed_1 = signed_from_data::<N>(
+        signer.clone().into(),
+        signer_id,
+        0,
+        0,
+        Data::Prevote(Some(block_id_1)),
+      )
+      .await;
+      let signed_2 = signed_from_data::<N>(
+        signer.clone().into(),
+        signer_id,
+        0,
+        0,
+        Data::Prevote(Some(block_id_2)),
+      )
+      .await;
       let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
 
       assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_ok());
@@ -219,8 +300,22 @@ async_sequential!(
       let block_id_1 = [0u8; 32];
       let block_id_2 = block_id_1.clone();
       let sig = signer.sign(&block_id_1).await; // signature doesn't matter
-      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Precommit(Some((block_id_1, sig)))).await;
-      let signed_2 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 1, Data::Precommit(Some((block_id_2, sig)))).await;
+      let signed_1 = signed_from_data::<N>(
+        signer.clone().into(),
+        signer_id,
+        0,
+        0,
+        Data::Precommit(Some((block_id_1, sig))),
+      )
+      .await;
+      let signed_2 = signed_from_data::<N>(
+        signer.clone().into(),
+        signer_id,
+        0,
+        1,
+        Data::Precommit(Some((block_id_2, sig))),
+      )
+      .await;
       let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
 
       assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
@@ -231,8 +326,22 @@ async_sequential!(
       let block_id_1 = [0u8; 32];
       let block_id_2 = [1u8; 32];
       let sig = signer.sign(&block_id_1).await; // signature doesn't matter
-      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Precommit(Some((block_id_1, sig)))).await;
-      let signed_2 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 1, Data::Precommit(Some((block_id_2, sig)))).await;
+      let signed_1 = signed_from_data::<N>(
+        signer.clone().into(),
+        signer_id,
+        0,
+        0,
+        Data::Precommit(Some((block_id_1, sig))),
+      )
+      .await;
+      let signed_2 = signed_from_data::<N>(
+        signer.clone().into(),
+        signer_id,
+        0,
+        1,
+        Data::Precommit(Some((block_id_2, sig))),
+      )
+      .await;
       let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
 
       assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_ok());
@@ -241,8 +350,10 @@ async_sequential!(
     // msgs to different block numbers should fail
     {
       let data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
-      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, data.clone()).await;
-      let signed_2 = signed_from_data::<N>(signer.clone().into(), signer_id, 1, 0, data.clone()).await;
+      let signed_1 =
+        signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, data.clone()).await;
+      let signed_2 =
+        signed_from_data::<N>(signer.clone().into(), signer_id, 1, 0, data.clone()).await;
       let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
 
       assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
@@ -251,26 +362,45 @@ async_sequential!(
     // msgs from different senders should fail
     {
       let data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
-      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, data.clone()).await;
+      let signed_1 =
+        signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, data.clone()).await;
 
-      let signer_2 = Signer::new(genesis, Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng)));
+      let signer_2 =
+        Signer::new(genesis, Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng)));
       let signed_id_2 = signer_2.validator_id().await.unwrap();
       let signed_2 = signed_from_data::<N>(signer_2.into(), signed_id_2, 0, 0, data.clone()).await;
 
       let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
 
       // update schema so that we don't fail due to invalid signature
-      let signer_g = <Ristretto as Ciphersuite>::read_G::<&[u8]>(&mut signer_id.as_slice()).unwrap();
-      let signer_g_2 = <Ristretto as Ciphersuite>::read_G::<&[u8]>(&mut signed_id_2.as_slice()).unwrap();
-      let validators = Arc::new(Validators::new(genesis, vec![(signer_g, 1), (signer_g_2, 1)]).unwrap());
+      let signer_g =
+        <Ristretto as Ciphersuite>::read_G::<&[u8]>(&mut signer_id.as_slice()).unwrap();
+      let signer_g_2 =
+        <Ristretto as Ciphersuite>::read_G::<&[u8]>(&mut signed_id_2.as_slice()).unwrap();
+      let validators =
+        Arc::new(Validators::new(genesis, vec![(signer_g, 1), (signer_g_2, 1)]).unwrap());
 
       assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
     }
 
     //  msgs with different round number should fail even with conflicting data
     {
-      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Prevote(Some([0u8; 32]))).await;
-      let signed_2 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 1, Data::Prevote(Some([1u8; 32]))).await;
+      let signed_1 = signed_from_data::<N>(
+        signer.clone().into(),
+        signer_id,
+        0,
+        0,
+        Data::Prevote(Some([0u8; 32])),
+      )
+      .await;
+      let signed_2 = signed_from_data::<N>(
+        signer.clone().into(),
+        signer_id,
+        0,
+        1,
+        Data::Prevote(Some([1u8; 32])),
+      )
+      .await;
       let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
 
       assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
@@ -278,8 +408,22 @@ async_sequential!(
 
     // msgs with different steps should fail
     {
-      let signed_1 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]))).await;
-      let signed_2 = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Prevote(Some([0u8; 32]))).await;
+      let signed_1 = signed_from_data::<N>(
+        signer.clone().into(),
+        signer_id,
+        0,
+        0,
+        Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![])),
+      )
+      .await;
+      let signed_2 = signed_from_data::<N>(
+        signer.clone().into(),
+        signer_id,
+        0,
+        0,
+        Data::Prevote(Some([0u8; 32])),
+      )
+      .await;
       let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
 
       assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());

--- a/coordinator/tributary/src/tests/transaction/tendermint.rs
+++ b/coordinator/tributary/src/tests/transaction/tendermint.rs
@@ -1,33 +1,32 @@
 use std::sync::Arc;
 
-use crate::{
-  tendermint::{
-    tx::{TendermintTx, verify_tendermint_tx},
-    Validators, TendermintNetwork, TendermintBlock, Signer,
-  },
-  ReadWrite,
-  tests::{
-    random_evidence_tx, random_vote_tx, SignedTransaction, p2p::DummyP2p, new_genesis, signer,
-    tx_from_evidence, signed_from_data,
-  },
-};
+use zeroize::Zeroizing;
+use rand::{RngCore, rngs::OsRng};
 
 use ciphersuite::{Ristretto, Ciphersuite, group::ff::Field};
 use schnorr::SchnorrSignature;
 
-use blake2::{Blake2s256, Digest};
-use rand::{RngCore, rngs::OsRng};
+use scale::Encode;
 
-use zeroize::Zeroizing;
+use tendermint::{
+  time::CanonicalInstant,
+  round::RoundData,
+  Data, SignedMessageFor, commit_msg,
+  ext::{RoundNumber, Commit, Signer as SignerTrait},
+};
 
 use serai_db::MemDb;
 
-use tendermint::{
-  Data,
-  ext::{RoundNumber, Commit, Signer as SignerTrait},
-  commit_msg,
-  round::RoundData,
-  time::CanonicalInstant,
+use crate::{
+  ReadWrite,
+  tendermint::{
+    tx::{TendermintTx, verify_tendermint_tx},
+    TendermintBlock, Signer, Validators, TendermintNetwork,
+  },
+  tests::{
+    p2p::DummyP2p, SignedTransaction, new_genesis, random_evidence_tx, random_vote_tx,
+    tendermint_meta, signed_from_data,
+  },
 };
 
 type N = TendermintNetwork<MemDb, SignedTransaction, DummyP2p>;
@@ -58,7 +57,7 @@ fn vote_tx() {
 #[tokio::test]
 async fn serialize_tendermint() {
   // make a tendermint tx with random evidence
-  let (genesis, signer, _, _) = signer().await;
+  let (genesis, signer, _, _) = tendermint_meta().await;
   let tx = random_evidence_tx::<N>(signer.into(), TendermintBlock(vec![])).await;
   let res = TendermintTx::read::<&[u8]>(&mut tx.serialize().as_ref()).unwrap();
   assert_eq!(res, tx);
@@ -70,17 +69,28 @@ async fn serialize_tendermint() {
 }
 
 #[tokio::test]
-async fn msg_signature() {
+async fn invalid_valid_round() {
   // signer
-  let (genesis, signer, signer_id, validators) = signer().await;
+  let (genesis, signer, signer_id, validators) = tendermint_meta().await;
   let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
     Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
   };
 
-  // msg
-  let data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
-  let mut signed = signed_from_data::<N>(signer.into(), signer_id, 0, 0, data).await;
-  let mut tx = tx_from_evidence::<N>(vec![signed.clone()]);
+  let valid_round_tx = |valid_round| {
+    let signer = signer.clone();
+    async move {
+      let data = Data::Proposal(valid_round, TendermintBlock(vec![]));
+      let signed = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, data).await;
+      (signed.clone(), TendermintTx::SlashEvidence((signed, None::<SignedMessageFor<N>>).encode()))
+    }
+  };
+
+  // This should be invalid evidence if a valid valid round is specified
+  let (_, tx) = valid_round_tx(None).await;
+  assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
+
+  // If an invalid valid round is specified (>= current), this should be invalid evidence
+  let (mut signed, tx) = valid_round_tx(Some(RoundNumber(0))).await;
 
   // should pass
   verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
@@ -89,326 +99,205 @@ async fn msg_signature() {
   let mut random_sig = [0u8; 64];
   OsRng.fill_bytes(&mut random_sig);
   signed.sig = random_sig;
-  tx = tx_from_evidence::<N>(vec![signed]);
+  let tx = TendermintTx::SlashEvidence((signed.clone(), None::<SignedMessageFor<N>>).encode());
 
   // should fail
   assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
 }
 
 #[tokio::test]
-async fn proposal_evidence_tx() {
-  // signer
-  let (genesis, signer, signer_id, validators) = signer().await;
-  let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
+async fn invalid_precommit_signature() {
+  let (genesis, signer, signer_id, validators) = tendermint_meta().await;
+  let commit = |i: u32| -> Option<Commit<Arc<Validators>>> {
+    assert_eq!(i, 0);
     Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
   };
 
-  // msg as valid evidence
-  let mut data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
-  let mut signed = signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, data).await;
-  let mut tx = tx_from_evidence::<N>(vec![signed]);
-
-  // should pass
-  verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
-
-  // invalid evidence(msg round number is bigger than vr)
-  data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
-  signed = signed_from_data::<N>(signer.into(), signer_id, 0, 1, data).await;
-  tx = tx_from_evidence::<N>(vec![signed]);
-
-  // should fail
-  assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
-}
-
-#[tokio::test]
-async fn precommit_evidence_tx() {
-  let (genesis, signer, signer_id, validators) = signer().await;
-  let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
-    Some(Commit::<Arc<Validators>> { end_time: 1686040916, validators: vec![], signature: vec![] })
+  let precommit = |precommit| {
+    let signer = signer.clone();
+    async move {
+      let signed =
+        signed_from_data::<N>(signer.clone().into(), signer_id, 1, 0, Data::Precommit(precommit))
+          .await;
+      (signed.clone(), TendermintTx::SlashEvidence((signed, None::<SignedMessageFor<N>>).encode()))
+    }
   };
-  let block_id = [0u8; 32];
 
-  // calculate the end time of the round 0
+  // Empty Precommit should fail.
+  assert!(verify_tendermint_tx::<N>(&precommit(None).await.1, genesis, validators.clone(), commit)
+    .is_err());
+
+  // valid precommit signature should fail.
+  let block_id = [0x22u8; 32];
   let last_end_time =
     RoundData::<N>::new(RoundNumber(0), CanonicalInstant::new(commit(0).unwrap().end_time))
       .end_time();
   let commit_msg = commit_msg(last_end_time.canonical(), block_id.as_ref());
 
-  // valid precommit msg should fail.
+  assert!(verify_tendermint_tx::<N>(
+    &precommit(Some((block_id, signer.clone().sign(&commit_msg).await))).await.1,
+    genesis,
+    validators.clone(),
+    commit
+  )
+  .is_err());
+
+  // any other signature can be used as evidence.
   {
-    let sig = signer.sign(&commit_msg).await;
-    let signed = signed_from_data::<N>(
-      signer.clone().into(),
-      signer_id,
-      1,
-      0,
-      Data::Precommit(Some((block_id, sig))),
-    )
-    .await;
-    let tx = tx_from_evidence::<N>(vec![signed]);
-
-    assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
-  }
-
-  // any other commit(invalid) can be used as evidence.
-  {
-    let sig = signer.sign(&Blake2s256::digest(commit_msg)).await;
-    let signed = signed_from_data::<N>(
-      signer.clone().into(),
-      signer_id,
-      1,
-      0,
-      Data::Precommit(Some((block_id, sig))),
-    )
-    .await;
-    let tx = tx_from_evidence::<N>(vec![signed]);
-
+    let (mut signed, tx) = precommit(Some((block_id, signer.sign(&[]).await))).await;
     verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
-  }
 
-  // Empty Precommit should fail.
-  {
-    let signed = signed_from_data::<N>(signer.into(), signer_id, 1, 0, Data::Precommit(None)).await;
-    let tx = tx_from_evidence::<N>(vec![signed]);
-
+    // So long as we can authenticate where it came from
+    let mut random_sig = [0u8; 64];
+    OsRng.fill_bytes(&mut random_sig);
+    signed.sig = random_sig;
+    let tx = TendermintTx::SlashEvidence((signed.clone(), None::<SignedMessageFor<N>>).encode());
     assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
   }
 }
 
 #[tokio::test]
-async fn prevote_evidence_tx() {
-  let (genesis, signer, signer_id, validators) = signer().await;
+async fn evidence_with_prevote() {
+  let (genesis, signer, signer_id, validators) = tendermint_meta().await;
   let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
     Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
   };
-  let block_id = [0u8; 32];
 
-  let signed =
-    signed_from_data::<N>(signer.into(), signer_id, 0, 0, Data::Prevote(Some(block_id))).await;
-  let tx = tx_from_evidence::<N>(vec![signed]);
+  let prevote = |block_id| {
+    let signer = signer.clone();
+    async move {
+      TendermintTx::SlashEvidence(
+        (
+          signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Prevote(block_id))
+            .await,
+          None::<SignedMessageFor<N>>,
+        )
+          .encode(),
+      )
+    }
+  };
 
-  // prevote can't be used as evidence
-  assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
+  // No prevote message should be valid as slash evidence at this time
+  for prevote in [prevote(None).await, prevote(Some([0x22u8; 32])).await] {
+    assert!(verify_tendermint_tx::<N>(&prevote, genesis, validators.clone(), commit).is_err());
+  }
 }
 
 #[tokio::test]
 async fn conflicting_msgs_evidence_tx() {
-  let (genesis, signer, signer_id, validators) = signer().await;
-  let commit = |_: u32| -> Option<Commit<Arc<Validators>>> {
+  let (genesis, signer, signer_id, validators) = tendermint_meta().await;
+  let commit = |i: u32| -> Option<Commit<Arc<Validators>>> {
+    assert_eq!(i, 0);
     Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
   };
 
-  // non-conflicting data should fail(Proposal)
-  {
-    let signed_1 = signed_from_data::<N>(
-      signer.clone().into(),
-      signer_id,
-      0,
-      0,
-      Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x11])),
-    )
-    .await;
-    let signed_2 = signed_from_data::<N>(
-      signer.clone().into(),
-      signer_id,
-      0,
-      0,
-      Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x11])),
-    )
-    .await;
-    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+  // Block b, round n
+  let signed_for_b_r = |block, round, data| {
+    let signer = signer.clone();
+    async move { signed_from_data::<N>(signer.clone().into(), signer_id, block, round, data).await }
+  };
 
+  // Proposal
+  {
+    // non-conflicting data should fail
+    let signed_1 = signed_for_b_r(0, 0, Data::Proposal(None, TendermintBlock(vec![0x11]))).await;
+    let tx = TendermintTx::SlashEvidence((&signed_1, Some(&signed_1)).encode());
     assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
-  }
 
-  // conflicting data should pass(Proposal)
-  {
-    let signed_1 = signed_from_data::<N>(
-      signer.clone().into(),
-      signer_id,
-      0,
-      0,
-      Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x11])),
-    )
-    .await;
-    let signed_2 = signed_from_data::<N>(
-      signer.clone().into(),
-      signer_id,
-      0,
-      0,
-      Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![0x22])),
-    )
-    .await;
-    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
-
+    // conflicting data should pass
+    let signed_2 = signed_for_b_r(0, 0, Data::Proposal(None, TendermintBlock(vec![0x22]))).await;
+    let tx = TendermintTx::SlashEvidence((&signed_1, Some(signed_2)).encode());
     verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
+
+    // Except if it has a distinct round number, as we don't check cross-round conflicts
+    // (except for Precommit)
+    let signed_2 = signed_for_b_r(0, 1, Data::Proposal(None, TendermintBlock(vec![0x22]))).await;
+    let tx = TendermintTx::SlashEvidence((&signed_1, Some(signed_2)).encode());
+    verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap_err();
+
+    // Proposals for different block numbers should also fail as evidence
+    let signed_2 = signed_for_b_r(1, 0, Data::Proposal(None, TendermintBlock(vec![0x22]))).await;
+    let tx = TendermintTx::SlashEvidence((&signed_1, Some(signed_2)).encode());
+    verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap_err();
   }
 
-  // non-conflicting data should fail(Prevote)
+  // Prevote
   {
-    let block_id_1 = [0u8; 32];
-    let block_id_2 = block_id_1;
-    let signed_1 = signed_from_data::<N>(
-      signer.clone().into(),
-      signer_id,
-      0,
-      0,
-      Data::Prevote(Some(block_id_1)),
-    )
-    .await;
-    let signed_2 = signed_from_data::<N>(
-      signer.clone().into(),
-      signer_id,
-      0,
-      0,
-      Data::Prevote(Some(block_id_2)),
-    )
-    .await;
-    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
-
+    // non-conflicting data should fail
+    let signed_1 = signed_for_b_r(0, 0, Data::Prevote(Some([0x11; 32]))).await;
+    let tx = TendermintTx::SlashEvidence((&signed_1, Some(&signed_1)).encode());
     assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
-  }
 
-  // conflicting data should pass(Prevote)
-  {
-    let block_id_1 = [0u8; 32];
-    let block_id_2 = [1u8; 32];
-    let signed_1 = signed_from_data::<N>(
-      signer.clone().into(),
-      signer_id,
-      0,
-      0,
-      Data::Prevote(Some(block_id_1)),
-    )
-    .await;
-    let signed_2 = signed_from_data::<N>(
-      signer.clone().into(),
-      signer_id,
-      0,
-      0,
-      Data::Prevote(Some(block_id_2)),
-    )
-    .await;
-    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
-
+    // conflicting data should pass
+    let signed_2 = signed_for_b_r(0, 0, Data::Prevote(Some([0x22; 32]))).await;
+    let tx = TendermintTx::SlashEvidence((&signed_1, Some(signed_2)).encode());
     verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
+
+    // Except if it has a distinct round number, as we don't check cross-round conflicts
+    // (except for Precommit)
+    let signed_2 = signed_for_b_r(0, 1, Data::Prevote(Some([0x22; 32]))).await;
+    let tx = TendermintTx::SlashEvidence((&signed_1, Some(signed_2)).encode());
+    verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap_err();
+
+    // Proposals for different block numbers should also fail as evidence
+    let signed_2 = signed_for_b_r(1, 0, Data::Prevote(Some([0x22; 32]))).await;
+    let tx = TendermintTx::SlashEvidence((&signed_1, Some(signed_2)).encode());
+    verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap_err();
   }
 
-  // non-conflicting data should fail irrespective of round number(Precommit)
+  // Precommit
   {
-    let block_id_1 = [0u8; 32];
-    let block_id_2 = block_id_1;
-    let sig = signer.sign(&block_id_1).await; // signature doesn't matter
-    let signed_1 = signed_from_data::<N>(
-      signer.clone().into(),
-      signer_id,
-      0,
-      0,
-      Data::Precommit(Some((block_id_1, sig))),
-    )
-    .await;
-    let signed_2 = signed_from_data::<N>(
-      signer.clone().into(),
-      signer_id,
-      0,
-      1,
-      Data::Precommit(Some((block_id_2, sig))),
-    )
-    .await;
-    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+    let sig = signer.sign(&[]).await; // the inner signature doesn't matter
 
+    let signed_1 = signed_for_b_r(0, 0, Data::Precommit(Some(([0x11; 32], sig)))).await;
+    let tx = TendermintTx::SlashEvidence((&signed_1, Some(&signed_1)).encode());
     assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
-  }
 
-  // conflicting data should pass irrespective of round number(Precommit)
-  {
-    let block_id_1 = [0u8; 32];
-    let block_id_2 = [1u8; 32];
-    let sig = signer.sign(&block_id_1).await; // signature doesn't matter
-    let signed_1 = signed_from_data::<N>(
-      signer.clone().into(),
-      signer_id,
-      0,
-      0,
-      Data::Precommit(Some((block_id_1, sig))),
-    )
-    .await;
-    let signed_2 = signed_from_data::<N>(
-      signer.clone().into(),
-      signer_id,
-      0,
-      1,
-      Data::Precommit(Some((block_id_2, sig))),
-    )
-    .await;
-    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
-
+    // For precommit, the round number is ignored
+    let signed_2 = signed_for_b_r(0, 1, Data::Precommit(Some(([0x22; 32], sig)))).await;
+    let tx = TendermintTx::SlashEvidence((&signed_1, Some(signed_2)).encode());
     verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).unwrap();
-  }
 
-  // msgs to different block numbers should fail
-  {
-    let data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
-    let signed_1 =
-      signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, data.clone()).await;
-    let signed_2 =
-      signed_from_data::<N>(signer.clone().into(), signer_id, 1, 0, data.clone()).await;
-    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
-
+    // Yet the block number isn't
+    let signed_2 = signed_for_b_r(1, 0, Data::Precommit(Some(([0x22; 32], sig)))).await;
+    let tx = TendermintTx::SlashEvidence((&signed_1, Some(signed_2)).encode());
     assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
   }
 
   // msgs from different senders should fail
   {
-    let data = Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![]));
-    let signed_1 =
-      signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, data.clone()).await;
+    let signed_1 = signed_for_b_r(0, 0, Data::Proposal(None, TendermintBlock(vec![0x11]))).await;
 
     let signer_2 =
       Signer::new(genesis, Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng)));
     let signed_id_2 = signer_2.validator_id().await.unwrap();
-    let signed_2 = signed_from_data::<N>(signer_2.into(), signed_id_2, 0, 0, data.clone()).await;
+    let signed_2 = signed_from_data::<N>(
+      signer_2.into(),
+      signed_id_2,
+      0,
+      0,
+      Data::Proposal(None, TendermintBlock(vec![0x22])),
+    )
+    .await;
 
-    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
+    let tx = TendermintTx::SlashEvidence((signed_1, Some(signed_2)).encode());
 
     // update schema so that we don't fail due to invalid signature
-    let signer_g = <Ristretto as Ciphersuite>::read_G::<&[u8]>(&mut signer_id.as_slice()).unwrap();
-    let signer_g_2 =
+    let signer_pub =
+      <Ristretto as Ciphersuite>::read_G::<&[u8]>(&mut signer_id.as_slice()).unwrap();
+    let signer_pub_2 =
       <Ristretto as Ciphersuite>::read_G::<&[u8]>(&mut signed_id_2.as_slice()).unwrap();
     let validators =
-      Arc::new(Validators::new(genesis, vec![(signer_g, 1), (signer_g_2, 1)]).unwrap());
+      Arc::new(Validators::new(genesis, vec![(signer_pub, 1), (signer_pub_2, 1)]).unwrap());
 
     assert!(verify_tendermint_tx::<N>(&tx, genesis, validators, commit).is_err());
   }
 
-  //  msgs with different round number should fail even with conflicting data
-  {
-    let signed_1 =
-      signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Prevote(Some([0u8; 32])))
-        .await;
-    let signed_2 =
-      signed_from_data::<N>(signer.clone().into(), signer_id, 0, 1, Data::Prevote(Some([1u8; 32])))
-        .await;
-    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
-
-    assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
-  }
-
   // msgs with different steps should fail
   {
-    let signed_1 = signed_from_data::<N>(
-      signer.clone().into(),
-      signer_id,
-      0,
-      0,
-      Data::Proposal(Some(RoundNumber(0)), TendermintBlock(vec![])),
-    )
-    .await;
-    let signed_2 =
-      signed_from_data::<N>(signer.clone().into(), signer_id, 0, 0, Data::Prevote(Some([0u8; 32])))
-        .await;
-    let tx = tx_from_evidence::<N>(vec![signed_1, signed_2]);
-
+    let signed_1 = signed_for_b_r(0, 0, Data::Proposal(None, TendermintBlock(vec![]))).await;
+    let signed_2 = signed_for_b_r(0, 0, Data::Prevote(None)).await;
+    let tx = TendermintTx::SlashEvidence((signed_1, Some(signed_2)).encode());
     assert!(verify_tendermint_tx::<N>(&tx, genesis, validators.clone(), commit).is_err());
   }
 }

--- a/coordinator/tributary/src/transaction.rs
+++ b/coordinator/tributary/src/transaction.rs
@@ -92,6 +92,10 @@ pub enum TransactionKind<'a> {
   Provided(&'static str),
 
   /// An unsigned transaction, only able to be included by the block producer.
+  ///
+  /// Once an Unsigned transaction is included on-chain, it may not be included again. In order to
+  /// have multiple Unsigned transactions with the same values included on-chain, some distinct
+  /// nonce must be included in order to cause a distinct hash.
   Unsigned,
 
   /// A signed transaction.

--- a/coordinator/tributary/src/transaction.rs
+++ b/coordinator/tributary/src/transaction.rs
@@ -98,6 +98,8 @@ pub enum TransactionKind<'a> {
   Signed(&'a Signed),
 }
 
+// TODO: Should this be renamed TransactionTrait now that a literal Transaction exists?
+// Or should the literal Transaction be renamed to Event?
 pub trait Transaction: 'static + Send + Sync + Clone + Eq + Debug + ReadWrite {
   /// Return what type of transaction this is.
   fn kind(&self) -> TransactionKind<'_>;

--- a/coordinator/tributary/tendermint/Cargo.toml
+++ b/coordinator/tributary/tendermint/Cargo.toml
@@ -14,6 +14,8 @@ thiserror = "1"
 hex = "0.4"
 log = "0.4"
 
+sha3 = "0.10"
+
 parity-scale-codec = { version = "3", features = ["derive"] }
 
 futures = "0.3"

--- a/coordinator/tributary/tendermint/Cargo.toml
+++ b/coordinator/tributary/tendermint/Cargo.toml
@@ -14,8 +14,6 @@ thiserror = "1"
 hex = "0.4"
 log = "0.4"
 
-sha3 = "0.10"
-
 parity-scale-codec = { version = "3", features = ["derive"] }
 
 futures = "0.3"

--- a/coordinator/tributary/tendermint/src/ext.rs
+++ b/coordinator/tributary/tendermint/src/ext.rs
@@ -45,8 +45,6 @@ pub trait Signer: Send + Sync {
   async fn validator_id(&self) -> Option<Self::ValidatorId>;
   /// Sign a signature with the current validator's private key.
   async fn sign(&self, msg: &[u8]) -> Self::Signature;
-  /// Return an empty signature.
-  async fn empty_signature(&self) -> Self::Signature;
 }
 
 #[async_trait]
@@ -60,10 +58,6 @@ impl<S: Signer> Signer for Arc<S> {
 
   async fn sign(&self, msg: &[u8]) -> Self::Signature {
     self.as_ref().sign(msg).await
-  }
-
-  async fn empty_signature(&self) -> Self::Signature {
-    self.as_ref().empty_signature().await
   }
 }
 

--- a/coordinator/tributary/tendermint/src/ext.rs
+++ b/coordinator/tributary/tendermint/src/ext.rs
@@ -61,7 +61,7 @@ impl<S: Signer> Signer for Arc<S> {
   async fn sign(&self, msg: &[u8]) -> Self::Signature {
     self.as_ref().sign(msg).await
   }
-  
+
   async fn empty_signature(&self) -> Self::Signature {
     self.as_ref().empty_signature().await
   }

--- a/coordinator/tributary/tendermint/src/lib.rs
+++ b/coordinator/tributary/tendermint/src/lib.rs
@@ -17,10 +17,10 @@ use futures::{
 };
 use tokio::time::sleep;
 
-mod time;
+pub mod time;
 use time::{sys_time, CanonicalInstant};
 
-mod round;
+pub mod round;
 
 mod block;
 use block::BlockData;
@@ -31,19 +31,19 @@ pub(crate) mod message_log;
 pub mod ext;
 use ext::*;
 
-pub(crate) fn commit_msg(end_time: u64, id: &[u8]) -> Vec<u8> {
+pub fn commit_msg(end_time: u64, id: &[u8]) -> Vec<u8> {
   [&end_time.to_le_bytes(), id].concat().to_vec()
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Encode, Decode)]
-enum Step {
+pub enum Step {
   Propose,
   Prevote,
   Precommit,
 }
 
 #[derive(Clone, Debug, Encode, Decode, Eq)]
-enum Data<B: Block, S: Signature> {
+pub enum Data<B: Block, S: Signature> {
   Proposal(Option<RoundNumber>, B),
   Prevote(Option<B::Id>),
   Precommit(Option<(B::Id, S)>),
@@ -64,7 +64,7 @@ impl<B: Block, S: Signature> PartialEq for Data<B, S> {
 }
 
 impl<B: Block, S: Signature> Data<B, S> {
-  fn step(&self) -> Step {
+  pub fn step(&self) -> Step {
     match self {
       Data::Proposal(..) => Step::Propose,
       Data::Prevote(..) => Step::Prevote,
@@ -74,20 +74,19 @@ impl<B: Block, S: Signature> Data<B, S> {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Encode, Decode)]
-struct Message<V: ValidatorId, B: Block, S: Signature> {
-  sender: V,
+pub struct Message<V: ValidatorId, B: Block, S: Signature> {
+  pub sender: V,
+  pub block: BlockNumber,
+  pub round: RoundNumber,
 
-  block: BlockNumber,
-  round: RoundNumber,
-
-  data: Data<B, S>,
+  pub data: Data<B, S>,
 }
 
 /// A signed Tendermint consensus message to be broadcast to the other validators.
 #[derive(Clone, PartialEq, Eq, Debug, Encode, Decode)]
 pub struct SignedMessage<V: ValidatorId, B: Block, S: Signature> {
-  msg: Message<V, B, S>,
-  sig: S,
+  pub msg: Message<V, B, S>,
+  pub sig: S,
 }
 
 impl<V: ValidatorId, B: Block, S: Signature> SignedMessage<V, B, S> {

--- a/coordinator/tributary/tendermint/src/lib.rs
+++ b/coordinator/tributary/tendermint/src/lib.rs
@@ -112,7 +112,7 @@ enum TendermintError<N: Network> {
 }
 
 // Type aliases to abstract over generic hell
-pub(crate) type DataFor<N> =
+pub type DataFor<N> =
   Data<<N as Network>::Block, <<N as Network>::SignatureScheme as SignatureScheme>::Signature>;
 pub(crate) type MessageFor<N> = Message<
   <N as Network>::ValidatorId,

--- a/coordinator/tributary/tendermint/src/message_log.rs
+++ b/coordinator/tributary/tendermint/src/message_log.rs
@@ -2,12 +2,12 @@ use std::{sync::Arc, collections::HashMap};
 
 use log::debug;
 
-use crate::{ext::*, RoundNumber, Step, Data, DataFor, MessageFor, TendermintError};
+use crate::{ext::*, RoundNumber, Step, Data, DataFor, TendermintError, SignedMessageFor};
 
-type RoundLog<N> = HashMap<<N as Network>::ValidatorId, HashMap<Step, DataFor<N>>>;
+type RoundLog<N> = HashMap<<N as Network>::ValidatorId, HashMap<Step, SignedMessageFor<N>>>;
 pub(crate) struct MessageLog<N: Network> {
   weights: Arc<N::Weights>,
-  precommitted: HashMap<N::ValidatorId, <N::Block as Block>::Id>,
+  precommitted: HashMap<N::ValidatorId, SignedMessageFor<N>>,
   pub(crate) log: HashMap<RoundNumber, RoundLog<N>>,
 }
 
@@ -19,36 +19,41 @@ impl<N: Network> MessageLog<N> {
   // Returns true if it's a new message
   pub(crate) fn log(
     &mut self,
-    msg: MessageFor<N>,
-  ) -> Result<bool, TendermintError<N::ValidatorId>> {
+    signed: SignedMessageFor<N>,
+  ) -> Result<bool, TendermintError<N>> {
+    let msg = &signed.msg;
     let round = self.log.entry(msg.round).or_insert_with(HashMap::new);
     let msgs = round.entry(msg.sender).or_insert_with(HashMap::new);
 
     // Handle message replays without issue. It's only multiple messages which is malicious
     let step = msg.data.step();
     if let Some(existing) = msgs.get(&step) {
-      if existing != &msg.data {
+      if existing.msg.data != msg.data {
         debug!(
           target: "tendermint",
           "Validator sent multiple messages for the same block + round + step"
         );
-        Err(TendermintError::Malicious(msg.sender))?;
+        Err(TendermintError::Malicious(msg.sender, Some(existing.clone())))?;
       }
       return Ok(false);
     }
 
     // If they already precommitted to a distinct hash, error
-    if let Data::Precommit(Some((hash, _))) = &msg.data {
+    if let Data::Precommit(Some((hash, _))) = msg.data {
       if let Some(prev) = self.precommitted.get(&msg.sender) {
-        if hash != prev {
-          debug!(target: "tendermint", "Validator precommitted to multiple blocks");
-          Err(TendermintError::Malicious(msg.sender))?;
+        if let Data::Precommit(Some((pre_hash, _))) = prev.msg.data {
+          if hash != pre_hash {
+            debug!(target: "tendermint", "Validator precommitted to multiple blocks");
+            Err(TendermintError::Malicious(msg.sender, Some(prev.clone())))?;
+          }
+        } else {
+          panic!("this should have never happened!");
         }
       }
-      self.precommitted.insert(msg.sender, *hash);
+      self.precommitted.insert(msg.sender, signed.clone());
     }
 
-    msgs.insert(step, msg.data);
+    msgs.insert(step, signed);
     Ok(true)
   }
 
@@ -61,7 +66,7 @@ impl<N: Network> MessageLog<N> {
       if let Some(msg) = msgs.get(&data.step()) {
         let validator_weight = self.weights.weight(*participant);
         participating += validator_weight;
-        if &data == msg {
+        if data == msg.msg.data {
           weight += validator_weight;
         }
       }
@@ -102,7 +107,7 @@ impl<N: Network> MessageLog<N> {
     round: RoundNumber,
     sender: N::ValidatorId,
     step: Step,
-  ) -> Option<&DataFor<N>> {
+  ) -> Option<&SignedMessageFor<N>> {
     self.log.get(&round).and_then(|round| round.get(&sender).and_then(|msgs| msgs.get(&step)))
   }
 }

--- a/coordinator/tributary/tendermint/src/message_log.rs
+++ b/coordinator/tributary/tendermint/src/message_log.rs
@@ -17,10 +17,7 @@ impl<N: Network> MessageLog<N> {
   }
 
   // Returns true if it's a new message
-  pub(crate) fn log(
-    &mut self,
-    signed: SignedMessageFor<N>,
-  ) -> Result<bool, TendermintError<N>> {
+  pub(crate) fn log(&mut self, signed: SignedMessageFor<N>) -> Result<bool, TendermintError<N>> {
     let msg = &signed.msg;
     let round = self.log.entry(msg.round).or_insert_with(HashMap::new);
     let msgs = round.entry(msg.sender).or_insert_with(HashMap::new);

--- a/coordinator/tributary/tendermint/src/message_log.rs
+++ b/coordinator/tributary/tendermint/src/message_log.rs
@@ -38,13 +38,13 @@ impl<N: Network> MessageLog<N> {
     // If they already precommitted to a distinct hash, error
     if let Data::Precommit(Some((hash, _))) = msg.data {
       if let Some(prev) = self.precommitted.get(&msg.sender) {
-        if let Data::Precommit(Some((pre_hash, _))) = prev.msg.data {
-          if hash != pre_hash {
+        if let Data::Precommit(Some((prev_hash, _))) = prev.msg.data {
+          if hash != prev_hash {
             debug!(target: "tendermint", "Validator precommitted to multiple blocks");
             Err(TendermintError::Malicious(msg.sender, Some(prev.clone())))?;
           }
         } else {
-          panic!("this should have never happened!");
+          panic!("message in precommitted wasn't Precommit");
         }
       }
       self.precommitted.insert(msg.sender, signed.clone());

--- a/coordinator/tributary/tendermint/src/round.rs
+++ b/coordinator/tributary/tendermint/src/round.rs
@@ -13,16 +13,16 @@ use crate::{
   ext::{RoundNumber, Network},
 };
 
-pub(crate) struct RoundData<N: Network> {
+pub struct RoundData<N: Network> {
   _network: PhantomData<N>,
-  pub(crate) number: RoundNumber,
-  pub(crate) start_time: CanonicalInstant,
-  pub(crate) step: Step,
-  pub(crate) timeouts: HashMap<Step, Instant>,
+  pub number: RoundNumber,
+  pub start_time: CanonicalInstant,
+  pub step: Step,
+  pub timeouts: HashMap<Step, Instant>,
 }
 
 impl<N: Network> RoundData<N> {
-  pub(crate) fn new(number: RoundNumber, start_time: CanonicalInstant) -> Self {
+  pub fn new(number: RoundNumber, start_time: CanonicalInstant) -> Self {
     RoundData {
       _network: PhantomData,
       number,
@@ -46,7 +46,7 @@ impl<N: Network> RoundData<N> {
     self.start_time + offset
   }
 
-  pub(crate) fn end_time(&self) -> CanonicalInstant {
+  pub fn end_time(&self) -> CanonicalInstant {
     self.timeout(Step::Precommit)
   }
 

--- a/coordinator/tributary/tendermint/src/time.rs
+++ b/coordinator/tributary/tendermint/src/time.rs
@@ -2,7 +2,7 @@ use core::ops::Add;
 use std::time::{UNIX_EPOCH, SystemTime, Instant, Duration};
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub(crate) struct CanonicalInstant {
+pub struct CanonicalInstant {
   /// Time since the epoch.
   time: u64,
   /// An Instant synchronized with the above time.
@@ -14,7 +14,7 @@ pub(crate) fn sys_time(time: u64) -> SystemTime {
 }
 
 impl CanonicalInstant {
-  pub(crate) fn new(time: u64) -> CanonicalInstant {
+  pub fn new(time: u64) -> CanonicalInstant {
     // This is imprecise yet should be precise enough, as it'll resolve within a few ms
     let instant_now = Instant::now();
     let sys_now = SystemTime::now();
@@ -27,11 +27,11 @@ impl CanonicalInstant {
     CanonicalInstant { time, instant: synced_instant }
   }
 
-  pub(crate) fn canonical(&self) -> u64 {
+  pub fn canonical(&self) -> u64 {
     self.time
   }
 
-  pub(crate) fn instant(&self) -> Instant {
+  pub fn instant(&self) -> Instant {
     self.instant
   }
 }

--- a/coordinator/tributary/tendermint/tests/ext.rs
+++ b/coordinator/tributary/tendermint/tests/ext.rs
@@ -11,8 +11,8 @@ use futures::SinkExt;
 use tokio::{sync::RwLock, time::sleep};
 
 use tendermint_machine::{
-  ext::*, SignedMessageFor, SyncedBlockSender, SyncedBlockResultReceiver, MessageSender, SlashEvent,
-  TendermintMachine, TendermintHandle,
+  ext::*, SignedMessageFor, SyncedBlockSender, SyncedBlockResultReceiver, MessageSender,
+  SlashEvent, TendermintMachine, TendermintHandle,
 };
 
 type TestValidatorId = u16;

--- a/coordinator/tributary/tendermint/tests/ext.rs
+++ b/coordinator/tributary/tendermint/tests/ext.rs
@@ -34,10 +34,6 @@ impl Signer for TestSigner {
     sig[2 .. (2 + 30.min(msg.len()))].copy_from_slice(&msg[.. 30.min(msg.len())]);
     sig
   }
-
-  async fn empty_signature(&self) -> Self::Signature {
-    [0; 32]
-  }
 }
 
 #[derive(Clone)]

--- a/crypto/schnorr/src/lib.rs
+++ b/crypto/schnorr/src/lib.rs
@@ -45,12 +45,6 @@ pub struct SchnorrSignature<C: Ciphersuite> {
   pub s: C::F,
 }
 
-impl<C: Ciphersuite> Default for SchnorrSignature<C> {
-  fn default() -> Self {
-    SchnorrSignature { R: C::generator(), s: C::F::ZERO }
-  }
-}
-
 impl<C: Ciphersuite> SchnorrSignature<C> {
   /// Read a SchnorrSignature from something implementing Read.
   pub fn read<R: Read>(reader: &mut R) -> io::Result<Self> {

--- a/crypto/schnorr/src/lib.rs
+++ b/crypto/schnorr/src/lib.rs
@@ -45,6 +45,12 @@ pub struct SchnorrSignature<C: Ciphersuite> {
   pub s: C::F,
 }
 
+impl<C: Ciphersuite> Default for SchnorrSignature<C> {
+  fn default() -> Self {
+    SchnorrSignature { R: C::generator(), s: C::F::ZERO }
+  }
+}
+
 impl<C: Ciphersuite> SchnorrSignature<C> {
   /// Read a SchnorrSignature from something implementing Read.
   pub fn read<R: Read>(reader: &mut R) -> io::Result<Self> {


### PR DESCRIPTION
This is a **draft** pr to slash validators with bad behavior. Comments and/or reviews are appreciated.

in tributary, tendermint is used for the consensus. And there are bunch of defined invalid or bad behaviors for validators that participate in the tendermint consensus algorithm. We slash those nodes to disincentive those behaviors.

In this case, once a node catches an invalid/bad behavior from another validator, it either sends an evidence for this bad  behavior or a vote to slash the bad node. If an evidence provided and valid, it is solely enough to slash the node by the network participants even if other nodes didn't see this behavior. Once the evidence is on the chain, the bad node is slashed. If a vote is sent, then we wait vote from 2/3 of the nodes to slash the node.

For now following points are completed;

- create a special tx type to publish bad validator behavior data and/or votes for slashing
- modify the tributary to hold the both app txs and this integral tx
- ignore unsigned tendermint tx replays
- verify that provided evidence was actually valid(sender isn't falsely try to claim someone else with invalid evidence).
- scan the slash evidence/votes in the chain
- support unsigned app txs while at it(not really related to this pr but hey! why not)
- enforce provided, unsigned, signed tx ordering within a block
- add unit tests for tendermint tx validation
- update existing mempool/blockchain tests for new tx types