### PR TITLE
Monero: add more legacy verify functions

### DIFF
--- a/coins/monero/src/bin/reserialize_chain.rs
+++ b/coins/monero/src/bin/reserialize_chain.rs
@@ -20,66 +20,7 @@ mod binaries {
     rpc::{RpcError, Rpc, HttpRpc},
   };
 
-  async fn get_outs(rpc: &Rpc<HttpRpc>, amount: u64, indexes: &[u64]) -> Vec<[EdwardsPoint; 2]> {
-    #[derive(Deserialize, Debug)]
-    struct Out {
-      key: String,
-      mask: String,
-    }
-
-    #[derive(Deserialize, Debug)]
-    struct Outs {
-      outs: Vec<Out>,
-    }
-
-    let outs: Outs = loop {
-      match rpc
-        .rpc_call(
-          "get_outs",
-          Some(json!({
-            "get_txid": true,
-            "outputs": indexes.iter().map(|o| json!({
-              "amount": amount,
-              "index": o
-            })).collect::<Vec<_>>()
-          })),
-        )
-        .await
-      {
-        Ok(outs) => break outs,
-        Err(RpcError::ConnectionError) => {
-          println!("get_outs ConnectionError");
-          continue;
-        }
-        Err(e) => panic!("couldn't connect to RPC to get outs: {e:?}"),
-      }
-    };
-
-    let rpc_point = |point: &str| {
-      CompressedEdwardsY(
-        hex::decode(point)
-          .expect("invalid hex for ring member")
-          .try_into()
-          .expect("invalid point len for ring member"),
-      )
-      .decompress()
-      .expect("invalid point for ring member")
-    };
-
-    outs
-      .outs
-      .iter()
-      .map(|out| {
-        let mask = rpc_point(&out.mask);
-        if amount != 0 {
-          assert_eq!(mask, Commitment::new(Scalar::from(1u8), amount).calculate());
-        }
-        [rpc_point(&out.key), mask]
-      })
-      .collect()
-  }
   pub(crate) use tokio::task::JoinHandle;
-  use monero_serai::ringct::mlsag::RingMatrix;
 
   pub(crate) async fn check_block(rpc: Arc<Rpc<HttpRpc>>, block_i: usize) {
     let hash = loop {
@@ -188,68 +129,9 @@ mod binaries {
         // Accordingly, making sure our signature_hash algorithm is correct is great, and further
         // making sure the verification functions are valid is appreciated
         match tx.rct_signatures.prunable {
-          RctPrunable::Null => {}
-          RctPrunable::AggregateMlsagBorromean { borromean, mlsag } => {
-            borromean
-              .iter()
-              .zip(&tx.rct_signatures.base.commitments)
-              .for_each(|(borro, commitment)| assert!(borro.verify(commitment)));
-
-            let mut ring = RingMatrix::aggregate_builder(
-              &tx.rct_signatures.base.commitments,
-              tx.rct_signatures.base.fee,
-            );
-            let mut key_images = Vec::new();
-
-            for input in &tx.prefix.inputs {
-              let (amount, key_offsets, image) = match input {
-                Input::Gen(_) => panic!("Input::Gen"),
-                Input::ToKey { amount, key_offsets, key_image } => (amount, key_offsets, key_image),
-              };
-
-              let mut running_sum = 0;
-              let mut actual_indexes = vec![];
-              for offset in key_offsets {
-                running_sum += offset;
-                actual_indexes.push(running_sum);
-              }
-
-              ring.push_ring(&get_outs(&rpc, amount.unwrap_or(0), &actual_indexes).await).unwrap();
-              key_images.push(image);
-            }
-
-            mlsag.verify(&sig_hash, &ring.finish(), &key_images).unwrap();
-          }
-          RctPrunable::MlsagBorromean { borromean, mlsags } => {
-            borromean
-              .iter()
-              .zip(tx.rct_signatures.base.commitments)
-              .for_each(|(borro, commitment)| assert!(borro.verify(&commitment)));
-
-            for ((i, mlsag), pseudo_out) in
-              mlsags.into_iter().enumerate().zip(tx.rct_signatures.base.pseudo_outs)
-            {
-              let (amount, key_offsets, image) = match &tx.prefix.inputs[i] {
-                Input::Gen(_) => panic!("Input::Gen"),
-                Input::ToKey { amount, key_offsets, key_image } => (amount, key_offsets, key_image),
-              };
-
-              let mut running_sum = 0;
-              let mut actual_indexes = vec![];
-              for offset in key_offsets {
-                running_sum += offset;
-                actual_indexes.push(running_sum);
-              }
-
-              let ring = RingMatrix::simple(
-                &get_outs(&rpc, amount.unwrap_or(0), &actual_indexes).await,
-                pseudo_out,
-              )
-              .unwrap();
-
-              mlsag.verify(&sig_hash, &ring, &[image]).unwrap();
-            }
-          }
+          RctPrunable::Null |
+          RctPrunable::AggregateMlsagBorromean { .. } |
+          RctPrunable::MlsagBorromean { .. } => {}
           RctPrunable::MlsagBulletproofs { bulletproofs, .. } => {
             assert!(bulletproofs.batch_verify(
               &mut rand_core::OsRng,

--- a/coins/monero/src/block.rs
+++ b/coins/monero/src/block.rs
@@ -79,20 +79,25 @@ impl Block {
     merkle_root(self.miner_tx.hash(), &self.txs)
   }
 
+  /// Serializes the block into the format required to get the proof of work hash, this is different
+  /// to the format for the block hash, to get the block hash use the [`Block::hash`] function.
   pub fn serialize_hashable(&self) -> Vec<u8> {
     let mut blob = self.header.serialize();
     blob.extend_from_slice(&self.tx_merkle_root());
     write_varint(&(1 + u64::try_from(self.txs.len()).unwrap()), &mut blob).unwrap();
 
-    let mut out = Vec::with_capacity(8 + blob.len());
-    write_varint(&u64::try_from(blob.len()).unwrap(), &mut out).unwrap();
-    out.append(&mut blob);
-
-    out
+    blob
   }
 
   pub fn hash(&self) -> [u8; 32] {
-    let hash = hash(&self.serialize_hashable());
+    let mut hashable = self.serialize_hashable();
+    // Monero pre-appends a VarInt of the block hashing blobs length before getting the block hash
+    // but doesn't do this when getting the proof of work hash :)
+    let mut hashing_blob = Vec::with_capacity(8 + hashable.len());
+    write_varint(&u64::try_from(hashable.len()).unwrap(), &mut hashing_blob).unwrap();
+    hashing_blob.append(&mut hashable);
+
+    let hash = hash(&hashing_blob);
     if hash == CORRECT_BLOCK_HASH_202612 {
       return EXISTING_BLOCK_HASH_202612;
     };

--- a/coins/monero/src/block.rs
+++ b/coins/monero/src/block.rs
@@ -17,8 +17,8 @@ const EXISTING_BLOCK_HASH_202612: [u8; 32] =
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct BlockHeader {
-  pub major_version: u64,
-  pub minor_version: u64,
+  pub major_version: u8,
+  pub minor_version: u8,
   pub timestamp: u64,
   pub previous: [u8; 32],
   pub nonce: u32,
@@ -68,7 +68,7 @@ impl Block {
   pub fn write<W: Write>(&self, w: &mut W) -> io::Result<()> {
     self.header.write(w)?;
     self.miner_tx.write(w)?;
-    write_varint(&self.txs.len().try_into().unwrap(), w)?;
+    write_varint(&self.txs.len(), w)?;
     for tx in &self.txs {
       w.write_all(tx)?;
     }
@@ -110,7 +110,7 @@ impl Block {
     Ok(Block {
       header: BlockHeader::read(r)?,
       miner_tx: Transaction::read(r)?,
-      txs: (0 .. read_varint(r)?).map(|_| read_bytes(r)).collect::<Result<_, _>>()?,
+      txs: (0_usize .. read_varint(r)?).map(|_| read_bytes(r)).collect::<Result<_, _>>()?,
     })
   }
 }

--- a/coins/monero/src/block.rs
+++ b/coins/monero/src/block.rs
@@ -79,7 +79,7 @@ impl Block {
     merkle_root(self.miner_tx.hash(), &self.txs)
   }
 
-  fn serialize_hashable(&self) -> Vec<u8> {
+  pub fn serialize_hashable(&self) -> Vec<u8> {
     let mut blob = self.header.serialize();
     blob.extend_from_slice(&self.tx_merkle_root());
     write_varint(&(1 + u64::try_from(self.txs.len()).unwrap()), &mut blob).unwrap();

--- a/coins/monero/src/block.rs
+++ b/coins/monero/src/block.rs
@@ -79,8 +79,10 @@ impl Block {
     merkle_root(self.miner_tx.hash(), &self.txs)
   }
 
-  /// Serializes the block into the format required to get the proof of work hash, this is different
-  /// to the format for the block hash, to get the block hash use the [`Block::hash`] function.
+  /// Serialize the block as required for the proof of work hash.
+  ///
+  /// This is distinct from the serialization required for the block hash. To get the block hash,
+  /// use the [`Block::hash`] function.
   pub fn serialize_hashable(&self) -> Vec<u8> {
     let mut blob = self.header.serialize();
     blob.extend_from_slice(&self.tx_merkle_root());

--- a/coins/monero/src/lib.rs
+++ b/coins/monero/src/lib.rs
@@ -26,12 +26,12 @@ use serialize::{read_byte, read_u16};
 /// UnreducedScalar struct with functionality for recovering incorrectly reduced scalars.
 mod unreduced_scalar;
 
+/// Ring Signature structs and functionality.
+pub mod ring_signatures;
+
 /// RingCT structs and functionality.
 pub mod ringct;
 use ringct::RctType;
-
-/// Ring Signature structs with verifying functions.
-pub mod ring_signatures;
 
 /// Transaction structs.
 pub mod transaction;

--- a/coins/monero/src/lib.rs
+++ b/coins/monero/src/lib.rs
@@ -23,8 +23,7 @@ mod merkle;
 mod serialize;
 use serialize::{read_byte, read_u16};
 
-/// UnreducedScalar struct with functionality for recovering incorrectly reduced
-/// scalars.
+/// UnreducedScalar struct with functionality for recovering incorrectly reduced scalars.
 mod unreduced_scalar;
 
 /// RingCT structs and functionality.
@@ -32,7 +31,7 @@ pub mod ringct;
 use ringct::RctType;
 
 /// Ring Signature structs with verifying functions.
-mod ring_signatures;
+pub mod ring_signatures;
 
 /// Transaction structs.
 pub mod transaction;

--- a/coins/monero/src/lib.rs
+++ b/coins/monero/src/lib.rs
@@ -27,6 +27,9 @@ use serialize::{read_byte, read_u16};
 pub mod ringct;
 use ringct::RctType;
 
+/// Ring Signature structs with verifying functions.
+mod ring_signatures;
+
 /// Transaction structs.
 pub mod transaction;
 /// Block structs.

--- a/coins/monero/src/lib.rs
+++ b/coins/monero/src/lib.rs
@@ -23,6 +23,10 @@ mod merkle;
 mod serialize;
 use serialize::{read_byte, read_u16};
 
+/// UnreducedScalar struct with functionality for recovering incorrectly reduced
+/// scalars.
+mod unreduced_scalar;
+
 /// RingCT structs and functionality.
 pub mod ringct;
 use ringct::RctType;

--- a/coins/monero/src/ring_signatures.rs
+++ b/coins/monero/src/ring_signatures.rs
@@ -1,0 +1,70 @@
+use std_shims::io::{self, *};
+
+use curve25519_dalek::edwards::EdwardsPoint;
+use curve25519_dalek::scalar::Scalar;
+use dalek_ff_group::ED25519_BASEPOINT_TABLE;
+
+use monero_generators::hash_to_point;
+
+use crate::{serialize::*, hash_to_scalar};
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Signature {
+  c: Scalar,
+  r: Scalar,
+}
+
+impl Signature {
+  pub fn write<W: Write>(&self, w: &mut W) -> io::Result<()> {
+    write_scalar(&self.c, w)?;
+    write_scalar(&self.r, w)?;
+    Ok(())
+  }
+
+  pub fn read<R: Read>(r: &mut R) -> io::Result<Signature> {
+    Ok(Signature { c: read_scalar(r)?, r: read_scalar(r)? })
+  }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct RingSignature {
+  sigs: Vec<Signature>,
+}
+
+impl RingSignature {
+  pub fn write<W: Write>(&self, w: &mut W) -> io::Result<()> {
+    for sig in &self.sigs {
+      sig.write(w)?;
+    }
+    Ok(())
+  }
+
+  pub fn read<R: Read>(members: usize, r: &mut R) -> io::Result<RingSignature> {
+    Ok(RingSignature { sigs: read_raw_vec(Signature::read, members, r)? })
+  }
+
+  pub fn verify_ring_signature(
+    &self,
+    msg: &[u8; 32],
+    ring: &[EdwardsPoint],
+    key_image: &EdwardsPoint,
+  ) -> bool {
+    let mut buf = Vec::with_capacity(32 + 32 * 2 * ring.len());
+    buf.extend_from_slice(msg);
+
+    let mut sum = Scalar::zero();
+
+    for (ring_member, sig) in ring.iter().zip(&self.sigs) {
+      #[allow(non_snake_case)]
+      let Li = &sig.r * &ED25519_BASEPOINT_TABLE + sig.c * ring_member;
+      buf.extend_from_slice(Li.compress().as_bytes());
+      #[allow(non_snake_case)]
+      let Ri = sig.r * hash_to_point(ring_member.compress().to_bytes()) + sig.c * key_image;
+      buf.extend_from_slice(Ri.compress().as_bytes());
+
+      sum += sig.c;
+    }
+
+    sum == hash_to_scalar(&buf)
+  }
+}

--- a/coins/monero/src/ring_signatures.rs
+++ b/coins/monero/src/ring_signatures.rs
@@ -1,4 +1,7 @@
-use std_shims::io::{self, *};
+use std_shims::{
+  io::{self, *},
+  vec::Vec,
+};
 
 use curve25519_dalek::{EdwardsPoint, Scalar, constants::ED25519_BASEPOINT_TABLE};
 

--- a/coins/monero/src/ring_signatures.rs
+++ b/coins/monero/src/ring_signatures.rs
@@ -1,8 +1,6 @@
 use std_shims::io::{self, *};
 
-use curve25519_dalek::edwards::EdwardsPoint;
-use curve25519_dalek::scalar::Scalar;
-use dalek_ff_group::ED25519_BASEPOINT_TABLE;
+use curve25519_dalek::{EdwardsPoint, Scalar, constants::ED25519_BASEPOINT_TABLE};
 
 use monero_generators::hash_to_point;
 

--- a/coins/monero/src/ring_signatures.rs
+++ b/coins/monero/src/ring_signatures.rs
@@ -52,11 +52,11 @@ impl RingSignature {
     let mut buf = Vec::with_capacity(32 + 32 * 2 * ring.len());
     buf.extend_from_slice(msg);
 
-    let mut sum = Scalar::zero();
+    let mut sum = Scalar::ZERO;
 
     for (ring_member, sig) in ring.iter().zip(&self.sigs) {
       #[allow(non_snake_case)]
-      let Li = &sig.r * &ED25519_BASEPOINT_TABLE + sig.c * ring_member;
+      let Li = &sig.r * ED25519_BASEPOINT_TABLE + sig.c * ring_member;
       buf.extend_from_slice(Li.compress().as_bytes());
       #[allow(non_snake_case)]
       let Ri = sig.r * hash_to_point(ring_member.compress().to_bytes()) + sig.c * key_image;

--- a/coins/monero/src/ringct/borromean.rs
+++ b/coins/monero/src/ringct/borromean.rs
@@ -1,15 +1,11 @@
 use core::fmt::Debug;
 use std_shims::io::{self, Read, Write};
 
-use curve25519_dalek::edwards::EdwardsPoint;
-use curve25519_dalek::scalar::Scalar;
-use curve25519_dalek::traits::Identity;
+use curve25519_dalek::{EdwardsPoint, Scalar, traits::Identity};
 
 use monero_generators::H_pow_2;
 
-use crate::hash_to_scalar;
-use crate::unreduced_scalar::UnreducedScalar;
-use crate::serialize::*;
+use crate::{hash_to_scalar, unreduced_scalar::UnreducedScalar, serialize::*};
 
 /// 64 Borromean ring signatures.
 ///

--- a/coins/monero/src/ringct/clsag/mod.rs
+++ b/coins/monero/src/ringct/clsag/mod.rs
@@ -180,7 +180,7 @@ fn core(
     let c_c = mu_C * c;
 
     let L = (&s[i] * ED25519_BASEPOINT_TABLE) + (c_p * P[i]) + (c_c * C[i]);
-    let PH = hash_to_point(P[i]);
+    let PH = hash_to_point(&P[i]);
     // Shouldn't be an issue as all of the variables in this vartime statement are public
     let R = (s[i] * PH) + images_precomp.vartime_multiscalar_mul([c_p, c_c]);
 
@@ -219,7 +219,7 @@ impl Clsag {
     let pseudo_out = Commitment::new(mask, input.commitment.amount).calculate();
     let z = input.commitment.mask - mask;
 
-    let H = hash_to_point(input.decoys.ring[r][0]);
+    let H = hash_to_point(&input.decoys.ring[r][0]);
     let D = H * z;
     let mut s = Vec::with_capacity(input.decoys.ring.len());
     for _ in 0 .. input.decoys.ring.len() {
@@ -259,7 +259,7 @@ impl Clsag {
         &msg,
         nonce.deref() * ED25519_BASEPOINT_TABLE,
         nonce.deref() *
-          hash_to_point(inputs[i].2.decoys.ring[usize::from(inputs[i].2.decoys.i)][0]),
+          hash_to_point(&inputs[i].2.decoys.ring[usize::from(inputs[i].2.decoys.i)][0]),
       );
       clsag.s[usize::from(inputs[i].2.decoys.i)] =
         (-((p * inputs[i].0.deref()) + c)) + nonce.deref();

--- a/coins/monero/src/ringct/clsag/multisig.rs
+++ b/coins/monero/src/ringct/clsag/multisig.rs
@@ -116,7 +116,7 @@ impl ClsagMultisig {
     ClsagMultisig {
       transcript,
 
-      H: hash_to_point(output_key),
+      H: hash_to_point(&output_key),
       image: EdwardsPoint::identity(),
 
       details,

--- a/coins/monero/src/ringct/hash_to_point.rs
+++ b/coins/monero/src/ringct/hash_to_point.rs
@@ -3,6 +3,6 @@ use curve25519_dalek::edwards::EdwardsPoint;
 pub use monero_generators::{hash_to_point as raw_hash_to_point};
 
 /// Monero's hash to point function, as named `ge_fromfe_frombytes_vartime`.
-pub fn hash_to_point(key: EdwardsPoint) -> EdwardsPoint {
+pub fn hash_to_point(key: &EdwardsPoint) -> EdwardsPoint {
   raw_hash_to_point(key.compress().to_bytes())
 }

--- a/coins/monero/src/ringct/mlsag.rs
+++ b/coins/monero/src/ringct/mlsag.rs
@@ -87,7 +87,7 @@ impl Mlsag {
       // keep the msg in the buffer.
       buf.drain(msg.len() ..);
 
-      if ci == Scalar::zero() {
+      if ci == Scalar::ZERO {
         return Err(MlsagError::InvalidCi);
       }
     }

--- a/coins/monero/src/ringct/mlsag.rs
+++ b/coins/monero/src/ringct/mlsag.rs
@@ -5,12 +5,22 @@ use std_shims::{
 
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::edwards::EdwardsPoint;
-use curve25519_dalek::traits::Identity;
 
 use monero_generators::H;
 
 use crate::serialize::*;
 use crate::{hash_to_scalar, ringct::hash_to_point};
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
+pub enum MlsagError {
+  #[cfg_attr(feature = "std", error("invalid ring"))]
+  InvalidRing,
+  #[cfg_attr(feature = "std", error("invalid amount of key images"))]
+  InvalidAmountOfKeyImages,
+  #[cfg_attr(feature = "std", error("invalid ci"))]
+  InvalidCi,
+}
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Mlsag {
@@ -35,72 +45,16 @@ impl Mlsag {
     })
   }
 
-  /// Verifies an aggregate MLSAG signature, an aggregate signature is over multiple inputs.
-  pub fn verify_aggregate(
+  pub fn verify(
     &self,
     msg: &[u8; 32],
-    rings: &[impl AsRef<[[EdwardsPoint; 2]]>],
-    out_pks: &[EdwardsPoint],
-    fee: u64,
+    ring: &RingMatrix,
     key_images: &[&EdwardsPoint],
-  ) -> bool {
-    // The idea behind the aggregate signature is to add all the inputs commitments and check that
-    // when we take the inputs from the outputs we get a commitment to 0. We can't simply sum the
-    // decoys as it's only one decoys commitment that is actually being used, so what we do is sum
-    // the decoys commitments at the same index, so for a 2 input transaction we sum the first decoy
-    // of the first input with the first decoy of the second input continuing for each decoy. We
-    // then take away the fee and the sum of outputs from each of those sums.
-    //
-    // This means that the real spend will be at the same index for each input, hurting privacy.
-
-    let decoys = rings[0].as_ref().len();
-    let inputs = rings.len();
-
-    let sum_out_pk = out_pks.iter().sum::<EdwardsPoint>();
-    #[allow(non_snake_case)]
-    let H_fee = H() * Scalar::from(fee);
-
-    // We start with separate matrix's for keys and commitments.
-    let mut key_matrix = vec![vec![EdwardsPoint::identity(); inputs + 1]; decoys];
-
-    for (i, ring) in rings.iter().enumerate() {
-      for (j, member) in ring.as_ref().iter().enumerate() {
-        key_matrix[j][i] = member[0];
-        key_matrix[j][inputs] += member[1];
-      }
-    }
-
-    for i in 0 .. decoys {
-      key_matrix[i][inputs] += -sum_out_pk - H_fee;
-    }
-
-    self.verify(msg, &key_matrix, key_images)
-  }
-
-  /// Verifies a simple MLSAG signature, a simple signature is over a single input only.
-  pub fn verify_simple(
-    &self,
-    msg: &[u8; 32],
-    ring: &[[EdwardsPoint; 2]],
-    key_image: &EdwardsPoint,
-    pseudo_out: &EdwardsPoint,
-  ) -> bool {
-    let mut ring_matrix = Vec::with_capacity(ring.len());
-    for member in ring.iter() {
-      ring_matrix.push([member[0], member[1] - pseudo_out].to_vec())
-    }
-
-    self.verify(msg, &ring_matrix, &[key_image])
-  }
-
-  fn verify(
-    &self,
-    msg: &[u8; 32],
-    ring: &[Vec<EdwardsPoint>],
-    key_images: &[&EdwardsPoint],
-  ) -> bool {
-    if ring.is_empty() {
-      return false;
+  ) -> Result<(), MlsagError> {
+    // Mlsag allows for layers to not need link-ability hence they don't need key images
+    // Monero requires that there is always only 1 non-linkable layer - the amount commitments.
+    if ring.member_len() != key_images.len() + 1 {
+      return Err(MlsagError::InvalidAmountOfKeyImages);
     }
 
     let mut buf = Vec::with_capacity(6 * 32);
@@ -108,35 +62,137 @@ impl Mlsag {
 
     let mut ci = self.cc;
 
-    let key_images_iter =
-      key_images.iter().map(|ki| Some(*ki)).chain(Some(None).into_iter().cycle());
+    // This is an iterator over the key images as options with an added entry of `None` at the
+    // end for the non-linkable layer
+    let key_images_iter = key_images.iter().map(|ki| Some(*ki)).chain(Some(None));
 
-    for (col, ss) in ring.iter().zip(&self.ss) {
-      for ((ring_member, s), ki) in col.iter().zip(ss).zip(key_images_iter.clone()) {
+    for (ring_member, ss) in ring.iter().zip(&self.ss) {
+      for ((ring_member_layer, s), ki) in ring_member.iter().zip(ss).zip(key_images_iter.clone()) {
         #[allow(non_snake_case)]
-        let L = EdwardsPoint::vartime_double_scalar_mul_basepoint(&ci, &ring_member, &s);
+        let L = EdwardsPoint::vartime_double_scalar_mul_basepoint(&ci, ring_member_layer, s);
 
-        buf.extend_from_slice(ring_member.compress().as_bytes());
+        buf.extend_from_slice(ring_member_layer.compress().as_bytes());
         buf.extend_from_slice(L.compress().as_bytes());
 
         // Not all dimensions need to be linkable, e.g. commitments, and only linkable layers need
         // to have key images.
         if let Some(ki) = ki {
           #[allow(non_snake_case)]
-          let R = (s * hash_to_point(ring_member)) + (ci * ki);
+          let R = (s * hash_to_point(ring_member_layer)) + (ci * ki);
           buf.extend_from_slice(R.compress().as_bytes());
         }
       }
 
       ci = hash_to_scalar(&buf);
-      buf.clear();
-      buf.extend_from_slice(msg);
+      // keep the msg in the buffer.
+      buf.drain(msg.len() ..);
 
       if ci == Scalar::zero() {
-        return false;
+        return Err(MlsagError::InvalidCi);
       }
     }
 
-    ci == self.cc
+    if ci == self.cc {
+      Ok(())
+    } else {
+      Err(MlsagError::InvalidCi)
+    }
+  }
+}
+
+pub struct RingMatrix {
+  matrix: Vec<Vec<EdwardsPoint>>,
+}
+
+impl RingMatrix {
+  /// Construct a simple ring matrix.
+  pub fn simple(ring: &[[EdwardsPoint; 2]], pseudo_out: EdwardsPoint) -> Result<Self, MlsagError> {
+    if ring.is_empty() {
+      return Err(MlsagError::InvalidRing);
+    }
+
+    let mut matrix = Vec::with_capacity(ring.len());
+
+    for ring_member in ring {
+      matrix.push(vec![ring_member[0], ring_member[1] - pseudo_out])
+    }
+
+    Ok(RingMatrix { matrix })
+  }
+
+  /// Returns a builder that can be used to construct an aggregate ring matrix
+  pub fn aggregate_builder(commitments: &[EdwardsPoint], fee: u64) -> AggregateRingMatrix {
+    AggregateRingMatrix::new(commitments, fee)
+  }
+
+  pub fn iter(&self) -> impl Iterator<Item = &[EdwardsPoint]> {
+    self.matrix.iter().map(|ring_member| ring_member.as_slice())
+  }
+
+  /// Returns the length of one ring member, a ring member is a set of keys
+  /// that are linked, one of which are the real spends.
+  pub fn member_len(&self) -> usize {
+    // this is safe to do as the constructors don't allow empty rings
+    self.matrix[0].len()
+  }
+}
+
+/// An aggregate ring matrix builder, used to set up the ring matrix to prove/
+/// verify an aggregate signature.
+pub struct AggregateRingMatrix {
+  key_ring: Vec<Vec<EdwardsPoint>>,
+  amounts_ring: Vec<EdwardsPoint>,
+  sum_out_commitments: EdwardsPoint,
+  fee: EdwardsPoint,
+}
+
+impl AggregateRingMatrix {
+  pub fn new(commitments: &[EdwardsPoint], fee: u64) -> Self {
+    AggregateRingMatrix {
+      key_ring: vec![],
+      amounts_ring: vec![],
+      sum_out_commitments: commitments.iter().sum::<EdwardsPoint>(),
+      fee: H() * Scalar::from(fee),
+    }
+  }
+
+  /// push a ring, aka input, to this aggregate ring matrix.
+  pub fn push_ring(&mut self, ring: &[[EdwardsPoint; 2]]) -> Result<(), MlsagError> {
+    if self.amounts_ring.is_empty() {
+      // This is our fist ring, now we know the length of the decoys fill the
+      // `amounts_ring` table, so we don't have to loop back over and take
+      // these values off at the end.
+      self.amounts_ring = vec![-self.sum_out_commitments - self.fee; ring.len()];
+    }
+
+    if self.amounts_ring.len() != ring.len() || ring.is_empty() {
+      // All the rings in an aggregate matrix must be the same length.
+      return Err(MlsagError::InvalidRing);
+    }
+
+    for (i, ring_member) in ring.iter().enumerate() {
+      if let Some(entry) = self.key_ring.get_mut(i) {
+        entry.push(ring_member[0]);
+      } else {
+        self.key_ring.push(vec![ring_member[0]])
+      }
+
+      self.amounts_ring[i] += ring_member[1]
+    }
+
+    Ok(())
+  }
+
+  /// Finalize and return the [`RingMatrix`]
+  ///
+  /// This will panic if no rings have been added.
+  pub fn finish(mut self) -> RingMatrix {
+    assert!(!self.key_ring.is_empty(), "No ring members entered, can't build empty ring");
+
+    for (i, amount_commitment) in self.amounts_ring.drain(..).enumerate() {
+      self.key_ring[i].push(amount_commitment)
+    }
+
+    RingMatrix { matrix: self.key_ring }
   }
 }

--- a/coins/monero/src/ringct/mod.rs
+++ b/coins/monero/src/ringct/mod.rs
@@ -61,7 +61,7 @@ impl EncryptedAmount {
 pub enum RctType {
   /// No RCT proofs.
   Null,
-  /// One MLSAG for a single input and a Borromean range proof (RCTTypeFull).
+  /// One MLSAG for multiple inputs and Borromean range proofs (RCTTypeFull).
   MlsagAggregate,
   // One MLSAG for each input and a Borromean range proof (RCTTypeSimple).
   MlsagIndividual,

--- a/coins/monero/src/ringct/mod.rs
+++ b/coins/monero/src/ringct/mod.rs
@@ -293,7 +293,7 @@ impl RctPrunable {
       }
       RctType::Clsag | RctType::BulletproofsPlus => RctPrunable::Clsag {
         bulletproofs: {
-          if read_varint(r)? != 1 {
+          if read_varint::<_, u64>(r)? != 1 {
             Err(io::Error::new(io::ErrorKind::Other, "n bulletproofs instead of one"))?;
           }
           (if rct_type == RctType::Clsag { Bulletproofs::read } else { Bulletproofs::read_plus })(

--- a/coins/monero/src/ringct/mod.rs
+++ b/coins/monero/src/ringct/mod.rs
@@ -28,7 +28,7 @@ use crate::{
 
 /// Generate a key image for a given key. Defined as `x * hash_to_point(xG)`.
 pub fn generate_key_image(secret: &Zeroizing<Scalar>) -> EdwardsPoint {
-  hash_to_point(&(&ED25519_BASEPOINT_TABLE * secret.deref())) * secret.deref()
+  hash_to_point(&(ED25519_BASEPOINT_TABLE * secret.deref())) * secret.deref()
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/coins/monero/src/ringct/mod.rs
+++ b/coins/monero/src/ringct/mod.rs
@@ -28,7 +28,7 @@ use crate::{
 
 /// Generate a key image for a given key. Defined as `x * hash_to_point(xG)`.
 pub fn generate_key_image(secret: &Zeroizing<Scalar>) -> EdwardsPoint {
-  hash_to_point(ED25519_BASEPOINT_TABLE * secret.deref()) * secret.deref()
+  hash_to_point(&(&ED25519_BASEPOINT_TABLE * secret.deref())) * secret.deref()
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -194,6 +194,10 @@ impl RctBase {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum RctPrunable {
   Null,
+  AggregateMlsagBorromean {
+    borromean: Vec<BorromeanRange>,
+    mlsag: Mlsag,
+  },
   MlsagBorromean {
     borromean: Vec<BorromeanRange>,
     mlsags: Vec<Mlsag>,
@@ -220,6 +224,10 @@ impl RctPrunable {
   pub fn write<W: Write>(&self, w: &mut W, rct_type: RctType) -> io::Result<()> {
     match self {
       RctPrunable::Null => Ok(()),
+      RctPrunable::AggregateMlsagBorromean { borromean, mlsag } => {
+        write_raw_vec(BorromeanRange::write, borromean, w)?;
+        mlsag.write(w)
+      }
       RctPrunable::MlsagBorromean { borromean, mlsags } => {
         write_raw_vec(BorromeanRange::write, borromean, w)?;
         write_raw_vec(Mlsag::write, mlsags, w)
@@ -270,9 +278,13 @@ impl RctPrunable {
 
     Ok(match rct_type {
       RctType::Null => RctPrunable::Null,
-      RctType::MlsagAggregate | RctType::MlsagIndividual => RctPrunable::MlsagBorromean {
+      RctType::MlsagAggregate => RctPrunable::AggregateMlsagBorromean {
         borromean: read_raw_vec(BorromeanRange::read, outputs, r)?,
-        mlsags: decoys.iter().map(|d| Mlsag::read(*d, r)).collect::<Result<_, _>>()?,
+        mlsag: Mlsag::read(decoys[0], decoys.len() + 1, r)?,
+      },
+      RctType::MlsagIndividual => RctPrunable::MlsagBorromean {
+        borromean: read_raw_vec(BorromeanRange::read, outputs, r)?,
+        mlsags: decoys.iter().map(|d| Mlsag::read(*d, 2, r)).collect::<Result<_, _>>()?,
       },
       RctType::Bulletproofs | RctType::BulletproofsCompactAmount => {
         RctPrunable::MlsagBulletproofs {
@@ -287,7 +299,7 @@ impl RctPrunable {
             }
             Bulletproofs::read(r)?
           },
-          mlsags: decoys.iter().map(|d| Mlsag::read(*d, r)).collect::<Result<_, _>>()?,
+          mlsags: decoys.iter().map(|d| Mlsag::read(*d, 2, r)).collect::<Result<_, _>>()?,
           pseudo_outs: read_raw_vec(read_point, decoys.len(), r)?,
         }
       }
@@ -309,6 +321,7 @@ impl RctPrunable {
   pub(crate) fn signature_write<W: Write>(&self, w: &mut W) -> io::Result<()> {
     match self {
       RctPrunable::Null => panic!("Serializing RctPrunable::Null for a signature"),
+      RctPrunable::AggregateMlsagBorromean { borromean, .. } |
       RctPrunable::MlsagBorromean { borromean, .. } => {
         borromean.iter().try_for_each(|rs| rs.write(w))
       }
@@ -329,30 +342,8 @@ impl RctSignatures {
   pub fn rct_type(&self) -> RctType {
     match &self.prunable {
       RctPrunable::Null => RctType::Null,
-      RctPrunable::MlsagBorromean { .. } => {
-        /*
-          This type of RctPrunable may have no outputs, yet pseudo_outs are per input
-          This will only be a valid RctSignatures if it's for a TX with inputs
-          That makes this valid for any valid RctSignatures
-
-          While it will be invalid for any invalid RctSignatures, potentially letting an invalid
-          MlsagAggregate be interpreted as a valid MlsagIndividual (or vice versa), they have
-          incompatible deserializations
-
-          This means it's impossible to receive a MlsagAggregate over the wire and interpret it
-          as a MlsagIndividual (or vice versa)
-
-          That only makes manual manipulation unsafe, which will always be true since these fields
-          are all pub
-
-          TODO: Consider making them private with read-only accessors?
-        */
-        if self.base.pseudo_outs.is_empty() {
-          RctType::MlsagAggregate
-        } else {
-          RctType::MlsagIndividual
-        }
-      }
+      RctPrunable::AggregateMlsagBorromean { .. } => RctType::MlsagAggregate,
+      RctPrunable::MlsagBorromean { .. } => RctType::MlsagIndividual,
       // RctBase ensures there's at least one output, making the following
       // inferences guaranteed/expects impossible on any valid RctSignatures
       RctPrunable::MlsagBulletproofs { .. } => {

--- a/coins/monero/src/rpc/mod.rs
+++ b/coins/monero/src/rpc/mod.rs
@@ -305,23 +305,27 @@ impl<R: RpcConnection> Rpc<R> {
   }
 
   pub async fn get_block_by_number(&self, number: usize) -> Result<Block, RpcError> {
-    match self.get_block(self.get_block_hash(number).await?).await {
-      Ok(block) => {
-        // Make sure this is actually the block for this number
-        match block.miner_tx.prefix.inputs.first() {
-          Some(Input::Gen(actual)) => {
-            if usize::try_from(*actual).unwrap() == number {
-              Ok(block)
-            } else {
-              Err(RpcError::InvalidNode("different block than requested (number)"))
-            }
-          }
-          _ => {
-            Err(RpcError::InvalidNode("block's miner_tx didn't have an input of kind Input::Gen"))
-          }
+    #[derive(Deserialize, Debug)]
+    struct BlockResponse {
+      blob: String,
+    }
+
+    let res: BlockResponse =
+      self.json_rpc_call("get_block", Some(json!({ "height": number }))).await?;
+
+    let block = Block::read::<&[u8]>(&mut rpc_hex(&res.blob)?.as_ref())
+      .map_err(|_| RpcError::InvalidNode("invalid block"))?;
+
+    // Make sure this is actually the block for this number
+    match block.miner_tx.prefix.inputs.first(0) {
+      Some(Input::Gen(actual)) => {
+        if usize::try_from(*actual).unwrap() == number {
+          Ok(block)
+        } else {
+          Err(RpcError::InvalidNode("different block than requested (number)"))
         }
       }
-      e => e,
+      Err(RpcError::InvalidNode("block's miner_tx didn't have an input of kind Input::Gen")),
     }
   }
 

--- a/coins/monero/src/rpc/mod.rs
+++ b/coins/monero/src/rpc/mod.rs
@@ -317,7 +317,7 @@ impl<R: RpcConnection> Rpc<R> {
       .map_err(|_| RpcError::InvalidNode("invalid block"))?;
 
     // Make sure this is actually the block for this number
-    match block.miner_tx.prefix.inputs.first(0) {
+    match block.miner_tx.prefix.inputs.first() {
       Some(Input::Gen(actual)) => {
         if usize::try_from(*actual).unwrap() == number {
           Ok(block)
@@ -325,7 +325,7 @@ impl<R: RpcConnection> Rpc<R> {
           Err(RpcError::InvalidNode("different block than requested (number)"))
         }
       }
-      Err(RpcError::InvalidNode("block's miner_tx didn't have an input of kind Input::Gen")),
+      _ => Err(RpcError::InvalidNode("block's miner_tx didn't have an input of kind Input::Gen")),
     }
   }
 

--- a/coins/monero/src/tests/mod.rs
+++ b/coins/monero/src/tests/mod.rs
@@ -1,3 +1,4 @@
+mod unreduced_scalar;
 mod clsag;
 mod bulletproofs;
 mod address;

--- a/coins/monero/src/tests/unreduced_scalar.rs
+++ b/coins/monero/src/tests/unreduced_scalar.rs
@@ -1,0 +1,32 @@
+use curve25519_dalek::scalar::Scalar;
+
+use crate::unreduced_scalar::*;
+
+#[test]
+fn recover_scalars() {
+  let test_recover = |stored: &str, recovered: &str| {
+    let stored = UnreducedScalar(hex::decode(stored).unwrap().try_into().unwrap());
+    let recovered =
+      Scalar::from_canonical_bytes(hex::decode(recovered).unwrap().try_into().unwrap()).unwrap();
+    assert_eq!(stored.recover_monero_slide_scalar(), recovered);
+  };
+
+  // https://www.moneroinflation.com/static/data_py/report_scalars_df.pdf
+  // Table 4.
+  test_recover(
+    "cb2be144948166d0a9edb831ea586da0c376efa217871505ad77f6ff80f203f8",
+    "b8ffd6a1aee47828808ab0d4c8524cb5c376efa217871505ad77f6ff80f20308",
+  );
+  test_recover(
+    "343d3df8a1051c15a400649c423dc4ed58bef49c50caef6ca4a618b80dee22f4",
+    "21113355bc682e6d7a9d5b3f2137a30259bef49c50caef6ca4a618b80dee2204",
+  );
+  test_recover(
+    "c14f75d612800ca2c1dcfa387a42c9cc086c005bc94b18d204dd61342418eba7",
+    "4f473804b1d27ab2c789c80ab21d034a096c005bc94b18d204dd61342418eb07",
+  );
+  test_recover(
+    "000102030405060708090a0b0c0d0e0f826c4f6e2329a31bc5bc320af0b2bcbb",
+    "a124cfd387f461bf3719e03965ee6877826c4f6e2329a31bc5bc320af0b2bc0b",
+  );
+}

--- a/coins/monero/src/transaction.rs
+++ b/coins/monero/src/transaction.rs
@@ -206,7 +206,7 @@ impl TransactionPrefix {
     self.timelock.write(w)?;
     write_vec(Input::write, &self.inputs, w)?;
     write_vec(Output::write, &self.outputs, w)?;
-    write_varint(&self.extra.len().try_into().unwrap(), w)?;
+    write_varint(&self.extra.len(), w)?;
     w.write_all(&self.extra)
   }
 

--- a/coins/monero/src/transaction.rs
+++ b/coins/monero/src/transaction.rs
@@ -11,8 +11,8 @@ use curve25519_dalek::edwards::{EdwardsPoint, CompressedEdwardsY};
 use crate::{
   Protocol, hash,
   serialize::*,
-  ringct::{bulletproofs::Bulletproofs, RctType, RctBase, RctPrunable, RctSignatures},
   ring_signatures::RingSignature,
+  ringct::{bulletproofs::Bulletproofs, RctType, RctBase, RctPrunable, RctSignatures},
 };
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/coins/monero/src/transaction.rs
+++ b/coins/monero/src/transaction.rs
@@ -6,10 +6,7 @@ use std_shims::{
 
 use zeroize::Zeroize;
 
-use curve25519_dalek::{
-  scalar::Scalar,
-  edwards::{EdwardsPoint, CompressedEdwardsY},
-};
+use curve25519_dalek::edwards::{EdwardsPoint, CompressedEdwardsY};
 
 use crate::{
   Protocol, hash,

--- a/coins/monero/src/transaction.rs
+++ b/coins/monero/src/transaction.rs
@@ -390,6 +390,10 @@ impl Transaction {
 
   /// Calculate the hash of this transaction as needed for signing it.
   pub fn signature_hash(&self) -> [u8; 32] {
+    if self.prefix.version == 1 {
+      return self.prefix.hash();
+    }
+
     let mut buf = Vec::with_capacity(2048);
     let mut sig_hash = Vec::with_capacity(96);
 

--- a/coins/monero/src/unreduced_scalar.rs
+++ b/coins/monero/src/unreduced_scalar.rs
@@ -12,7 +12,7 @@ static PRECOMPUTED_SCALARS_CELL: OnceLock<[Scalar; 8]> = OnceLock::new();
 #[allow(non_snake_case)]
 pub fn PRECOMPUTED_SCALARS() -> [Scalar; 8] {
   *PRECOMPUTED_SCALARS_CELL.get_or_init(|| {
-    let mut precomputed_scalars = [Scalar::one(); 8];
+    let mut precomputed_scalars = [Scalar::ONE; 8];
     for (i, scalar) in precomputed_scalars.iter_mut().enumerate().skip(1) {
       *scalar = Scalar::from((i * 2 + 1) as u8);
     }
@@ -120,7 +120,7 @@ impl UnreducedScalar {
 
     let precomputed_scalars = PRECOMPUTED_SCALARS();
 
-    let mut recovered = Scalar::zero();
+    let mut recovered = Scalar::ZERO;
 
     for &numb in naf.iter().rev() {
       recovered += recovered;

--- a/coins/monero/src/unreduced_scalar.rs
+++ b/coins/monero/src/unreduced_scalar.rs
@@ -1,27 +1,29 @@
 use core::cmp::Ordering;
 
-use std_shims::io::{self, *};
-use std_shims::sync::OnceLock;
+use std_shims::{
+  sync::OnceLock,
+  io::{self, *},
+};
 
 use curve25519_dalek::scalar::Scalar;
 
 use crate::serialize::*;
 
 static PRECOMPUTED_SCALARS_CELL: OnceLock<[Scalar; 8]> = OnceLock::new();
-/// Precomputed scalars used to recover an incorrectly reduced scalar
+/// Precomputed scalars used to recover an incorrectly reduced scalar.
 #[allow(non_snake_case)]
-pub fn PRECOMPUTED_SCALARS() -> [Scalar; 8] {
+pub(crate) fn PRECOMPUTED_SCALARS() -> [Scalar; 8] {
   *PRECOMPUTED_SCALARS_CELL.get_or_init(|| {
     let mut precomputed_scalars = [Scalar::ONE; 8];
     for (i, scalar) in precomputed_scalars.iter_mut().enumerate().skip(1) {
-      *scalar = Scalar::from((i * 2 + 1) as u8);
+      *scalar = Scalar::from(((i * 2) + 1) as u8);
     }
     precomputed_scalars
   })
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct UnreducedScalar([u8; 32]);
+pub struct UnreducedScalar(pub [u8; 32]);
 
 impl UnreducedScalar {
   pub fn write<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -36,14 +38,10 @@ impl UnreducedScalar {
     &self.0
   }
 
-  pub fn reduce_mod_order(&self) -> Scalar {
-    Scalar::from_bytes_mod_order(self.0)
-  }
-
-  fn as_bits(&self) -> [i8; 256] {
+  fn as_bits(&self) -> [u8; 256] {
     let mut bits = [0; 256];
     for (i, bit) in bits.iter_mut().enumerate() {
-      *bit = 1 & (self.0[i >> 3] >> (i & 7)) as i8
+      *bit = core::hint::black_box(1 & (self.0[i / 8] >> (i % 8)))
     }
 
     bits
@@ -51,44 +49,50 @@ impl UnreducedScalar {
 
   /// Computes the non-adjacent form of this scalar with width 5.
   ///
-  /// This is the same as Monero's `slide` function, it intentionally gives incorrect
-  /// outputs if the last bit is set to match Monero.
+  /// This matches Monero's `slide` function and intentionally gives incorrect outputs under
+  /// certain conditions in order to match Monero.
+  ///
+  /// This function does not execute in constant time.
   fn non_adjacent_form(&self) -> [i8; 256] {
-    let mut bits = self.as_bits();
+    let bits = self.as_bits();
+    let mut naf = [0i8; 256];
+    for (b, bit) in bits.into_iter().enumerate() {
+      naf[b] = bit as i8;
+    }
 
-    #[allow(clippy::needless_range_loop)]
     for i in 0 .. 256 {
-      if bits[i] != 0 {
+      if naf[i] != 0 {
         // if the bit is a one, work our way up through the window
         // combining the bits with this bit.
         for b in 1 .. 6 {
-          if i + b >= 256 {
+          if (i + b) >= 256 {
             // if we are at the length of the array then break out
             // the loop.
             break;
           }
           // potential_carry - the value of the bit at i+b compared to the bit at i
-          let potential_carry = bits[i + b] << b;
+          let potential_carry = naf[i + b] << b;
 
           if potential_carry != 0 {
-            if bits[i] + potential_carry <= 15 {
+            if (naf[i] + potential_carry) <= 15 {
               // if our current "bit" plus the potential carry is less than 16
               // add it to our current "bit" and set the potential carry bit to 0.
-              bits[i] += potential_carry;
-              bits[i + b] = 0;
-            } else if bits[i] - potential_carry >= -15 {
+              naf[i] += potential_carry;
+              naf[i + b] = 0;
+            } else if (naf[i] - potential_carry) >= -15 {
               // else if our current "bit" minus the potential carry is more than -16
               // take it away from our current "bit".
               // we then work our way up through the bits setting ones to zero, when
               // we hit the first zero we change it to one then stop, this is to factor
               // in the minus.
-              bits[i] -= potential_carry;
-              for k in i + b .. 256 {
-                if bits[k] == 0 {
-                  bits[k] = 1;
+              naf[i] -= potential_carry;
+              #[allow(clippy::needless_range_loop)]
+              for k in (i + b) .. 256 {
+                if naf[k] == 0 {
+                  naf[k] = 1;
                   break;
                 }
-                bits[k] = 0;
+                naf[k] = 0;
               }
             } else {
               break;
@@ -98,10 +102,11 @@ impl UnreducedScalar {
       }
     }
 
-    bits
+    naf
   }
 
-  /// Recover the scalar that an array of bytes was incorrectly interpreted as.
+  /// Recover the scalar that an array of bytes was incorrectly interpreted as by Monero's `slide`
+  /// function.
   ///
   /// In Borromean range proofs Monero was not checking that the scalars used were
   /// reduced. This lead to the scalar stored being interpreted as a different scalar,
@@ -111,61 +116,22 @@ impl UnreducedScalar {
   pub fn recover_monero_slide_scalar(&self) -> Scalar {
     if self.0[31] & 128 == 0 {
       // Computing the w-NAF of a number can only give an output with 1 more bit than
-      // the number so even if the number isn't reduced the `slide` function will be
+      // the number, so even if the number isn't reduced, the `slide` function will be
       // correct when the last bit isn't set.
-      return self.reduce_mod_order();
+      return Scalar::from_bytes_mod_order(self.0);
     }
-
-    let naf = self.non_adjacent_form();
 
     let precomputed_scalars = PRECOMPUTED_SCALARS();
 
     let mut recovered = Scalar::ZERO;
-
-    for &numb in naf.iter().rev() {
+    for &numb in self.non_adjacent_form().iter().rev() {
       recovered += recovered;
-
       match numb.cmp(&0) {
-        Ordering::Greater => recovered += precomputed_scalars[numb as usize / 2],
-        Ordering::Less => recovered -= precomputed_scalars[(-numb) as usize / 2],
+        Ordering::Greater => recovered += precomputed_scalars[(numb as usize) / 2],
+        Ordering::Less => recovered -= precomputed_scalars[((-numb) as usize) / 2],
         Ordering::Equal => (),
       }
     }
-
     recovered
-  }
-}
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-
-  #[test]
-  fn recover_scalars() {
-    let test_recover = |stored: &str, recovered: &str| {
-      let stored = UnreducedScalar(hex::decode(stored).unwrap().try_into().unwrap());
-      let recovered =
-        Scalar::from_canonical_bytes(hex::decode(recovered).unwrap().try_into().unwrap()).unwrap();
-      assert_eq!(stored.recover_monero_slide_scalar(), recovered);
-    };
-
-    // https://www.moneroinflation.com/static/data_py/report_scalars_df.pdf
-    // Table 4.
-    test_recover(
-      "cb2be144948166d0a9edb831ea586da0c376efa217871505ad77f6ff80f203f8",
-      "b8ffd6a1aee47828808ab0d4c8524cb5c376efa217871505ad77f6ff80f20308",
-    );
-    test_recover(
-      "343d3df8a1051c15a400649c423dc4ed58bef49c50caef6ca4a618b80dee22f4",
-      "21113355bc682e6d7a9d5b3f2137a30259bef49c50caef6ca4a618b80dee2204",
-    );
-    test_recover(
-      "c14f75d612800ca2c1dcfa387a42c9cc086c005bc94b18d204dd61342418eba7",
-      "4f473804b1d27ab2c789c80ab21d034a096c005bc94b18d204dd61342418eb07",
-    );
-    test_recover(
-      "000102030405060708090a0b0c0d0e0f826c4f6e2329a31bc5bc320af0b2bcbb",
-      "a124cfd387f461bf3719e03965ee6877826c4f6e2329a31bc5bc320af0b2bc0b",
-    );
   }
 }

--- a/coins/monero/src/unreduced_scalar.rs
+++ b/coins/monero/src/unreduced_scalar.rs
@@ -1,0 +1,176 @@
+use std_shims::io::{self, *};
+use std_shims::sync::OnceLock;
+
+use curve25519_dalek::scalar::Scalar;
+
+use crate::serialize::*;
+
+static PRECOMPUTED_SCALARS_CELL: OnceLock<[Scalar; 8]> = OnceLock::new();
+/// Precomputed scalars used to recover an incorrectly reduced scalar
+#[allow(non_snake_case)]
+pub fn PRECOMPUTED_SCALARS() -> [Scalar; 8] {
+  *PRECOMPUTED_SCALARS_CELL.get_or_init(|| {
+    let mut precomputed_scalars = [Scalar::one(); 8];
+    for i in 1 .. 8 {
+      precomputed_scalars[i] = Scalar::from((i * 2 + 1) as u8);
+    }
+    precomputed_scalars
+  })
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct UnreducedScalar([u8; 32]);
+
+impl UnreducedScalar {
+  pub fn write<W: Write>(&self, w: &mut W) -> io::Result<()> {
+    w.write_all(&self.0)
+  }
+
+  pub fn read<R: Read>(r: &mut R) -> io::Result<UnreducedScalar> {
+    Ok(UnreducedScalar(read_bytes(r)?))
+  }
+
+  pub fn as_bytes(&self) -> &[u8; 32] {
+    &self.0
+  }
+
+  pub fn reduce_mod_order(&self) -> Scalar {
+    Scalar::from_bytes_mod_order(self.0)
+  }
+
+  fn as_bits(&self) -> [i8; 256] {
+    let mut bits = [0; 256];
+    for i in 0 .. 256 {
+      bits[i] = 1 & (self.0[i >> 3] >> (i & 7)) as i8
+    }
+
+    bits
+  }
+
+  fn non_adjacent_form(&self) -> [i8; 256] {
+    let mut bits = self.as_bits();
+
+    for i in 0 .. 256 {
+      if bits[i] != 0 {
+        for b in 1 .. 6 {
+          if i + b >= 256 {
+            break;
+          }
+          if bits[i + b] != 0 {
+            if bits[i] + (bits[i + b] << b) <= 15 {
+              bits[i] += bits[i + b] << b;
+              bits[i + b] = 0;
+            } else if bits[i] - (bits[i + b] << b) >= -15 {
+              bits[i] -= bits[i + b] << b;
+              for k in i + b .. 256 {
+                if bits[k] == 0 {
+                  bits[k] = 1;
+                  break;
+                }
+                bits[k] = 0;
+              }
+            } else {
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    bits
+  }
+
+  /// Recover the scalar that an array of bytes was incorrectly interpreted as.
+  ///
+  /// In Borromean range proofs Monero was not checking that the scalars used were
+  /// reduced. This lead to the scalar stored being interpreted as a different scalar,
+  /// this function recovers that scalar.
+  ///
+  /// See: https://github.com/monero-project/monero/issues/8438
+  pub fn recover_monero_slide_scalar(&self) -> Scalar {
+    if self.0[31] & 128 == 0 {
+      // Computing the w-NAF of a number can only give an output with 1 more bit than
+      // the number so even if the number isn't reduced the `slide` function will be
+      // correct when the last bit isn't set.
+      return self.reduce_mod_order();
+    }
+
+    let naf = self.non_adjacent_form();
+
+    let precomputed_scalars = PRECOMPUTED_SCALARS();
+
+    let mut recovered = Scalar::zero();
+
+    for &numb in naf.iter().rev() {
+      recovered += recovered;
+
+      if numb > 0 {
+        recovered += precomputed_scalars[numb as usize / 2];
+      } else if numb < 0 {
+        recovered -= precomputed_scalars[(-numb) as usize / 2];
+      }
+    }
+
+    recovered
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn recover_scalars() {
+    let test_recover = |stored: &str, recovered: &str| {
+      let stored = UnreducedScalar(hex::decode(stored).unwrap().try_into().unwrap());
+      let recovered =
+        Scalar::from_canonical_bytes(hex::decode(recovered).unwrap().try_into().unwrap()).unwrap();
+      assert_eq!(stored.recover_monero_slide_scalar(), recovered);
+    };
+
+    // https://www.moneroinflation.com/static/data_py/report_scalars_df.pdf
+    // Table 4.
+    test_recover(
+      "cb2be144948166d0a9edb831ea586da0c376efa217871505ad77f6ff80f203f8",
+      "b8ffd6a1aee47828808ab0d4c8524cb5c376efa217871505ad77f6ff80f20308",
+    );
+    test_recover(
+      "343d3df8a1051c15a400649c423dc4ed58bef49c50caef6ca4a618b80dee22f4",
+      "21113355bc682e6d7a9d5b3f2137a30259bef49c50caef6ca4a618b80dee2204",
+    );
+    test_recover(
+      "c14f75d612800ca2c1dcfa387a42c9cc086c005bc94b18d204dd61342418eba7",
+      "4f473804b1d27ab2c789c80ab21d034a096c005bc94b18d204dd61342418eb07",
+    );
+    test_recover(
+      "000102030405060708090a0b0c0d0e0f826c4f6e2329a31bc5bc320af0b2bcbb",
+      "a124cfd387f461bf3719e03965ee6877826c4f6e2329a31bc5bc320af0b2bc0b",
+    );
+  }
+
+  #[test]
+  fn non_adjacent_form() {
+    let mut bytes: [u8; 32] = rand::random();
+    bytes[31] &= 127;
+
+    let reduced_scalar = Scalar::from_bytes_mod_order(bytes.clone());
+    let scalar = UnreducedScalar(bytes);
+
+    let naf = scalar.non_adjacent_form();
+    let precomputed_scalars = PRECOMPUTED_SCALARS();
+
+    let mut recovered = Scalar::zero();
+
+    for &numb in naf.iter().rev() {
+      recovered += recovered;
+
+      if numb > 0 {
+        recovered += precomputed_scalars[numb as usize / 2];
+      } else if numb < 0 {
+        recovered -= precomputed_scalars[(-numb) as usize / 2];
+      }
+    }
+
+    assert_eq!(recovered, reduced_scalar)
+  }
+}

--- a/coins/monero/src/wallet/extra.rs
+++ b/coins/monero/src/wallet/extra.rs
@@ -110,11 +110,7 @@ impl ExtraField {
         }
         nonce
       }),
-      3 => ExtraField::MergeMining(
-        usize::try_from(read_varint(r)?)
-          .map_err(|_| io::Error::new(io::ErrorKind::Other, "varint for height exceeds usize"))?,
-        read_bytes(r)?,
-      ),
+      3 => ExtraField::MergeMining(read_varint(r)?, read_bytes(r)?),
       4 => ExtraField::PublicKeys(read_vec(read_point, r)?),
       _ => Err(io::Error::new(io::ErrorKind::Other, "unknown extra field"))?,
     })

--- a/coins/monero/src/wallet/mod.rs
+++ b/coins/monero/src/wallet/mod.rs
@@ -74,7 +74,7 @@ pub(crate) fn shared_key(
     .copy_from_slice(&hash(&[output_derivation.as_ref(), [0x8d].as_ref()].concat())[.. 8]);
 
   // || o
-  write_varint(&o.try_into().unwrap(), &mut output_derivation).unwrap();
+  write_varint(&o, &mut output_derivation).unwrap();
 
   let view_tag = hash(&[b"view_tag".as_ref(), &output_derivation].concat())[0];
 

--- a/coins/monero/src/wallet/send/multisig.rs
+++ b/coins/monero/src/wallet/send/multisig.rs
@@ -406,7 +406,9 @@ impl SignatureMachine<Transaction> for TransactionSignatureMachine {
           pseudo_outs.push(pseudo_out);
         }
       }
-      RctPrunable::MlsagBorromean { .. } | RctPrunable::MlsagBulletproofs { .. } => {
+      RctPrunable::AggregateMlsagBorromean { .. } |
+      RctPrunable::MlsagBorromean { .. } |
+      RctPrunable::MlsagBulletproofs { .. } => {
         unreachable!("attempted to sign a multisig TX which wasn't CLSAG")
       }
     }


### PR DESCRIPTION
Fixes #367 

- Adds support for verifying legacy ring signatures
- Changes blocks major/ miner versions to u8 to [match monero](https://github.com/monero-project/monero/blob/master/src/cryptonote_basic/cryptonote_basic.h#L459-L460)
- Changes more of the varint code to be generic over the integer type
- adds back support for multiple input aggregate MLSAG signatures
- adds verifying for both types of MLSAG signatures 
- adds an `UnreducedScalar` type which has a method for recovering scalars which underwent an incorrect reduction
