### PR TITLE
monero-serai: fee calculation parity with Monero's wallet2

### DIFF
--- a/coins/monero/src/ringct/bulletproofs/mod.rs
+++ b/coins/monero/src/ringct/bulletproofs/mod.rs
@@ -37,14 +37,16 @@ pub enum Bulletproofs {
 }
 
 impl Bulletproofs {
-  pub(crate) fn fee_weight(plus: bool, outputs: usize) -> usize {
-    #[allow(non_snake_case)]
-    let (bp_clawback, LR_len) = Bulletproofs::calculate_bp_clawback(plus, outputs);
-    32 * (Bulletproofs::bp_fields(plus) + (2 * LR_len)) + 2 + bp_clawback
+  fn bp_fields(plus: bool) -> usize {
+    if plus {
+      6
+    } else {
+      9
+    }
   }
 
   // https://github.com/monero-project/monero/blob/94e67bf96bbc010241f29ada6abc89f49a81759c/
-  // src/cryptonote_basic/cryptonote_format_utils.cpp#L106-L124
+  //   src/cryptonote_basic/cryptonote_format_utils.cpp#L106-L124
   pub(crate) fn calculate_bp_clawback(plus: bool, n_outputs: usize) -> (usize, usize) {
     #[allow(non_snake_case)]
     let mut LR_len = 0;
@@ -66,12 +68,10 @@ impl Bulletproofs {
     (bp_clawback, LR_len)
   }
 
-  fn bp_fields(plus: bool) -> usize {
-    if plus {
-      6
-    } else {
-      9
-    }
+  pub(crate) fn fee_weight(plus: bool, outputs: usize) -> usize {
+    #[allow(non_snake_case)]
+    let (bp_clawback, LR_len) = Bulletproofs::calculate_bp_clawback(plus, outputs);
+    32 * (Bulletproofs::bp_fields(plus) + (2 * LR_len)) + 2 + bp_clawback
   }
 
   /// Prove the list of commitments are within [0 .. 2^64).

--- a/coins/monero/src/ringct/mod.rs
+++ b/coins/monero/src/ringct/mod.rs
@@ -124,8 +124,8 @@ pub struct RctBase {
 }
 
 impl RctBase {
-  // 1 byte for the RCT signature type
   pub(crate) fn fee_weight(outputs: usize, fee: u64) -> usize {
+    // 1 byte for the RCT signature type
     1 + (outputs * (8 + 32)) + varint_len(fee)
   }
 
@@ -212,7 +212,7 @@ pub enum RctPrunable {
 
 impl RctPrunable {
   pub(crate) fn fee_weight(protocol: Protocol, inputs: usize, outputs: usize) -> usize {
-    // 1 byte for number of bps (technically a varint)
+    // 1 byte for number of BPs (technically a VarInt, yet there's always just zero or one)
     1 + Bulletproofs::fee_weight(protocol.bp_plus(), outputs) +
       (inputs * (Clsag::fee_weight(protocol.ring_len()) + 32))
   }

--- a/coins/monero/src/ringct/mod.rs
+++ b/coins/monero/src/ringct/mod.rs
@@ -124,8 +124,9 @@ pub struct RctBase {
 }
 
 impl RctBase {
-  pub(crate) fn fee_weight(outputs: usize) -> usize {
-    1 + 8 + (outputs * (8 + 32))
+  // 1 byte for the RCT signature type
+  pub(crate) fn fee_weight(outputs: usize, fee: u64) -> usize {
+    1 + (outputs * (8 + 32)) + varint_len(fee)
   }
 
   pub fn write<W: Write>(&self, w: &mut W, rct_type: RctType) -> io::Result<()> {
@@ -211,6 +212,7 @@ pub enum RctPrunable {
 
 impl RctPrunable {
   pub(crate) fn fee_weight(protocol: Protocol, inputs: usize, outputs: usize) -> usize {
+    // 1 byte for number of bps (technically a varint)
     1 + Bulletproofs::fee_weight(protocol.bp_plus(), outputs) +
       (inputs * (Clsag::fee_weight(protocol.ring_len()) + 32))
   }
@@ -377,8 +379,8 @@ impl RctSignatures {
     }
   }
 
-  pub(crate) fn fee_weight(protocol: Protocol, inputs: usize, outputs: usize) -> usize {
-    RctBase::fee_weight(outputs) + RctPrunable::fee_weight(protocol, inputs, outputs)
+  pub(crate) fn fee_weight(protocol: Protocol, inputs: usize, outputs: usize, fee: u64) -> usize {
+    RctBase::fee_weight(outputs, fee) + RctPrunable::fee_weight(protocol, inputs, outputs)
   }
 
   pub fn write<W: Write>(&self, w: &mut W) -> io::Result<()> {

--- a/coins/monero/src/rpc/mod.rs
+++ b/coins/monero/src/rpc/mod.rs
@@ -19,7 +19,7 @@ use crate::{
   serialize::*,
   transaction::{Input, Timelock, Transaction},
   block::Block,
-  wallet::{Fee, FeePriority},
+  wallet::{FeePriority, Fee},
 };
 
 #[cfg(feature = "http_rpc")]
@@ -29,7 +29,7 @@ pub use http::*;
 
 // Number of blocks the fee estimate will be valid for
 // https://github.com/monero-project/monero/blob/94e67bf96bbc010241f29ada6abc89f49a81759c/
-// src/wallet/wallet2.cpp#L121
+//   src/wallet/wallet2.cpp#L121
 const GRACE_BLOCKS_FOR_FEE_ESTIMATE: u64 = 10;
 
 #[derive(Deserialize, Debug)]
@@ -347,7 +347,6 @@ impl<R: RpcConnection> Rpc<R> {
       txid: [u8; 32],
     }
 
-    #[allow(dead_code)]
     #[derive(Deserialize, Debug)]
     struct OIndexes {
       o_indexes: Vec<u64>,
@@ -479,13 +478,11 @@ impl<R: RpcConnection> Rpc<R> {
     from: usize,
     to: usize,
   ) -> Result<Vec<u64>, RpcError> {
-    #[allow(dead_code)]
     #[derive(Deserialize, Debug)]
     struct Distribution {
       distribution: Vec<u64>,
     }
 
-    #[allow(dead_code)]
     #[derive(Deserialize, Debug)]
     struct Distributions {
       distributions: Vec<Distribution>,
@@ -566,14 +563,50 @@ impl<R: RpcConnection> Rpc<R> {
       .collect()
   }
 
-  /// Get the currently estimated fee from the node. This may be manipulated to unsafe levels and
-  /// MUST be sanity checked.
+  async fn get_fee_v14(&self, priority: FeePriority) -> Result<Fee, RpcError> {
+    #[derive(Deserialize, Debug)]
+    struct FeeResponseV14 {
+      status: String,
+      fee: u64,
+      quantization_mask: u64,
+    }
+
+    // https://github.com/monero-project/monero/blob/94e67bf96bbc010241f29ada6abc89f49a81759c/
+    //   src/wallet/wallet2.cpp#L7569-L7584
+    // https://github.com/monero-project/monero/blob/94e67bf96bbc010241f29ada6abc89f49a81759c/
+    //   src/wallet/wallet2.cpp#L7660-L7661
+    let priority_idx =
+      usize::try_from(if priority.fee_priority() == 0 { 1 } else { priority.fee_priority() - 1 })
+        .map_err(|_| RpcError::InvalidPriority)?;
+    let multipliers = [1, 5, 25, 1000];
+    if priority_idx >= multipliers.len() {
+      // though not an RPC error, it seems sensible to treat as such
+      Err(RpcError::InvalidPriority)?;
+    }
+    let fee_multiplier = multipliers[priority_idx];
+
+    let res: FeeResponseV14 = self
+      .json_rpc_call(
+        "get_fee_estimate",
+        Some(json!({ "grace_blocks": GRACE_BLOCKS_FOR_FEE_ESTIMATE })),
+      )
+      .await?;
+
+    if res.status != "OK" {
+      Err(RpcError::InvalidFee)?;
+    }
+
+    Ok(Fee { per_weight: res.fee * fee_multiplier, mask: res.quantization_mask })
+  }
+
+  /// Get the currently estimated fee from the node.
+  ///
+  /// This may be manipulated to unsafe levels and MUST be sanity checked.
   // TODO: Take a sanity check argument
   pub async fn get_fee(&self, protocol: Protocol, priority: FeePriority) -> Result<Fee, RpcError> {
-    // TODO: implement wallet2's adjust_priority which by default automatically
-    // uses a lower priority than provided depending on the backlog in the pool
+    // TODO: Implement wallet2's adjust_priority which by default automatically uses a lower
+    // priority than provided depending on the backlog in the pool
     if protocol.v16_fee() {
-      #[allow(dead_code)]
       #[derive(Deserialize, Debug)]
       struct FeeResponse {
         status: String,
@@ -607,43 +640,6 @@ impl<R: RpcConnection> Rpc<R> {
     } else {
       self.get_fee_v14(priority).await
     }
-  }
-
-  pub async fn get_fee_v14(&self, priority: FeePriority) -> Result<Fee, RpcError> {
-    #[allow(dead_code)]
-    #[derive(Deserialize, Debug)]
-    struct FeeResponseV14 {
-      status: String,
-      fee: u64,
-      quantization_mask: u64,
-    }
-
-    // https://github.com/monero-project/monero/blob/94e67bf96bbc010241f29ada6abc89f49a81759c/
-    // src/wallet/wallet2.cpp#L7569-L7584
-    // https://github.com/monero-project/monero/blob/94e67bf96bbc010241f29ada6abc89f49a81759c/
-    // src/wallet/wallet2.cpp#L7660-L7661
-    let priority_idx =
-      usize::try_from(if priority.fee_priority() == 0 { 1 } else { priority.fee_priority() - 1 })
-        .map_err(|_| RpcError::InvalidPriority)?;
-    let multipliers: Vec<u64> = vec![1, 5, 25, 1000];
-    if priority_idx >= multipliers.len() {
-      // though not an RPC error, it seems sensible to treat as such
-      Err(RpcError::InvalidPriority)?;
-    }
-    let fee_multiplier = multipliers[priority_idx];
-
-    let res: FeeResponseV14 = self
-      .json_rpc_call(
-        "get_fee_estimate",
-        Some(json!({ "grace_blocks": GRACE_BLOCKS_FOR_FEE_ESTIMATE })),
-      )
-      .await?;
-
-    if res.status != "OK" {
-      Err(RpcError::InvalidFee)?;
-    }
-
-    Ok(Fee { per_weight: res.fee * fee_multiplier, mask: res.quantization_mask })
   }
 
   pub async fn publish_transaction(&self, tx: &Transaction) -> Result<(), RpcError> {

--- a/coins/monero/src/rpc/mod.rs
+++ b/coins/monero/src/rpc/mod.rs
@@ -19,13 +19,18 @@ use crate::{
   serialize::*,
   transaction::{Input, Timelock, Transaction},
   block::Block,
-  wallet::Fee,
+  wallet::{Fee, FeePriority},
 };
 
 #[cfg(feature = "http_rpc")]
 mod http;
 #[cfg(feature = "http_rpc")]
 pub use http::*;
+
+// Number of blocks the fee estimate will be valid for
+// https://github.com/monero-project/monero/blob/94e67bf96bbc010241f29ada6abc89f49a81759c/
+// src/wallet/wallet2.cpp#L121
+const GRACE_BLOCKS_FOR_FEE_ESTIMATE: u64 = 10;
 
 #[derive(Deserialize, Debug)]
 pub struct EmptyResponse {}
@@ -66,6 +71,10 @@ pub enum RpcError {
   PrunedTransaction,
   #[cfg_attr(feature = "std", error("invalid transaction ({0:?})"))]
   InvalidTransaction([u8; 32]),
+  #[cfg_attr(feature = "std", error("unexpected fee response"))]
+  InvalidFee,
+  #[cfg_attr(feature = "std", error("invalid priority"))]
+  InvalidPriority,
 }
 
 fn rpc_hex(value: &str) -> Result<Vec<u8>, RpcError> {
@@ -560,16 +569,81 @@ impl<R: RpcConnection> Rpc<R> {
   /// Get the currently estimated fee from the node. This may be manipulated to unsafe levels and
   /// MUST be sanity checked.
   // TODO: Take a sanity check argument
-  pub async fn get_fee(&self) -> Result<Fee, RpcError> {
+  pub async fn get_fee(&self, protocol: Protocol, priority: FeePriority) -> Result<Fee, RpcError> {
+    // TODO: implement wallet2's adjust_priority which by default automatically
+    // uses a lower priority than provided depending on the backlog in the pool
+    if protocol.v16_fee() {
+      #[allow(dead_code)]
+      #[derive(Deserialize, Debug)]
+      struct FeeResponse {
+        status: String,
+        fees: Vec<u64>,
+        quantization_mask: u64,
+      }
+
+      let res: FeeResponse = self
+        .json_rpc_call(
+          "get_fee_estimate",
+          Some(json!({ "grace_blocks": GRACE_BLOCKS_FOR_FEE_ESTIMATE })),
+        )
+        .await?;
+
+      // https://github.com/monero-project/monero/blob/94e67bf96bbc010241f29ada6abc89f49a81759c/
+      // src/wallet/wallet2.cpp#L7615-L7620
+      let priority_idx = usize::try_from(if priority.fee_priority() >= 4 {
+        3
+      } else {
+        priority.fee_priority().saturating_sub(1)
+      })
+      .map_err(|_| RpcError::InvalidPriority)?;
+
+      if res.status != "OK" {
+        Err(RpcError::InvalidFee)
+      } else if priority_idx >= res.fees.len() {
+        Err(RpcError::InvalidPriority)
+      } else {
+        Ok(Fee { per_weight: res.fees[priority_idx], mask: res.quantization_mask })
+      }
+    } else {
+      self.get_fee_v14(priority).await
+    }
+  }
+
+  pub async fn get_fee_v14(&self, priority: FeePriority) -> Result<Fee, RpcError> {
     #[allow(dead_code)]
     #[derive(Deserialize, Debug)]
-    struct FeeResponse {
+    struct FeeResponseV14 {
+      status: String,
       fee: u64,
       quantization_mask: u64,
     }
 
-    let res: FeeResponse = self.json_rpc_call("get_fee_estimate", None).await?;
-    Ok(Fee { per_weight: res.fee, mask: res.quantization_mask })
+    // https://github.com/monero-project/monero/blob/94e67bf96bbc010241f29ada6abc89f49a81759c/
+    // src/wallet/wallet2.cpp#L7569-L7584
+    // https://github.com/monero-project/monero/blob/94e67bf96bbc010241f29ada6abc89f49a81759c/
+    // src/wallet/wallet2.cpp#L7660-L7661
+    let priority_idx =
+      usize::try_from(if priority.fee_priority() == 0 { 1 } else { priority.fee_priority() - 1 })
+        .map_err(|_| RpcError::InvalidPriority)?;
+    let multipliers: Vec<u64> = vec![1, 5, 25, 1000];
+    if priority_idx >= multipliers.len() {
+      // though not an RPC error, it seems sensible to treat as such
+      Err(RpcError::InvalidPriority)?;
+    }
+    let fee_multiplier = multipliers[priority_idx];
+
+    let res: FeeResponseV14 = self
+      .json_rpc_call(
+        "get_fee_estimate",
+        Some(json!({ "grace_blocks": GRACE_BLOCKS_FOR_FEE_ESTIMATE })),
+      )
+      .await?;
+
+    if res.status != "OK" {
+      Err(RpcError::InvalidFee)?;
+    }
+
+    Ok(Fee { per_weight: res.fee * fee_multiplier, mask: res.quantization_mask })
   }
 
   pub async fn publish_transaction(&self, tx: &Transaction) -> Result<(), RpcError> {

--- a/coins/monero/src/serialize.rs
+++ b/coins/monero/src/serialize.rs
@@ -19,7 +19,7 @@ mod sealed {
   impl VarInt for usize {}
 }
 
-/// This will panic if the varint exceeds u64::MAX
+// This will panic if the VarInt exceeds u64::MAX
 pub(crate) fn varint_len<U: sealed::VarInt>(varint: U) -> usize {
   let varint_u64: u64 = varint.try_into().map_err(|_| "varint exceeded u64").unwrap();
   ((usize::try_from(u64::BITS - varint_u64.leading_zeros()).unwrap().saturating_sub(1)) / 7) + 1

--- a/coins/monero/src/transaction.rs
+++ b/coins/monero/src/transaction.rs
@@ -14,7 +14,7 @@ use curve25519_dalek::{
 use crate::{
   Protocol, hash,
   serialize::*,
-  ringct::{RctBase, RctPrunable, RctSignatures, bulletproofs::Bulletproofs, RctType},
+  ringct::{bulletproofs::Bulletproofs, RctType, RctBase, RctPrunable, RctSignatures},
 };
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -409,17 +409,16 @@ impl Transaction {
     }
   }
 
-  /// Calculate the transaction's final weight
+  /// Calculate the transaction's weight.
   pub fn weight(&self) -> usize {
     let blob_size = self.serialize().len();
 
     let bp = self.is_rct_bulletproof();
     let bp_plus = self.is_rct_bulletproof_plus();
-    if !bp && !bp_plus {
+    if !(bp || bp_plus) {
       blob_size
     } else {
-      let n_outputs = self.prefix.outputs.len();
-      blob_size + Bulletproofs::calculate_bp_clawback(bp_plus, n_outputs).0
+      blob_size + Bulletproofs::calculate_bp_clawback(bp_plus, self.prefix.outputs.len()).0
     }
   }
 }

--- a/coins/monero/src/transaction.rs
+++ b/coins/monero/src/transaction.rs
@@ -14,7 +14,7 @@ use curve25519_dalek::{
 use crate::{
   Protocol, hash,
   serialize::*,
-  ringct::{RctBase, RctPrunable, RctSignatures},
+  ringct::{RctBase, RctPrunable, RctSignatures, bulletproofs::Bulletproofs, RctType},
 };
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -24,11 +24,10 @@ pub enum Input {
 }
 
 impl Input {
-  // Worst-case predictive len
-  pub(crate) fn fee_weight(ring_len: usize) -> usize {
+  pub(crate) fn fee_weight(offsets_weight: usize) -> usize {
+    // Uses 1 byte for the input type
     // Uses 1 byte for the VarInt amount due to amount being 0
-    // Uses 1 byte for the VarInt encoding of the length of the ring as well
-    1 + 1 + 1 + (8 * ring_len) + 32
+    1 + 1 + offsets_weight + 32
   }
 
   pub fn write<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -86,8 +85,10 @@ pub struct Output {
 }
 
 impl Output {
-  pub(crate) fn fee_weight() -> usize {
-    1 + 1 + 32 + 1
+  pub(crate) fn fee_weight(view_tags: bool) -> usize {
+    // Uses 1 byte for the output type
+    // Uses 1 byte for the VarInt amount due to amount being 0
+    1 + 1 + 32 + if view_tags { 1 } else { 0 }
   }
 
   pub fn write<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -185,13 +186,19 @@ pub struct TransactionPrefix {
 }
 
 impl TransactionPrefix {
-  pub(crate) fn fee_weight(ring_len: usize, inputs: usize, outputs: usize, extra: usize) -> usize {
+  pub(crate) fn fee_weight(
+    decoy_weights: &[usize],
+    outputs: usize,
+    view_tags: bool,
+    extra: usize,
+  ) -> usize {
     // Assumes Timelock::None since this library won't let you create a TX with a timelock
+    // 1 input for every decoy weight
     1 + 1 +
-      varint_len(inputs) +
-      (inputs * Input::fee_weight(ring_len)) +
-      1 +
-      (outputs * Output::fee_weight()) +
+      varint_len(decoy_weights.len()) +
+      decoy_weights.iter().map(|&offsets_weight| Input::fee_weight(offsets_weight)).sum::<usize>() +
+      varint_len(outputs) +
+      (outputs * Output::fee_weight(view_tags)) +
       varint_len(extra) +
       extra
   }
@@ -253,12 +260,13 @@ pub struct Transaction {
 impl Transaction {
   pub(crate) fn fee_weight(
     protocol: Protocol,
-    inputs: usize,
+    decoy_weights: &[usize],
     outputs: usize,
     extra: usize,
+    fee: u64,
   ) -> usize {
-    TransactionPrefix::fee_weight(protocol.ring_len(), inputs, outputs, extra) +
-      RctSignatures::fee_weight(protocol, inputs, outputs)
+    TransactionPrefix::fee_weight(decoy_weights, outputs, protocol.view_tags(), extra) +
+      RctSignatures::fee_weight(protocol, decoy_weights.len(), outputs, fee)
   }
 
   pub fn write<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -377,5 +385,41 @@ impl Transaction {
     sig_hash.extend(hash(&buf));
 
     hash(&sig_hash)
+  }
+
+  fn is_rct_bulletproof(&self) -> bool {
+    match &self.rct_signatures.rct_type() {
+      RctType::Bulletproofs | RctType::BulletproofsCompactAmount | RctType::Clsag => true,
+      RctType::Null |
+      RctType::MlsagAggregate |
+      RctType::MlsagIndividual |
+      RctType::BulletproofsPlus => false,
+    }
+  }
+
+  fn is_rct_bulletproof_plus(&self) -> bool {
+    match &self.rct_signatures.rct_type() {
+      RctType::BulletproofsPlus => true,
+      RctType::Null |
+      RctType::MlsagAggregate |
+      RctType::MlsagIndividual |
+      RctType::Bulletproofs |
+      RctType::BulletproofsCompactAmount |
+      RctType::Clsag => false,
+    }
+  }
+
+  /// Calculate the transaction's final weight
+  pub fn weight(&self) -> usize {
+    let blob_size = self.serialize().len();
+
+    let bp = self.is_rct_bulletproof();
+    let bp_plus = self.is_rct_bulletproof_plus();
+    if !bp && !bp_plus {
+      blob_size
+    } else {
+      let n_outputs = self.prefix.outputs.len();
+      blob_size + Bulletproofs::calculate_bp_clawback(bp_plus, n_outputs).0
+    }
   }
 }

--- a/coins/monero/src/wallet/decoys.rs
+++ b/coins/monero/src/wallet/decoys.rs
@@ -15,9 +15,9 @@ use rand_distr::num_traits::Float;
 use curve25519_dalek::edwards::EdwardsPoint;
 
 use crate::{
+  serialize::varint_len,
   wallet::SpendableOutput,
   rpc::{RpcError, RpcConnection, Rpc},
-  serialize::varint_len,
 };
 
 const LOCK_WINDOW: usize = 10;

--- a/coins/monero/src/wallet/mod.rs
+++ b/coins/monero/src/wallet/mod.rs
@@ -26,11 +26,11 @@ use address::{Network, AddressType, SubaddressIndex, AddressSpec, AddressMeta, M
 mod scan;
 pub use scan::{ReceivedOutput, SpendableOutput, Timelocked};
 
-pub(crate) mod decoys;
-pub(crate) use decoys::Decoys;
+pub mod decoys;
+pub use decoys::Decoys;
 
 mod send;
-pub use send::{Fee, TransactionError, Change, SignableTransaction, Eventuality};
+pub use send::{Fee, TransactionError, Change, SignableTransaction, Eventuality, FeePriority};
 #[cfg(feature = "std")]
 pub use send::SignableTransactionBuilder;
 #[cfg(feature = "multisig")]

--- a/coins/monero/src/wallet/mod.rs
+++ b/coins/monero/src/wallet/mod.rs
@@ -30,7 +30,7 @@ pub mod decoys;
 pub use decoys::Decoys;
 
 mod send;
-pub use send::{Fee, TransactionError, Change, SignableTransaction, Eventuality, FeePriority};
+pub use send::{FeePriority, Fee, TransactionError, Change, SignableTransaction, Eventuality};
 #[cfg(feature = "std")]
 pub use send::SignableTransactionBuilder;
 #[cfg(feature = "multisig")]

--- a/coins/monero/src/wallet/send/builder.rs
+++ b/coins/monero/src/wallet/send/builder.rs
@@ -6,17 +6,17 @@ use crate::{
   Protocol,
   wallet::{
     address::MoneroAddress, Fee, SpendableOutput, Change, SignableTransaction, TransactionError,
-    extra::MAX_ARBITRARY_DATA_SIZE,
+    extra::MAX_ARBITRARY_DATA_SIZE, Decoys,
   },
 };
 
 #[derive(Clone, PartialEq, Eq, Debug, Zeroize, ZeroizeOnDrop)]
 struct SignableTransactionBuilderInternal {
   protocol: Protocol,
-  fee: Fee,
+  fee_rate: Fee,
 
   r_seed: Option<Zeroizing<[u8; 32]>>,
-  inputs: Vec<SpendableOutput>,
+  inputs: Vec<(SpendableOutput, Decoys)>,
   payments: Vec<(MoneroAddress, u64)>,
   change_address: Option<Change>,
   data: Vec<Vec<u8>>,
@@ -25,10 +25,10 @@ struct SignableTransactionBuilderInternal {
 impl SignableTransactionBuilderInternal {
   // Takes in the change address so users don't miss that they have to manually set one
   // If they don't, all leftover funds will become part of the fee
-  fn new(protocol: Protocol, fee: Fee, change_address: Option<Change>) -> Self {
+  fn new(protocol: Protocol, fee_rate: Fee, change_address: Option<Change>) -> Self {
     Self {
       protocol,
-      fee,
+      fee_rate,
       r_seed: None,
       inputs: vec![],
       payments: vec![],
@@ -41,10 +41,10 @@ impl SignableTransactionBuilderInternal {
     self.r_seed = Some(r_seed);
   }
 
-  fn add_input(&mut self, input: SpendableOutput) {
+  fn add_input(&mut self, input: (SpendableOutput, Decoys)) {
     self.inputs.push(input);
   }
-  fn add_inputs(&mut self, inputs: &[SpendableOutput]) {
+  fn add_inputs(&mut self, inputs: &[(SpendableOutput, Decoys)]) {
     self.inputs.extend(inputs.iter().cloned());
   }
 
@@ -90,10 +90,10 @@ impl SignableTransactionBuilder {
     Self(self.0.clone())
   }
 
-  pub fn new(protocol: Protocol, fee: Fee, change_address: Option<Change>) -> Self {
+  pub fn new(protocol: Protocol, fee_rate: Fee, change_address: Option<Change>) -> Self {
     Self(Arc::new(RwLock::new(SignableTransactionBuilderInternal::new(
       protocol,
-      fee,
+      fee_rate,
       change_address,
     ))))
   }
@@ -103,11 +103,11 @@ impl SignableTransactionBuilder {
     self.shallow_copy()
   }
 
-  pub fn add_input(&mut self, input: SpendableOutput) -> Self {
+  pub fn add_input(&mut self, input: (SpendableOutput, Decoys)) -> Self {
     self.0.write().unwrap().add_input(input);
     self.shallow_copy()
   }
-  pub fn add_inputs(&mut self, inputs: &[SpendableOutput]) -> Self {
+  pub fn add_inputs(&mut self, inputs: &[(SpendableOutput, Decoys)]) -> Self {
     self.0.write().unwrap().add_inputs(inputs);
     self.shallow_copy()
   }
@@ -138,7 +138,7 @@ impl SignableTransactionBuilder {
       read.payments.clone(),
       read.change_address.clone(),
       read.data.clone(),
-      read.fee,
+      read.fee_rate,
     )
   }
 }

--- a/coins/monero/src/wallet/send/builder.rs
+++ b/coins/monero/src/wallet/send/builder.rs
@@ -5,8 +5,8 @@ use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 use crate::{
   Protocol,
   wallet::{
-    address::MoneroAddress, Fee, SpendableOutput, Change, SignableTransaction, TransactionError,
-    extra::MAX_ARBITRARY_DATA_SIZE, Decoys,
+    address::MoneroAddress, Fee, SpendableOutput, Change, Decoys, SignableTransaction,
+    TransactionError, extra::MAX_ARBITRARY_DATA_SIZE,
   },
 };
 

--- a/coins/monero/src/wallet/send/mod.rs
+++ b/coins/monero/src/wallet/send/mod.rs
@@ -35,7 +35,7 @@ use crate::{
     RctBase, RctPrunable, RctSignatures,
   },
   transaction::{Input, Output, Timelock, TransactionPrefix, Transaction},
-  rpc::{RpcError, RpcConnection, Rpc},
+  rpc::RpcError,
   wallet::{
     address::{Network, AddressSpec, MoneroAddress},
     ViewPair, SpendableOutput, Decoys, PaymentId, ExtraField, Extra, key_image_sort, uniqueness,
@@ -130,6 +130,8 @@ pub enum TransactionError {
   NoInputs,
   #[cfg_attr(feature = "std", error("no outputs"))]
   NoOutputs,
+  #[cfg_attr(feature = "std", error("invalid number of decoys"))]
+  InvalidNumDecoys,
   #[cfg_attr(feature = "std", error("only one output and no change address"))]
   NoChange,
   #[cfg_attr(feature = "std", error("too many outputs"))]
@@ -153,40 +155,26 @@ pub enum TransactionError {
   FrostError(FrostError),
 }
 
-async fn prepare_inputs<R: RngCore + CryptoRng, RPC: RpcConnection>(
-  rng: &mut R,
-  rpc: &Rpc<RPC>,
-  ring_len: usize,
-  inputs: &[SpendableOutput],
+fn prepare_inputs(
+  inputs: &[(SpendableOutput, Decoys)],
   spend: &Zeroizing<Scalar>,
   tx: &mut Transaction,
 ) -> Result<Vec<(Zeroizing<Scalar>, EdwardsPoint, ClsagInput)>, TransactionError> {
   let mut signable = Vec::with_capacity(inputs.len());
 
-  // Select decoys
-  let decoys = Decoys::select(
-    rng,
-    rpc,
-    ring_len,
-    rpc.get_height().await.map_err(TransactionError::RpcError)? - 1,
-    inputs,
-  )
-  .await
-  .map_err(TransactionError::RpcError)?;
-
-  for (i, input) in inputs.iter().enumerate() {
+  for (i, (input, decoys)) in inputs.iter().enumerate() {
     let input_spend = Zeroizing::new(input.key_offset() + spend.deref());
     let image = generate_key_image(&input_spend);
     signable.push((
       input_spend,
       image,
-      ClsagInput::new(input.commitment().clone(), decoys[i].clone())
+      ClsagInput::new(input.commitment().clone(), decoys.clone())
         .map_err(TransactionError::ClsagError)?,
     ));
 
     tx.prefix.inputs.push(Input::ToKey {
       amount: None,
-      key_offsets: decoys[i].offsets.clone(),
+      key_offsets: decoys.offsets.clone(),
       key_image: signable[i].1,
     });
   }
@@ -203,6 +191,55 @@ async fn prepare_inputs<R: RngCore + CryptoRng, RPC: RpcConnection>(
   Ok(signable)
 }
 
+/// Deterministically calculate what the tx weight and fee will be
+fn calculate_weight_and_fee(
+  protocol: Protocol,
+  decoy_weights: &[usize],
+  n_outputs: usize,
+  extra: usize,
+  fee_rate: Fee,
+) -> (usize, u64) {
+  let mut weight = 0usize;
+  let mut fee = 0u64;
+  // Starting the fee at 0 here is different than core Monero's wallet2.cpp,
+  // which starts its fee calculation with an estimate. This difference is ok in
+  // practice because wallet2 still ends up using a fee calculated from a tx's weight,
+  // as we calculate later in this function. See this PR highlighting wallet2's behavior:
+  // https://github.com/monero-project/monero/pull/8882
+  // Even with that PR, if the estimated fee's varint byte length is larger than
+  // the calculated fee's, the wallet can theoretically use a fee not
+  // based on the *final* tx weight. However, this does not occur in practice:
+  // it's nearly impossible for wallet2 to estimate a fee that is larger
+  // than the calculated fee today, and on top of that, even more unlikely for
+  // that estimate varint to be larger in byte length than the calculated fee.
+
+  let mut done = false;
+  let mut iters = 0;
+  let max_iters = 5;
+  while !done {
+    weight = Transaction::fee_weight(protocol, decoy_weights, n_outputs, extra, fee);
+
+    let fee_calculated_from_weight = fee_rate.calculate_fee_from_weight(weight);
+
+    // Continue trying to use the fee calculated from the tx's weight
+    done = fee_calculated_from_weight == fee;
+
+    fee = fee_calculated_from_weight;
+
+    #[cfg(test)]
+    debug_assert!(iters < max_iters, "Reached max fee calculation attempts");
+    // Should never happen because the fee VarInt byte length shouldn't change
+    // *every* single iter. `iters` reaching `max_iters` is unexpected.
+    if iters >= max_iters {
+      // Fail-safe break to ensure funds are still spendable
+      break;
+    }
+    iters += 1;
+  }
+
+  (weight, fee)
+}
+
 /// Fee struct, defined as a per-unit cost and a mask for rounding purposes.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Zeroize)]
 pub struct Fee {
@@ -211,8 +248,38 @@ pub struct Fee {
 }
 
 impl Fee {
-  pub fn calculate(&self, weight: usize) -> u64 {
-    ((((self.per_weight * u64::try_from(weight).unwrap()) - 1) / self.mask) + 1) * self.mask
+  pub fn calculate_fee_from_weight(&self, weight: usize) -> u64 {
+    let fee = (((self.per_weight * u64::try_from(weight).unwrap()) + self.mask - 1) / self.mask) *
+      self.mask;
+    debug_assert_eq!(weight, self.calculate_weight_from_fee(fee), "Miscalculated weight from fee");
+    fee
+  }
+
+  pub fn calculate_weight_from_fee(&self, fee: u64) -> usize {
+    usize::try_from(fee / self.per_weight).unwrap()
+  }
+}
+
+/// Priority to include a transaction in the next block
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[allow(non_camel_case_types)]
+pub enum FeePriority {
+  Lowest,
+  Low,
+  Medium,
+  High,
+  Custom { priority: u32 },
+}
+
+impl FeePriority {
+  pub fn fee_priority(&self) -> u32 {
+    match self {
+      FeePriority::Lowest => 0,
+      FeePriority::Low => 1,
+      FeePriority::Medium => 2,
+      FeePriority::High => 3,
+      FeePriority::Custom { priority, .. } => *priority,
+    }
   }
 }
 
@@ -240,10 +307,11 @@ pub struct Eventuality {
 pub struct SignableTransaction {
   protocol: Protocol,
   r_seed: Option<Zeroizing<[u8; 32]>>,
-  inputs: Vec<SpendableOutput>,
+  inputs: Vec<(SpendableOutput, Decoys)>,
   payments: Vec<InternalPayment>,
   data: Vec<Vec<u8>>,
   fee: u64,
+  fee_rate: Fee,
 }
 
 /// Specification for a change output.
@@ -282,6 +350,49 @@ impl Change {
   }
 }
 
+fn need_additional(payments: &[InternalPayment]) -> (bool, bool) {
+  let mut has_change_view = false;
+  let subaddresses = payments
+    .iter()
+    .filter(|payment| match *payment {
+      InternalPayment::Payment(payment) => payment.0.is_subaddress(),
+      InternalPayment::Change(change, _) => {
+        if change.view.is_some() {
+          has_change_view = true;
+          // It should not be possible to construct a change specification to a subaddress with a
+          // view key
+          debug_assert!(!change.address.is_subaddress());
+        }
+        change.address.is_subaddress()
+      }
+    })
+    .count() !=
+    0;
+
+  // We need additional keys if we have any subaddresses
+  let mut additional = subaddresses;
+  // Unless the above change view key path is taken
+  if (payments.len() == 2) && has_change_view {
+    additional = false;
+  }
+
+  (subaddresses, additional)
+}
+
+fn sanity_check_change_payment(payments: &[InternalPayment], has_change_address: bool) {
+  debug_assert_eq!(
+    payments
+      .iter()
+      .filter(|payment| match *payment {
+        InternalPayment::Payment(_) => false,
+        InternalPayment::Change(_, _) => true,
+      })
+      .count(),
+    if has_change_address { 1 } else { 0 },
+    "Unexpected number of change outputs"
+  );
+}
+
 impl SignableTransaction {
   /// Create a signable transaction.
   ///
@@ -295,7 +406,7 @@ impl SignableTransaction {
   pub fn new(
     protocol: Protocol,
     r_seed: Option<Zeroizing<[u8; 32]>>,
-    inputs: Vec<SpendableOutput>,
+    inputs: Vec<(SpendableOutput, Decoys)>,
     payments: Vec<(MoneroAddress, u64)>,
     change_address: Option<Change>,
     data: Vec<Vec<u8>>,
@@ -328,6 +439,12 @@ impl SignableTransaction {
       Err(TransactionError::NoOutputs)?;
     }
 
+    for (_, decoys) in &inputs {
+      if decoys.len() != protocol.ring_len() {
+        Err(TransactionError::InvalidNumDecoys)?;
+      }
+    }
+
     for part in &data {
       if part.len() > MAX_ARBITRARY_DATA_SIZE {
         Err(TransactionError::TooMuchData)?;
@@ -338,13 +455,31 @@ impl SignableTransaction {
     if (payments.len() == 1) && change_address.is_none() {
       Err(TransactionError::NoChange)?;
     }
+
+    // Get the outgoing amount ignoring fees
+    let out_amount = payments.iter().map(|payment| payment.1).sum::<u64>();
+
     let outputs = payments.len() + usize::from(change_address.is_some());
+    if outputs > MAX_OUTPUTS {
+      Err(TransactionError::TooManyOutputs)?;
+    }
+
+    // Collect payments in a container that includes a change output if a change address is provided
+    let mut payments = payments.into_iter().map(InternalPayment::Payment).collect::<Vec<_>>();
+    if change_address.is_some() {
+      // Push a 0 amount change output that we'll use to do fee calculations.
+      // We'll modify the change amount after calculating the fee
+      payments.push(InternalPayment::Change(change_address.clone().unwrap(), 0));
+    }
+
+    // Determine if we'll need additional pub keys in tx extra
+    let (_, additional) = need_additional(&payments);
+
     // Add a dummy payment ID if there's only 2 payments
     has_payment_id |= outputs == 2;
 
     // Calculate the extra length
-    // Assume additional keys are needed in order to cause a worst-case estimation
-    let extra = Extra::fee_weight(outputs, true, has_payment_id, data.as_ref());
+    let extra = Extra::fee_weight(outputs, additional, has_payment_id, data.as_ref());
 
     // https://github.com/monero-project/monero/pull/8733
     const MAX_EXTRA_SIZE: usize = 1060;
@@ -352,46 +487,64 @@ impl SignableTransaction {
       Err(TransactionError::TooMuchData)?;
     }
 
-    // This is a extremely heavy fee weight estimation which can only be trusted for two things
-    // 1) Ensuring we have enough for whatever fee we end up using
-    // 2) Ensuring we aren't over the max size
-    let estimated_tx_size = Transaction::fee_weight(protocol, inputs.len(), outputs, extra);
+    // Caclculate weight of decoys
+    let decoy_weights =
+      inputs.iter().map(|(_, decoy)| Decoys::fee_weight(&decoy.offsets)).collect::<Vec<_>>();
+
+    // Deterministically calculate tx weight and fee
+    let (weight, fee) =
+      calculate_weight_and_fee(protocol, &decoy_weights, outputs, extra, fee_rate);
 
     // The actual limit is half the block size, and for the minimum block size of 300k, that'd be
     // 150k
     // wallet2 will only create transactions up to 100k bytes however
     const MAX_TX_SIZE: usize = 100_000;
-
-    // This uses the weight (estimated_tx_size) despite the BP clawback
-    // The clawback *increases* the weight, so this will over-estimate, yet it's still safe
-    if estimated_tx_size >= MAX_TX_SIZE {
+    if weight >= MAX_TX_SIZE {
       Err(TransactionError::TooLargeTransaction)?;
     }
 
-    // Calculate the fee.
-    let fee = fee_rate.calculate(estimated_tx_size);
-
     // Make sure we have enough funds
-    let in_amount = inputs.iter().map(|input| input.commitment().amount).sum::<u64>();
-    let out_amount = payments.iter().map(|payment| payment.1).sum::<u64>() + fee;
-    if in_amount < out_amount {
-      Err(TransactionError::NotEnoughFunds(in_amount, out_amount))?;
+    let in_amount = inputs.iter().map(|(input, _)| input.commitment().amount).sum::<u64>();
+    if in_amount < (out_amount + fee) {
+      Err(TransactionError::NotEnoughFunds(in_amount, out_amount + fee))?;
     }
 
-    if outputs > MAX_OUTPUTS {
-      Err(TransactionError::TooManyOutputs)?;
+    // Sanity check we have the expected number of change outputs
+    sanity_check_change_payment(&payments, change_address.is_some());
+
+    // Modify the amount of the change output
+    if change_address.is_some() {
+      let change_payment = payments.last_mut().unwrap();
+      *change_payment =
+        InternalPayment::Change(change_address.clone().unwrap(), in_amount - out_amount - fee);
     }
 
-    let mut payments = payments.into_iter().map(InternalPayment::Payment).collect::<Vec<_>>();
-    if let Some(change) = change_address {
-      payments.push(InternalPayment::Change(change, in_amount - out_amount));
-    }
+    // Sanity check the change again after modifying
+    sanity_check_change_payment(&payments, change_address.is_some());
 
-    Ok(SignableTransaction { protocol, r_seed, inputs, payments, data, fee })
+    // Sanity check outgoing amount + fee == incoming amount
+    debug_assert_eq!(
+      payments
+        .iter()
+        .map(|payment| match *payment {
+          InternalPayment::Payment(payment) => payment.1,
+          InternalPayment::Change(_, amount) => amount,
+        })
+        .sum::<u64>() +
+        fee,
+      in_amount,
+      "Outgoing amount + fee != incoming amount"
+    );
+
+    Ok(SignableTransaction { protocol, r_seed, inputs, payments, data, fee, fee_rate })
   }
 
   pub fn fee(&self) -> u64 {
     self.fee
+  }
+
+  pub fn fee_rate(&self) -> Fee {
+    self.fee_rate
   }
 
   #[allow(clippy::type_complexity)]
@@ -425,30 +578,7 @@ impl SignableTransaction {
     // If any of these outputs are to a subaddress, we need keys distinct to them
     // The only time this *does not* force having additional keys is when the only other output
     // is a change output we have the view key for, enabling rewriting rA to aR
-    let mut has_change_view = false;
-    let subaddresses = payments
-      .iter()
-      .filter(|payment| match *payment {
-        InternalPayment::Payment(payment) => payment.0.is_subaddress(),
-        InternalPayment::Change(change, _) => {
-          if change.view.is_some() {
-            has_change_view = true;
-            // It should not be possible to construct a change specification to a subaddress with a
-            // view key
-            debug_assert!(!change.address.is_subaddress());
-          }
-          change.address.is_subaddress()
-        }
-      })
-      .count() !=
-      0;
-
-    // We need additional keys if we have any subaddresses
-    let mut additional = subaddresses;
-    // Unless the above change view key path is taken
-    if (payments.len() == 2) && has_change_view {
-      additional = false;
-    }
+    let (subaddresses, additional) = need_additional(payments);
     let modified_change_ecdh = subaddresses && (!additional);
 
     // If we're using the aR rewrite, update tx_public_key from rG to rB
@@ -567,7 +697,7 @@ impl SignableTransaction {
   /// with the specified seed. This eventuality can be compared to on-chain transactions to see
   /// if the transaction has already been signed and published.
   pub fn eventuality(&self) -> Option<Eventuality> {
-    let inputs = self.inputs.iter().map(SpendableOutput::key).collect::<Vec<_>>();
+    let inputs = self.inputs.iter().map(|(input, _)| input.key()).collect::<Vec<_>>();
     let (tx_key, additional, outputs, id) = Self::prepare_payments(
       self.r_seed.as_ref()?,
       &inputs,
@@ -607,7 +737,7 @@ impl SignableTransaction {
 
     let (tx_key, additional, outputs, id) = Self::prepare_payments(
       &r_seed,
-      &self.inputs.iter().map(SpendableOutput::key).collect::<Vec<_>>(),
+      &self.inputs.iter().map(|(input, _)| input.key()).collect::<Vec<_>>(),
       &mut self.payments,
       uniqueness,
     );
@@ -629,7 +759,7 @@ impl SignableTransaction {
       &mut self.data,
     );
 
-    let mut fee = self.inputs.iter().map(|input| input.commitment().amount).sum::<u64>();
+    let mut fee = self.inputs.iter().map(|(input, _)| input.commitment().amount).sum::<u64>();
     let mut tx_outputs = Vec::with_capacity(outputs.len());
     let mut encrypted_amounts = Vec::with_capacity(outputs.len());
     for output in &outputs {
@@ -637,10 +767,11 @@ impl SignableTransaction {
       tx_outputs.push(Output {
         amount: None,
         key: output.dest.compress(),
-        view_tag: Some(output.view_tag).filter(|_| matches!(self.protocol, Protocol::v16)),
+        view_tag: Some(output.view_tag).filter(|_| self.protocol.view_tags()),
       });
       encrypted_amounts.push(EncryptedAmount::Compact { amount: output.amount });
     }
+    debug_assert_eq!(self.fee, fee, "Transaction will use unexpected fee");
 
     (
       Transaction {
@@ -667,14 +798,13 @@ impl SignableTransaction {
   }
 
   /// Sign this transaction.
-  pub async fn sign<R: RngCore + CryptoRng, RPC: RpcConnection>(
+  pub async fn sign<R: RngCore + CryptoRng>(
     mut self,
     rng: &mut R,
-    rpc: &Rpc<RPC>,
     spend: &Zeroizing<Scalar>,
   ) -> Result<Transaction, TransactionError> {
     let mut images = Vec::with_capacity(self.inputs.len());
-    for input in &self.inputs {
+    for (input, _) in &self.inputs {
       let mut offset = Zeroizing::new(spend.deref() + input.key_offset());
       if (offset.deref() * &ED25519_BASEPOINT_TABLE) != input.key() {
         Err(TransactionError::WrongPrivateKey)?;
@@ -695,8 +825,7 @@ impl SignableTransaction {
       ),
     );
 
-    let signable =
-      prepare_inputs(rng, rpc, self.protocol.ring_len(), &self.inputs, spend, &mut tx).await?;
+    let signable = prepare_inputs(&self.inputs, spend, &mut tx)?;
 
     let clsag_pairs = Clsag::sign(rng, signable, mask_sum, tx.signature_hash());
     match tx.rct_signatures.prunable {
@@ -707,6 +836,13 @@ impl SignableTransaction {
       }
       _ => unreachable!("attempted to sign a TX which wasn't CLSAG"),
     }
+
+    debug_assert_eq!(
+      self.fee_rate.calculate_fee_from_weight(tx.weight()),
+      tx.rct_signatures.base.fee,
+      "Transaction used unexpected fee"
+    );
+
     Ok(tx)
   }
 }
@@ -768,7 +904,7 @@ impl Eventuality {
       if (&Output {
         amount: None,
         key: expected.dest.compress(),
-        view_tag: Some(expected.view_tag).filter(|_| matches!(self.protocol, Protocol::v16)),
+        view_tag: Some(expected.view_tag).filter(|_| self.protocol.view_tags()),
       } != actual) ||
         (Some(&expected.commitment.calculate()) != tx.rct_signatures.base.commitments.get(o)) ||
         (Some(&EncryptedAmount::Compact { amount: expected.amount }) !=

--- a/coins/monero/tests/runner.rs
+++ b/coins/monero/tests/runner.rs
@@ -73,7 +73,7 @@ pub async fn get_miner_tx_output(rpc: &Rpc<HttpRpc>, view: &ViewPair) -> Spendab
   scanner.scan(rpc, &block).await.unwrap().swap_remove(0).ignore_timelock().swap_remove(0)
 }
 
-/// Makes sure the weight and fee match the expected calculation
+/// Make sure the weight and fee match the expected calculation.
 pub fn check_weight_and_fee(tx: &Transaction, fee_rate: Fee) {
   let fee = tx.rct_signatures.base.fee;
 
@@ -167,8 +167,8 @@ macro_rules! test {
         use monero_serai::{
           random_scalar,
           wallet::{
-            address::{Network, AddressSpec}, ViewPair, Scanner, Change, SignableTransaction,
-            SignableTransactionBuilder, Decoys, FeePriority,
+            address::{Network, AddressSpec}, ViewPair, Scanner, Change, Decoys, FeePriority,
+            SignableTransaction, SignableTransactionBuilder,
           },
         };
 

--- a/coins/monero/tests/send.rs
+++ b/coins/monero/tests/send.rs
@@ -1,10 +1,43 @@
 use monero_serai::{
   transaction::Transaction,
-  wallet::{extra::Extra, address::SubaddressIndex, ReceivedOutput, SpendableOutput},
-  rpc::Rpc,
+  wallet::{
+    extra::Extra, address::SubaddressIndex, ReceivedOutput, SpendableOutput,
+    SignableTransactionBuilder, Decoys,
+  },
+  rpc::{Rpc, HttpRpc},
+  Protocol as P,
 };
 
 mod runner;
+
+use rand_core::OsRng;
+
+// Set up inputs, select decoys, then add to tx builder
+async fn add_inputs(
+  protocol: P,
+  rpc: &Rpc<HttpRpc>,
+  outputs: Vec<ReceivedOutput>,
+  builder: &mut SignableTransactionBuilder,
+) {
+  let mut spendable_outputs = Vec::with_capacity(outputs.len());
+  for output in outputs {
+    spendable_outputs.push(SpendableOutput::from(rpc, output).await.unwrap());
+  }
+
+  let decoys = Decoys::select(
+    &mut OsRng,
+    rpc,
+    protocol.ring_len(),
+    rpc.get_height().await.unwrap() - 1,
+    &spendable_outputs,
+  )
+  .await
+  .unwrap();
+
+  let inputs = spendable_outputs.into_iter().zip(decoys.into_iter()).collect::<Vec<_>>();
+
+  builder.add_inputs(&inputs);
+}
 
 test!(
   spend_miner_output,
@@ -37,10 +70,8 @@ test!(
     },
   ),
   (
-    |rpc, mut builder: Builder, addr, outputs: Vec<ReceivedOutput>| async move {
-      for output in outputs {
-        builder.add_input(SpendableOutput::from(&rpc, output).await.unwrap());
-      }
+    |protocol: P, rpc, mut builder: Builder, addr, outputs: Vec<ReceivedOutput>| async move {
+      add_inputs(protocol, &rpc, outputs, &mut builder).await;
       builder.add_payment(addr, 6);
       (builder.build().unwrap(), ())
     },
@@ -69,18 +100,20 @@ test!(
     },
   ),
   (
-    |rpc: Rpc<_>, _, _, mut outputs: Vec<ReceivedOutput>| async move {
+    |protocol, rpc: Rpc<_>, _, _, outputs: Vec<ReceivedOutput>| async move {
+      use monero_serai::wallet::FeePriority;
+
       let change_view = ViewPair::new(
         &random_scalar(&mut OsRng) * &ED25519_BASEPOINT_TABLE,
         Zeroizing::new(random_scalar(&mut OsRng)),
       );
 
       let mut builder = SignableTransactionBuilder::new(
-        rpc.get_protocol().await.unwrap(),
-        rpc.get_fee().await.unwrap(),
+        protocol,
+        rpc.get_fee(protocol, FeePriority::Low).await.unwrap(),
         Some(Change::new(&change_view, false)),
       );
-      builder.add_input(SpendableOutput::from(&rpc, outputs.swap_remove(0)).await.unwrap());
+      add_inputs(protocol, &rpc, vec![outputs.first().unwrap().clone()], &mut builder).await;
 
       // Send to a subaddress
       let sub_view = ViewPair::new(
@@ -113,6 +146,130 @@ test!(
         .unwrap()
         .1
         .is_none());
+    },
+  ),
+);
+
+test!(
+  spend_one_input_to_one_output_plus_change,
+  (
+    |_, mut builder: Builder, addr| async move {
+      builder.add_payment(addr, 2000000000000);
+      (builder.build().unwrap(), ())
+    },
+    |_, tx: Transaction, mut scanner: Scanner, _| async move {
+      let mut outputs = scanner.scan_transaction(&tx).not_locked();
+      outputs.sort_by(|x, y| x.commitment().amount.cmp(&y.commitment().amount));
+      assert_eq!(outputs[0].commitment().amount, 2000000000000);
+      outputs
+    },
+  ),
+  (
+    |protocol: P, rpc, mut builder: Builder, addr, outputs: Vec<ReceivedOutput>| async move {
+      add_inputs(protocol, &rpc, outputs, &mut builder).await;
+      builder.add_payment(addr, 2);
+      (builder.build().unwrap(), ())
+    },
+    |_, tx: Transaction, mut scanner: Scanner, _| async move {
+      let output = scanner.scan_transaction(&tx).not_locked().swap_remove(0);
+      assert_eq!(output.commitment().amount, 2);
+    },
+  ),
+);
+
+test!(
+  spend_max_outputs,
+  (
+    |_, mut builder: Builder, addr| async move {
+      builder.add_payment(addr, 1000000000000);
+      (builder.build().unwrap(), ())
+    },
+    |_, tx: Transaction, mut scanner: Scanner, _| async move {
+      let mut outputs = scanner.scan_transaction(&tx).not_locked();
+      outputs.sort_by(|x, y| x.commitment().amount.cmp(&y.commitment().amount));
+      assert_eq!(outputs[0].commitment().amount, 1000000000000);
+      outputs
+    },
+  ),
+  (
+    |protocol: P, rpc, mut builder: Builder, addr, outputs: Vec<ReceivedOutput>| async move {
+      add_inputs(protocol, &rpc, outputs, &mut builder).await;
+
+      for i in 0 .. 15 {
+        builder.add_payment(addr, i + 1);
+      }
+      (builder.build().unwrap(), ())
+    },
+    |_, tx: Transaction, mut scanner: Scanner, _| async move {
+      let mut scanned_tx = scanner.scan_transaction(&tx).not_locked();
+
+      let mut output_amounts = HashSet::new();
+      for i in 0 .. 15 {
+        output_amounts.insert((i + 1) as u64);
+      }
+      for _ in 0 .. 15 {
+        let output = scanned_tx.swap_remove(0);
+        let amount = output.commitment().amount;
+        assert!(output_amounts.contains(&amount));
+        output_amounts.remove(&amount);
+      }
+    },
+  ),
+);
+
+test!(
+  spend_max_outputs_to_subaddresses,
+  (
+    |_, mut builder: Builder, addr| async move {
+      builder.add_payment(addr, 1000000000000);
+      (builder.build().unwrap(), ())
+    },
+    |_, tx: Transaction, mut scanner: Scanner, _| async move {
+      let mut outputs = scanner.scan_transaction(&tx).not_locked();
+      outputs.sort_by(|x, y| x.commitment().amount.cmp(&y.commitment().amount));
+      assert_eq!(outputs[0].commitment().amount, 1000000000000);
+      outputs
+    },
+  ),
+  (
+    |protocol: P, rpc, mut builder: Builder, _, outputs: Vec<ReceivedOutput>| async move {
+      add_inputs(protocol, &rpc, outputs, &mut builder).await;
+
+      let view = runner::random_address().1;
+      let mut scanner = Scanner::from_view(view.clone(), Some(HashSet::new()));
+
+      let mut subaddresses = vec![];
+      for i in 0 .. 15 {
+        let subaddress = SubaddressIndex::new(0, i + 1).unwrap();
+        scanner.register_subaddress(subaddress);
+
+        builder.add_payment(
+          view.address(Network::Mainnet, AddressSpec::Subaddress(subaddress)),
+          (i + 1) as u64,
+        );
+        subaddresses.push(subaddress);
+      }
+
+      (builder.build().unwrap(), (scanner, subaddresses))
+    },
+    |_, tx: Transaction, _, mut state: (Scanner, Vec<SubaddressIndex>)| async move {
+      use std::collections::HashMap;
+
+      let mut scanned_tx = state.0.scan_transaction(&tx).not_locked();
+
+      let mut output_amounts_by_subaddress = HashMap::new();
+      for i in 0 .. 15 {
+        output_amounts_by_subaddress.insert((i + 1) as u64, state.1[i]);
+      }
+      for _ in 0 .. 15 {
+        let output = scanned_tx.swap_remove(0);
+        let amount = output.commitment().amount;
+
+        assert!(output_amounts_by_subaddress.contains_key(&amount));
+        assert_eq!(output.metadata.subaddress, Some(output_amounts_by_subaddress[&amount]));
+
+        output_amounts_by_subaddress.remove(&amount);
+      }
     },
   ),
 );

--- a/coins/monero/tests/send.rs
+++ b/coins/monero/tests/send.rs
@@ -1,20 +1,20 @@
+use rand_core::OsRng;
+
 use monero_serai::{
   transaction::Transaction,
   wallet::{
-    extra::Extra, address::SubaddressIndex, ReceivedOutput, SpendableOutput,
-    SignableTransactionBuilder, Decoys,
+    extra::Extra, address::SubaddressIndex, ReceivedOutput, SpendableOutput, Decoys,
+    SignableTransactionBuilder,
   },
   rpc::{Rpc, HttpRpc},
-  Protocol as P,
+  Protocol,
 };
 
 mod runner;
 
-use rand_core::OsRng;
-
-// Set up inputs, select decoys, then add to tx builder
+// Set up inputs, select decoys, then add them to the TX builder
 async fn add_inputs(
-  protocol: P,
+  protocol: Protocol,
   rpc: &Rpc<HttpRpc>,
   outputs: Vec<ReceivedOutput>,
   builder: &mut SignableTransactionBuilder,
@@ -70,7 +70,7 @@ test!(
     },
   ),
   (
-    |protocol: P, rpc, mut builder: Builder, addr, outputs: Vec<ReceivedOutput>| async move {
+    |protocol: Protocol, rpc, mut builder: Builder, addr, outputs: Vec<ReceivedOutput>| async move {
       add_inputs(protocol, &rpc, outputs, &mut builder).await;
       builder.add_payment(addr, 6);
       (builder.build().unwrap(), ())
@@ -165,7 +165,7 @@ test!(
     },
   ),
   (
-    |protocol: P, rpc, mut builder: Builder, addr, outputs: Vec<ReceivedOutput>| async move {
+    |protocol: Protocol, rpc, mut builder: Builder, addr, outputs: Vec<ReceivedOutput>| async move {
       add_inputs(protocol, &rpc, outputs, &mut builder).await;
       builder.add_payment(addr, 2);
       (builder.build().unwrap(), ())
@@ -192,7 +192,7 @@ test!(
     },
   ),
   (
-    |protocol: P, rpc, mut builder: Builder, addr, outputs: Vec<ReceivedOutput>| async move {
+    |protocol: Protocol, rpc, mut builder: Builder, addr, outputs: Vec<ReceivedOutput>| async move {
       add_inputs(protocol, &rpc, outputs, &mut builder).await;
 
       for i in 0 .. 15 {
@@ -232,7 +232,7 @@ test!(
     },
   ),
   (
-    |protocol: P, rpc, mut builder: Builder, _, outputs: Vec<ReceivedOutput>| async move {
+    |protocol: Protocol, rpc, mut builder: Builder, _, outputs: Vec<ReceivedOutput>| async move {
       add_inputs(protocol, &rpc, outputs, &mut builder).await;
 
       let view = runner::random_address().1;

--- a/coins/monero/tests/wallet2_compatibility.rs
+++ b/coins/monero/tests/wallet2_compatibility.rs
@@ -84,6 +84,14 @@ async fn from_wallet_rpc_to_self(spec: AddressSpec) {
     .unwrap();
   let tx_hash: [u8; 32] = tx.tx_hash.0.try_into().unwrap();
 
+  // TODO: needs https://github.com/monero-project/monero/pull/8882
+  // let fee_rate = daemon_rpc
+  //   // Uses `FeePriority::Low` instead of `FeePriority::Lowest` because wallet RPC
+  //   // adjusts `monero_rpc::TransferPriority::Default` up by 1
+  //   .get_fee(daemon_rpc.get_protocol().await.unwrap(), FeePriority::Low)
+  //   .await
+  //   .unwrap();
+
   // unlock it
   runner::mine_until_unlocked(&daemon_rpc, &wallet_rpc_addr.to_string(), tx_hash).await;
 
@@ -96,6 +104,9 @@ async fn from_wallet_rpc_to_self(spec: AddressSpec) {
   // retrieve it and confirm
   let tx = daemon_rpc.get_transaction(tx_hash).await.unwrap();
   let output = scanner.scan_transaction(&tx).not_locked().swap_remove(0);
+
+  // TODO: needs https://github.com/monero-project/monero/pull/8882
+  // runner::check_weight_and_fee(&tx, fee_rate);
 
   match spec {
     AddressSpec::Subaddress(index) => assert_eq!(output.metadata.subaddress, Some(index)),

--- a/coins/monero/tests/wallet2_compatibility.rs
+++ b/coins/monero/tests/wallet2_compatibility.rs
@@ -84,7 +84,7 @@ async fn from_wallet_rpc_to_self(spec: AddressSpec) {
     .unwrap();
   let tx_hash: [u8; 32] = tx.tx_hash.0.try_into().unwrap();
 
-  // TODO: needs https://github.com/monero-project/monero/pull/8882
+  // TODO: Needs https://github.com/monero-project/monero/pull/8882
   // let fee_rate = daemon_rpc
   //   // Uses `FeePriority::Low` instead of `FeePriority::Lowest` because wallet RPC
   //   // adjusts `monero_rpc::TransferPriority::Default` up by 1
@@ -95,17 +95,17 @@ async fn from_wallet_rpc_to_self(spec: AddressSpec) {
   // unlock it
   runner::mine_until_unlocked(&daemon_rpc, &wallet_rpc_addr.to_string(), tx_hash).await;
 
-  // create the scanner
+  // Create the scanner
   let mut scanner = Scanner::from_view(view_pair, Some(HashSet::new()));
   if let AddressSpec::Subaddress(index) = spec {
     scanner.register_subaddress(index);
   }
 
-  // retrieve it and confirm
+  // Retrieve it and scan it
   let tx = daemon_rpc.get_transaction(tx_hash).await.unwrap();
   let output = scanner.scan_transaction(&tx).not_locked().swap_remove(0);
 
-  // TODO: needs https://github.com/monero-project/monero/pull/8882
+  // TODO: Needs https://github.com/monero-project/monero/pull/8882
   // runner::check_weight_and_fee(&tx, fee_rate);
 
   match spec {

--- a/processor/src/coins/monero.rs
+++ b/processor/src/coins/monero.rs
@@ -4,10 +4,10 @@ use async_trait::async_trait;
 
 use zeroize::Zeroizing;
 
-use transcript::{Transcript, RecommendedTranscript};
-
-use rand_chacha::ChaCha20Rng;
 use rand_core::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+
+use transcript::{Transcript, RecommendedTranscript};
 
 use group::{ff::Field, Group};
 use dalek_ff_group::{Scalar, EdwardsPoint};
@@ -21,8 +21,8 @@ use monero_serai::{
   wallet::{
     ViewPair, Scanner,
     address::{Network, SubaddressIndex, AddressSpec},
-    Fee, SpendableOutput, Change, TransactionError, SignableTransaction as MSignableTransaction,
-    Eventuality, TransactionMachine, Decoys,
+    Fee, SpendableOutput, Change, Decoys, TransactionError,
+    SignableTransaction as MSignableTransaction, Eventuality, TransactionMachine,
   },
 };
 
@@ -403,10 +403,8 @@ impl Coin for Monero {
 
     let mut transcript = plan.transcript();
 
-    // All signers need to select the same decoys. All signers use the same height +
-    // seeded RNG to make sure they do so. We select decoys here and keep the
-    // selection constant for the remainder of tx construction to ensure the
-    // calculated fee is derived from a fixed set of decoys with fixed byte length.
+    // All signers need to select the same decoys
+    // All signers use the same height and a seeded RNG to make sure they do so.
     let decoys = Decoys::select(
       &mut ChaCha20Rng::from_seed(transcript.rng_seed(b"decoys")),
       &self.rpc,
@@ -469,7 +467,7 @@ impl Coin for Monero {
           }
           TransactionError::NoInputs |
           TransactionError::NoOutputs |
-          TransactionError::InvalidNumDecoys |
+          TransactionError::InvalidDecoyQuantity |
           TransactionError::NoChange |
           TransactionError::TooManyOutputs |
           TransactionError::TooMuchData |
@@ -522,7 +520,7 @@ impl Coin for Monero {
   ) -> Result<Self::TransactionMachine, CoinError> {
     match transaction.actual.clone().multisig(transaction.keys.clone(), transaction.transcript) {
       Ok(machine) => Ok(machine),
-      Err(e) => panic!("failed attempting to send TX: {}", e),
+      Err(e) => panic!("failed to create a multisig machine for TX: {e}"),
     }
   }
 


### PR DESCRIPTION
The goal of this PR is to ensure `monero-serai` constructs transactions using fees that are indistinguishable from Monero's wallet2. This PR accomplishes this goal to the best of my knowledge. I haven't tested it with mainnet yet but plan on doing so (while working on the decoy selection algorithm next).

The core internal difference this PR introduces to `monero-serai` transaction construction logic is that decoys must be selected *before* first calculating the fee. This is because a ring's `key_offsets` can vary in byte length between decoy selection attempts. By fixing the selected decoys at the start of tx construction, the tx builder can immediately calculate the tx's weight, calculate the fee based on that weight, and settle on the user's change.

Of note, there is a theoretical discrepancy to wallet2 that I noted in a comment in the function `calculate_weight_and_fee`. This discrepancy should never apply in practice. In short, wallet2 can theoretically use an estimate that is significantly different from what the calculated tx fee should be, which could cause wallet2 to use a fee that is not calculated from the final tx's weight. This does not occur in practice to the best of my knowledge; wallet2 *always* under-estimates the fee today by a small margin (it could have happened in the past when there were very few outputs in the chain). The reason I kept this theoretical discrepancy in `monero-serai` is because handling it would require copying brittle code from wallet2 that has oddities (and what look like bugs) that would be a pain to integrate cleanly for no practical gain (e.g. wallet2 does not factor in the expected final weight of tx extra in its initial estimate, while the CLI, RPC, and GUI do factor in the estimated weight of a payment ID in tx extra only if sending to an integrated address).