### PR TITLE
Improve provided handling

### DIFF
--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -649,6 +649,18 @@ async fn handle_processor_messages<D: Db, Pro: Processors, P: P2p>(
               log::trace!("providing transaction {}", hex::encode(tx.hash()));
               let res = tributary.tributary.provide_transaction(tx).await;
               if !(res.is_ok() || (res == Err(ProvidedError::AlreadyProvided))) {
+                if res == Err(ProvidedError::LocalMismatchesOnChain) {
+                  // Spin, since this is a crit for this Tributary
+                  loop {
+                    log::error!(
+                      "{}. tributary: {}, provided: SubstrateBlock({})",
+                      "tributary added distinct provided to delayed locally provided TX",
+                      hex::encode(tributary.spec.genesis()),
+                      block,
+                    );
+                    sleep(Duration::from_secs(60)).await;
+                  }
+                }
                 panic!("provided an invalid transaction: {res:?}");
               }
             }
@@ -956,8 +968,20 @@ async fn handle_processor_messages<D: Db, Pro: Processors, P: P2p>(
           match tx.kind() {
             TransactionKind::Provided(_) => {
               log::trace!("providing transaction {}", hex::encode(tx.hash()));
-              let res = tributary.provide_transaction(tx).await;
+              let res = tributary.provide_transaction(tx.clone()).await;
               if !(res.is_ok() || (res == Err(ProvidedError::AlreadyProvided))) {
+                if res == Err(ProvidedError::LocalMismatchesOnChain) {
+                  // Spin, since this is a crit for this Tributary
+                  loop {
+                    log::error!(
+                      "{}. tributary: {}, provided: {:?}",
+                      "tributary added distinct provided to delayed locally provided TX",
+                      hex::encode(spec.genesis()),
+                      &tx,
+                    );
+                    sleep(Duration::from_secs(60)).await;
+                  }
+                }
                 panic!("provided an invalid transaction: {res:?}");
               }
             }

--- a/coordinator/src/tributary/scanner.rs
+++ b/coordinator/src/tributary/scanner.rs
@@ -120,6 +120,11 @@ pub(crate) async fn handle_new_blocks<
   let mut last_block = db.last_block(genesis);
   while let Some(next) = tributary.block_after(&last_block) {
     let block = tributary.block(&next).unwrap();
+
+    if !tributary.provided_waiting_list_empty() {
+      return;
+    }
+
     handle_block::<_, _, _, _, _, _, P>(
       db,
       key,

--- a/coordinator/tributary/src/lib.rs
+++ b/coordinator/tributary/src/lib.rs
@@ -397,6 +397,10 @@ impl<D: Db, T: TransactionTrait> TributaryReader<D, T> {
       .map(|commit| Commit::<Validators>::decode(&mut commit.as_ref()).unwrap().end_time)
   }
 
+  pub fn provided_waiting_list_empty(&self) -> bool {
+    Blockchain::<D, T>::provided_waiting_list_empty(&self.0, self.1)
+  }
+
   // This isn't static, yet can be read with only minor discrepancy risks
   pub fn tip(&self) -> [u8; 32] {
     Blockchain::<D, T>::tip_from_db(&self.0, self.1)

--- a/coordinator/tributary/src/lib.rs
+++ b/coordinator/tributary/src/lib.rs
@@ -397,8 +397,8 @@ impl<D: Db, T: TransactionTrait> TributaryReader<D, T> {
       .map(|commit| Commit::<Validators>::decode(&mut commit.as_ref()).unwrap().end_time)
   }
 
-  pub fn provided_waiting_list_empty(&self) -> bool {
-    Blockchain::<D, T>::provided_waiting_list_empty(&self.0, self.1)
+  pub fn provided_txs_ok_for_block(&self, hash: &[u8; 32], order: &str) -> bool {
+    Blockchain::<D, T>::provided_txs_ok_for_block(&self.0, &self.1, hash, order)
   }
 
   // This isn't static, yet can be read with only minor discrepancy risks

--- a/coordinator/tributary/src/lib.rs
+++ b/coordinator/tributary/src/lib.rs
@@ -397,8 +397,8 @@ impl<D: Db, T: TransactionTrait> TributaryReader<D, T> {
       .map(|commit| Commit::<Validators>::decode(&mut commit.as_ref()).unwrap().end_time)
   }
 
-  pub fn provided_txs_ok_for_block(&self, hash: &[u8; 32], order: &str) -> bool {
-    Blockchain::<D, T>::provided_txs_ok_for_block(&self.0, &self.1, hash, order)
+  pub fn locally_provided_txs_in_block(&self, hash: &[u8; 32], order: &str) -> bool {
+    Blockchain::<D, T>::locally_provided_txs_in_block(&self.0, &self.1, hash, order)
   }
 
   // This isn't static, yet can be read with only minor discrepancy risks

--- a/coordinator/tributary/src/tendermint/mod.rs
+++ b/coordinator/tributary/src/tendermint/mod.rs
@@ -35,10 +35,7 @@ use tendermint::{
   SlashEvent,
 };
 
-use tokio::{
-  sync::RwLock,
-  time::{Duration, sleep},
-};
+use tokio::sync::RwLock;
 
 use crate::{
   TENDERMINT_MESSAGE, TRANSACTION_MESSAGE, BLOCK_MESSAGE, ReadWrite,
@@ -412,9 +409,6 @@ impl<D: Db, T: TransactionTrait, P: P2p> Network for TendermintNetwork<D, T, P> 
             hex::encode(hash),
             hex::encode(self.genesis)
           );
-          // TODO: Use a notification system for when we have a new provided, in order to minimize
-          // latency
-          sleep(Duration::from_secs(Self::block_time().into())).await;
         }
         _ => return invalid_block(),
       }

--- a/coordinator/tributary/src/tendermint/mod.rs
+++ b/coordinator/tributary/src/tendermint/mod.rs
@@ -357,12 +357,15 @@ impl<D: Db, T: TransactionTrait, P: P2p> Network for TendermintNetwork<D, T, P> 
   async fn validate(&mut self, block: &Self::Block) -> Result<(), TendermintBlockError> {
     let block =
       Block::read::<&[u8]>(&mut block.0.as_ref()).map_err(|_| TendermintBlockError::Fatal)?;
-    self.blockchain.read().await.verify_block::<Self>(&block, self.signature_scheme()).map_err(
-      |e| match e {
+    self
+      .blockchain
+      .read()
+      .await
+      .verify_block::<Self>(&block, self.signature_scheme(), false)
+      .map_err(|e| match e {
         BlockError::NonLocalProvided(_) => TendermintBlockError::Temporal,
         _ => TendermintBlockError::Fatal,
-      },
-    )
+      })
   }
 
   async fn add_block(

--- a/coordinator/tributary/src/tests/block.rs
+++ b/coordinator/tributary/src/tests/block.rs
@@ -82,6 +82,7 @@ fn empty_block() {
     Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
   };
   let unsigned_in_chain = |_: [u8; 32]| false;
+  let provided_in_chain = |_: [u8; 32]| false;
   Block::<NonceTransaction>::new(LAST, vec![], vec![])
     .verify::<N>(
       GENESIS,
@@ -91,7 +92,7 @@ fn empty_block() {
       validators,
       commit,
       unsigned_in_chain,
-      unsigned_in_chain,
+      provided_in_chain,
       false,
     )
     .unwrap();
@@ -116,6 +117,7 @@ fn duplicate_nonces() {
       Some(Commit::<Arc<Validators>> { end_time: 0, validators: vec![], signature: vec![] })
     };
     let unsigned_in_chain = |_: [u8; 32]| false;
+    let provided_in_chain = |_: [u8; 32]| false;
 
     let res = Block::new(LAST, vec![], mempool).verify::<N>(
       GENESIS,
@@ -125,7 +127,7 @@ fn duplicate_nonces() {
       validators.clone(),
       commit,
       unsigned_in_chain,
-      unsigned_in_chain,
+      provided_in_chain,
       false,
     );
     if i == 1 {

--- a/coordinator/tributary/src/tests/block.rs
+++ b/coordinator/tributary/src/tests/block.rs
@@ -91,6 +91,8 @@ fn empty_block() {
       validators,
       commit,
       unsigned_in_chain,
+      unsigned_in_chain,
+      false,
     )
     .unwrap();
 }
@@ -123,6 +125,8 @@ fn duplicate_nonces() {
       validators.clone(),
       commit,
       unsigned_in_chain,
+      unsigned_in_chain,
+      false,
     );
     if i == 1 {
       res.unwrap();

--- a/coordinator/tributary/src/tests/blockchain.rs
+++ b/coordinator/tributary/src/tests/blockchain.rs
@@ -219,7 +219,7 @@ fn provided_transaction() {
 
   let tx = random_provided_transaction(&mut OsRng);
 
-  // This should be provideable
+  // This should be providable
   let mut db = MemDb::new();
   let mut txs = ProvidedTransactions::<_, ProvidedTransaction>::new(db.clone(), genesis);
   txs.provide(tx.clone()).unwrap();

--- a/coordinator/tributary/src/tests/blockchain.rs
+++ b/coordinator/tributary/src/tests/blockchain.rs
@@ -276,7 +276,7 @@ fn provided_transaction() {
 
     // make sure we won't return ok for the block before we actually got the txs
     let TransactionKind::Provided(order) = tx1.kind() else { panic!("tx wasn't provided") };
-    assert!(!Blockchain::<MemDb, ProvidedTransaction>::provided_txs_ok_for_block(
+    assert!(!Blockchain::<MemDb, ProvidedTransaction>::locally_provided_txs_in_block(
       &db,
       &genesis,
       &block1.hash(),
@@ -285,7 +285,7 @@ fn provided_transaction() {
     // provide the first tx
     blockchain.provide_transaction(tx1).unwrap();
     // it should be ok for this order now, since the second tx has different order.
-    assert!(Blockchain::<MemDb, ProvidedTransaction>::provided_txs_ok_for_block(
+    assert!(Blockchain::<MemDb, ProvidedTransaction>::locally_provided_txs_in_block(
       &db,
       &genesis,
       &block1.hash(),
@@ -294,7 +294,7 @@ fn provided_transaction() {
 
     // give the second tx
     let TransactionKind::Provided(order) = tx3.kind() else { panic!("tx wasn't provided") };
-    assert!(!Blockchain::<MemDb, ProvidedTransaction>::provided_txs_ok_for_block(
+    assert!(!Blockchain::<MemDb, ProvidedTransaction>::locally_provided_txs_in_block(
       &db,
       &genesis,
       &block1.hash(),
@@ -302,7 +302,7 @@ fn provided_transaction() {
     ));
     blockchain.provide_transaction(tx3).unwrap();
     // it should be ok now for the first block
-    assert!(Blockchain::<MemDb, ProvidedTransaction>::provided_txs_ok_for_block(
+    assert!(Blockchain::<MemDb, ProvidedTransaction>::locally_provided_txs_in_block(
       &db,
       &genesis,
       &block1.hash(),
@@ -312,7 +312,7 @@ fn provided_transaction() {
     // provide the second block txs
     let TransactionKind::Provided(order) = tx4.kind() else { panic!("tx wasn't provided") };
     // not ok yet
-    assert!(!Blockchain::<MemDb, ProvidedTransaction>::provided_txs_ok_for_block(
+    assert!(!Blockchain::<MemDb, ProvidedTransaction>::locally_provided_txs_in_block(
       &db,
       &genesis,
       &block2.hash(),
@@ -320,7 +320,7 @@ fn provided_transaction() {
     ));
     blockchain.provide_transaction(tx4).unwrap();
     // ok now
-    assert!(Blockchain::<MemDb, ProvidedTransaction>::provided_txs_ok_for_block(
+    assert!(Blockchain::<MemDb, ProvidedTransaction>::locally_provided_txs_in_block(
       &db,
       &genesis,
       &block2.hash(),
@@ -329,14 +329,14 @@ fn provided_transaction() {
 
     // provide the second block txs
     let TransactionKind::Provided(order) = tx2.kind() else { panic!("tx wasn't provided") };
-    assert!(!Blockchain::<MemDb, ProvidedTransaction>::provided_txs_ok_for_block(
+    assert!(!Blockchain::<MemDb, ProvidedTransaction>::locally_provided_txs_in_block(
       &db,
       &genesis,
       &block2.hash(),
       order
     ));
     blockchain.provide_transaction(tx2).unwrap();
-    assert!(Blockchain::<MemDb, ProvidedTransaction>::provided_txs_ok_for_block(
+    assert!(Blockchain::<MemDb, ProvidedTransaction>::locally_provided_txs_in_block(
       &db,
       &genesis,
       &block2.hash(),

--- a/coordinator/tributary/src/tests/blockchain.rs
+++ b/coordinator/tributary/src/tests/blockchain.rs
@@ -48,7 +48,7 @@ fn block_addition() {
 
   assert_eq!(block.header.parent, genesis);
   assert_eq!(block.header.transactions, [0; 32]);
-  blockchain.verify_block::<N>(&block, validators.clone()).unwrap();
+  blockchain.verify_block::<N>(&block, validators.clone(), false).unwrap();
   assert!(blockchain.add_block::<N>(&block, vec![], validators).is_ok());
   assert_eq!(blockchain.tip(), block.hash());
   assert_eq!(blockchain.block_number(), 1);
@@ -71,14 +71,14 @@ fn invalid_block() {
     #[allow(clippy::redundant_clone)] // False positive
     let mut block = block.clone();
     block.header.parent = Blake2s256::digest(block.header.parent).into();
-    assert!(blockchain.verify_block::<N>(&block, validators.clone()).is_err());
+    assert!(blockchain.verify_block::<N>(&block, validators.clone(), false).is_err());
   }
 
   // Mutate tranactions merkle
   {
     let mut block = block;
     block.header.transactions = Blake2s256::digest(block.header.transactions).into();
-    assert!(blockchain.verify_block::<N>(&block, validators.clone()).is_err());
+    assert!(blockchain.verify_block::<N>(&block, validators.clone(), false).is_err());
   }
 
   let key = Zeroizing::new(<Ristretto as Ciphersuite>::F::random(&mut OsRng));
@@ -89,7 +89,7 @@ fn invalid_block() {
     // Manually create the block to bypass build_block's checks
     let block = Block::new(blockchain.tip(), vec![], vec![Transaction::Application(tx.clone())]);
     assert_eq!(block.header.transactions, merkle(&[tx.hash()]));
-    assert!(blockchain.verify_block::<N>(&block, validators.clone()).is_err());
+    assert!(blockchain.verify_block::<N>(&block, validators.clone(), false).is_err());
   }
 
   // Run the rest of the tests with them as a participant
@@ -99,7 +99,7 @@ fn invalid_block() {
   {
     let block = Block::new(blockchain.tip(), vec![], vec![Transaction::Application(tx.clone())]);
     assert_eq!(block.header.transactions, merkle(&[tx.hash()]));
-    blockchain.verify_block::<N>(&block, validators.clone()).unwrap();
+    blockchain.verify_block::<N>(&block, validators.clone(), false).unwrap();
   }
 
   {
@@ -112,11 +112,11 @@ fn invalid_block() {
     ));
     let mut block = blockchain.build_block::<N>(validators.clone());
     assert_eq!(block.header.transactions, merkle(&[tx.hash()]));
-    blockchain.verify_block::<N>(&block, validators.clone()).unwrap();
+    blockchain.verify_block::<N>(&block, validators.clone(), false).unwrap();
 
     // And verify mutating the transactions merkle now causes a failure
     block.header.transactions = merkle(&[]);
-    assert!(blockchain.verify_block::<N>(&block, validators.clone()).is_err());
+    assert!(blockchain.verify_block::<N>(&block, validators.clone(), false).is_err());
   }
 
   {
@@ -124,7 +124,7 @@ fn invalid_block() {
     let tx = crate::tests::signed_transaction(&mut OsRng, genesis, &key, 5);
     // Manually create the block to bypass build_block's checks
     let block = Block::new(blockchain.tip(), vec![], vec![Transaction::Application(tx)]);
-    assert!(blockchain.verify_block::<N>(&block, validators.clone()).is_err());
+    assert!(blockchain.verify_block::<N>(&block, validators.clone(), false).is_err());
   }
 
   {
@@ -136,14 +136,14 @@ fn invalid_block() {
       validators.clone()
     ));
     let mut block = blockchain.build_block::<N>(validators.clone());
-    blockchain.verify_block::<N>(&block, validators.clone()).unwrap();
+    blockchain.verify_block::<N>(&block, validators.clone(), false).unwrap();
     match &mut block.transactions[0] {
       Transaction::Application(tx) => {
         tx.1.signature.s += <Ristretto as Ciphersuite>::F::ONE;
       }
       _ => panic!("non-signed tx found"),
     }
-    assert!(blockchain.verify_block::<N>(&block, validators.clone()).is_err());
+    assert!(blockchain.verify_block::<N>(&block, validators.clone(), false).is_err());
 
     // Make sure this isn't because the merkle changed due to the transaction hash including the
     // signature (which it explicitly isn't allowed to anyways)
@@ -191,7 +191,7 @@ fn signed_transaction() {
     );
 
     // Verify and add the block
-    blockchain.verify_block::<N>(&block, validators.clone()).unwrap();
+    blockchain.verify_block::<N>(&block, validators.clone(), false).unwrap();
     assert!(blockchain.add_block::<N>(&block, vec![], validators.clone()).is_ok());
     assert_eq!(blockchain.tip(), block.hash());
   };
@@ -215,42 +215,64 @@ fn signed_transaction() {
 fn provided_transaction() {
   let genesis = new_genesis();
   let validators = Arc::new(Validators::new(genesis, vec![]).unwrap());
-  let (_, mut blockchain) = new_blockchain::<ProvidedTransaction>(genesis, &[]);
+  let (db, mut blockchain) = new_blockchain::<ProvidedTransaction>(genesis, &[]);
 
   let tx = random_provided_transaction(&mut OsRng);
 
   // This should be providable
-  let mut db = MemDb::new();
-  let mut txs = ProvidedTransactions::<_, ProvidedTransaction>::new(db.clone(), genesis);
+  let mut temp_db = MemDb::new();
+  let mut txs = ProvidedTransactions::<_, ProvidedTransaction>::new(temp_db.clone(), genesis);
   txs.provide(tx.clone()).unwrap();
   assert_eq!(txs.provide(tx.clone()), Err(ProvidedError::AlreadyProvided));
   assert_eq!(
-    ProvidedTransactions::<_, ProvidedTransaction>::new(db.clone(), genesis).transactions,
+    ProvidedTransactions::<_, ProvidedTransaction>::new(temp_db.clone(), genesis).transactions,
     HashMap::from([("provided", VecDeque::from([tx.clone()]))]),
   );
-  let mut txn = db.txn();
+  let mut txn = temp_db.txn();
   txs.complete(&mut txn, "provided", tx.hash());
   txn.commit();
   assert!(ProvidedTransactions::<_, ProvidedTransaction>::new(db.clone(), genesis)
     .transactions
     .is_empty());
 
-  // Non-provided transactions should fail verification
-  let block = Block::new(blockchain.tip(), vec![tx.clone()], vec![]);
-  assert!(blockchain.verify_block::<N>(&block, validators.clone()).is_err());
+  // case we have the block's provided txs in our local as well
+  {
+    // Non-provided transactions should fail verification because we don't have them locally.
+    let block = Block::new(blockchain.tip(), vec![tx.clone()], vec![]);
+    assert!(blockchain.verify_block::<N>(&block, validators.clone(), false).is_err());
 
-  // Provided transactions should pass verification
-  blockchain.provide_transaction(tx.clone()).unwrap();
-  blockchain.verify_block::<N>(&block, validators.clone()).unwrap();
+    // Provided transactions should pass verification
+    blockchain.provide_transaction(tx.clone()).unwrap();
+    blockchain.verify_block::<N>(&block, validators.clone(), false).unwrap();
 
-  // add_block should work for verified blocks
-  assert!(blockchain.add_block::<N>(&block, vec![], validators.clone()).is_ok());
+    // add_block should work for verified blocks
+    assert!(blockchain.add_block::<N>(&block, vec![], validators.clone()).is_ok());
 
-  let block = Block::new(blockchain.tip(), vec![tx], vec![]);
-  // The provided transaction should no longer considered provided, causing this error
-  assert!(blockchain.verify_block::<N>(&block, validators.clone()).is_err());
-  // add_block should fail for unverified provided transactions if told to add them
-  assert!(blockchain.add_block::<N>(&block, vec![], validators.clone()).is_err());
+    let block = Block::new(blockchain.tip(), vec![tx.clone()], vec![]);
+
+    // The provided transaction should no longer considered provided but added to chain,
+    // causing this error
+    assert_eq!(
+      blockchain.verify_block::<N>(&block, validators.clone(), false),
+      Err(BlockError::ProvidedAlreadyIncluded)
+    );
+  }
+
+  // case we don't have the block's provided txs in our local
+  {
+    let tx = random_provided_transaction(&mut OsRng);
+    let block = Block::new(blockchain.tip(), vec![tx.clone()], vec![]);
+    // add_block DOES NOT fail for unverified provided transactions if told to add them,
+    // since now we can have them later.
+    assert!(blockchain.add_block::<N>(&block, vec![], validators.clone()).is_ok());
+
+    // make sure waiting list is not empty now
+    assert!(!Blockchain::<MemDb, ProvidedTransaction>::provided_waiting_list_empty(&db, genesis));
+    // we provide it now..
+    blockchain.provide_transaction(tx.clone()).unwrap();
+    // list has to be empty now
+    assert!(Blockchain::<MemDb, ProvidedTransaction>::provided_waiting_list_empty(&db, genesis));
+  }
 }
 
 #[tokio::test]
@@ -287,7 +309,7 @@ async fn tendermint_evidence_tx() {
     }
 
     // Verify and add the block
-    blockchain.verify_block::<N>(&block, validators.clone()).unwrap();
+    blockchain.verify_block::<N>(&block, validators.clone(), false).unwrap();
     assert!(blockchain.add_block::<N>(&block, vec![], validators.clone()).is_ok());
     assert_eq!(blockchain.tip(), block.hash());
   };
@@ -424,7 +446,7 @@ async fn block_tx_ordering() {
   }
 
   // should be a valid block
-  blockchain.verify_block::<N>(&block, validators.clone()).unwrap();
+  blockchain.verify_block::<N>(&block, validators.clone(), false).unwrap();
 
   // Unsigned before Provided
   {
@@ -433,7 +455,7 @@ async fn block_tx_ordering() {
     let unsigned = block.transactions.remove(128);
     block.transactions.insert(0, unsigned);
     assert_eq!(
-      blockchain.verify_block::<N>(&block, validators.clone()).unwrap_err(),
+      blockchain.verify_block::<N>(&block, validators.clone(), false).unwrap_err(),
       BlockError::WrongTransactionOrder
     );
   }
@@ -444,7 +466,7 @@ async fn block_tx_ordering() {
     let signed = block.transactions.remove(256);
     block.transactions.insert(0, signed);
     assert_eq!(
-      blockchain.verify_block::<N>(&block, validators.clone()).unwrap_err(),
+      blockchain.verify_block::<N>(&block, validators.clone(), false).unwrap_err(),
       BlockError::WrongTransactionOrder
     );
   }
@@ -454,7 +476,7 @@ async fn block_tx_ordering() {
     let mut block = block;
     block.transactions.swap(128, 256);
     assert_eq!(
-      blockchain.verify_block::<N>(&block, validators.clone()).unwrap_err(),
+      blockchain.verify_block::<N>(&block, validators.clone(), false).unwrap_err(),
       BlockError::WrongTransactionOrder
     );
   }

--- a/coordinator/tributary/src/tests/transaction/mod.rs
+++ b/coordinator/tributary/src/tests/transaction/mod.rs
@@ -62,7 +62,11 @@ impl ReadWrite for ProvidedTransaction {
 
 impl Transaction for ProvidedTransaction {
   fn kind(&self) -> TransactionKind<'_> {
-    TransactionKind::Provided("provided")
+    match self.0[0] {
+      1 => TransactionKind::Provided("order1"),
+      2 => TransactionKind::Provided("order2"),
+      _ => panic!("unknown order"),
+    }
   }
 
   fn hash(&self) -> [u8; 32] {
@@ -74,9 +78,17 @@ impl Transaction for ProvidedTransaction {
   }
 }
 
-pub fn random_provided_transaction<R: RngCore + CryptoRng>(rng: &mut R) -> ProvidedTransaction {
+pub fn random_provided_transaction<R: RngCore + CryptoRng>(
+  rng: &mut R,
+  order: &str,
+) -> ProvidedTransaction {
   let mut data = vec![0; 512];
   rng.fill_bytes(&mut data);
+  data[0] = match order {
+    "order1" => 1,
+    "order2" => 2,
+    _ => panic!("unknown order"),
+  };
   ProvidedTransaction(data)
 }
 

--- a/coordinator/tributary/src/transaction.rs
+++ b/coordinator/tributary/src/transaction.rs
@@ -87,8 +87,9 @@ pub enum TransactionKind<'a> {
   /// The only malleability is in when this transaction appears on chain. The block producer will
   /// include it when they have it. Block verification will fail for validators without it.
   ///
-  /// If super majority of validators still produce a commit for a block with a provided
-  /// transaction which isn't locally held, the chain will sleep until it is locally provided.
+  /// If a supermajority of validators produce a commit for a block with a provided transaction
+  /// which isn't locally held, the block will be added to the local chain. When the transaction is
+  /// locally provided, it will be compared for correctness to the on-chain version
   Provided(&'static str),
 
   /// An unsigned transaction, only able to be included by the block producer.

--- a/coordinator/tributary/src/transaction.rs
+++ b/coordinator/tributary/src/transaction.rs
@@ -78,7 +78,7 @@ impl ReadWrite for Signed {
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum TransactionKind<'a> {
-  /// This tranaction should be provided by every validator, in an exact order.
+  /// This transaction should be provided by every validator, in an exact order.
   ///
   /// The contained static string names the orderer to use. This allows two distinct provided
   /// transaction kinds, without a synchronized order, to be ordered within their own kind without
@@ -87,7 +87,7 @@ pub enum TransactionKind<'a> {
   /// The only malleability is in when this transaction appears on chain. The block producer will
   /// include it when they have it. Block verification will fail for validators without it.
   ///
-  /// If a supermajority of validators still produce a commit for a block with a provided
+  /// If super majority of validators still produce a commit for a block with a provided
   /// transaction which isn't locally held, the chain will sleep until it is locally provided.
   Provided(&'static str),
 

--- a/coordinator/tributary/tendermint/src/lib.rs
+++ b/coordinator/tributary/tendermint/src/lib.rs
@@ -794,9 +794,9 @@ impl<N: Network + 'static> TendermintMachine<N> {
       if self.block.log.has_consensus(self.block.round().number, Data::Prevote(Some(block.id()))) {
         match self.network.validate(block).await {
           Ok(_) => (),
-          // BlockError::Temporal is due to us not having the locally provided tx yet,
-          // since the majority has voted on this block, it should be us that
-          // have the problem. So we just accept that the block is valid.
+          // BlockError::Temporal is due to a temporal error we have, yet a supermajority of the
+          // network does not, Because we do not believe this block to be fatally invalid, and
+          // because a supermajority deems it valid, accept it.
           Err(BlockError::Temporal) => (),
           Err(BlockError::Fatal) => {
             log::warn!(target: "tendermint", "Validator proposed a fatally invalid block");

--- a/coordinator/tributary/tendermint/src/lib.rs
+++ b/coordinator/tributary/tendermint/src/lib.rs
@@ -794,6 +794,9 @@ impl<N: Network + 'static> TendermintMachine<N> {
       if self.block.log.has_consensus(self.block.round().number, Data::Prevote(Some(block.id()))) {
         match self.network.validate(block).await {
           Ok(_) => (),
+          // BlockError::Temporal is due to us not having the locally provided tx yet,
+          // since the majority has voted on this block, it should be us that
+          // have the problem. So we just accept that the block is valid.
           Err(BlockError::Temporal) => (),
           Err(BlockError::Fatal) => {
             log::warn!(target: "tendermint", "Validator proposed a fatally invalid block");


### PR DESCRIPTION
Instead of preventing a node adding a tributary block that contains provided tx(s) that doesn't locally available, we add the block to tributary(since it would be acknowledged the by the network anyway) and let the node participates in the consensus as usual. But we stop handling(scanning) the block by the coordinator until it has the provided txs in the block locally available.

So provided tx completion now happens on coordinator scanner instead of within the tributary.

Tackles https://github.com/serai-dex/serai/issues/366.