### PR TITLE
docs/Getting Started.md: cargo build --release --all-features

### DIFF
--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -59,7 +59,7 @@ cargo install --git https://github.com/foundry-rs/foundry --profile local --lock
 ```
 git clone https://github.com/serai-dex/serai
 cd serai
-cargo build --release
+cargo build --release --all-features
 ```
 
 ### Run Tests


### PR DESCRIPTION
Calling:
`cargo build --release`

Throws errors:
![Screenshot 2023-07-12 at 12 51 19 pm](https://github.com/serai-dex/serai/assets/14280689/8b86091d-5448-4125-8b4e-74719e06150a)

Suggested solution fixed this:
![Screenshot 2023-07-12 at 12 51 57 pm](https://github.com/serai-dex/serai/assets/14280689/9c8a6575-0f9e-4580-8be5-d1b317246c78)