### PR TITLE
Monero: fix decoy selection algo and add test for latest spendable

### DIFF
--- a/coins/monero/src/lib.rs
+++ b/coins/monero/src/lib.rs
@@ -46,6 +46,10 @@ pub mod wallet;
 #[cfg(test)]
 mod tests;
 
+pub const DEFAULT_LOCK_WINDOW: usize = 10;
+pub const COINBASE_LOCK_WINDOW: usize = 60;
+pub const BLOCK_TIME: usize = 120;
+
 static INV_EIGHT_CELL: OnceLock<Scalar> = OnceLock::new();
 #[allow(non_snake_case)]
 pub(crate) fn INV_EIGHT() -> Scalar {

--- a/coins/monero/src/rpc/mod.rs
+++ b/coins/monero/src/rpc/mod.rs
@@ -565,7 +565,7 @@ impl<R: RpcConnection> Rpc<R> {
       .await?;
 
     if res.status != "OK" {
-      Err(RpcError::InvalidNode)?;
+      Err(RpcError::InvalidNode("bad response to get_outs".to_string()))?;
     }
 
     Ok(res.outs)

--- a/coins/monero/src/rpc/mod.rs
+++ b/coins/monero/src/rpc/mod.rs
@@ -595,6 +595,7 @@ impl<R: RpcConnection> Rpc<R> {
       Vec::new()
     };
 
+    // TODO: https://github.com/serai-dex/serai/issues/104
     outs
       .iter()
       .enumerate()

--- a/coins/monero/src/transaction.rs
+++ b/coins/monero/src/transaction.rs
@@ -161,7 +161,9 @@ impl Timelock {
 impl PartialOrd for Timelock {
   fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
     match (self, other) {
+      (Timelock::None, Timelock::None) => Some(Ordering::Equal),
       (Timelock::None, _) => Some(Ordering::Less),
+      (_, Timelock::None) => Some(Ordering::Greater),
       (Timelock::Block(a), Timelock::Block(b)) => a.partial_cmp(b),
       (Timelock::Time(a), Timelock::Time(b)) => a.partial_cmp(b),
       _ => None,

--- a/coins/monero/src/wallet/decoys.rs
+++ b/coins/monero/src/wallet/decoys.rs
@@ -188,9 +188,7 @@ async fn select_decoys<R: RngCore + CryptoRng, RPC: RpcConnection>(
   // Should never happen, yet risks desyncing if it did
   distribution.truncate(height);
 
-  if distribution.len() != height {
-    Err(RpcError::InternalError("unexpected rct out distribution len"))?;
-  } else if distribution.len() < DEFAULT_LOCK_WINDOW {
+  if distribution.len() < DEFAULT_LOCK_WINDOW {
     Err(RpcError::InternalError("not enough decoy candidates"))?;
   }
 

--- a/coins/monero/src/wallet/decoys.rs
+++ b/coins/monero/src/wallet/decoys.rs
@@ -341,7 +341,7 @@ impl Decoys {
   /// If no reorg has occurred and an honest RPC, any caller who passes the same height to this
   /// function will use the same distribution to select decoys. It is fingerprintable
   /// because a caller using this will not be able to select decoys that are timelocked
-  /// with a timestamp. Any transaction which includes timestamp timelocked outputs in its
+  /// with a timestamp. Any transaction which includes timestamp timelocked decoys in its
   /// rings could not be constructed using this function.
   ///
   /// TODO: upstream change to monerod get_outs RPC to accept a height param for checking

--- a/coins/monero/tests/decoys.rs
+++ b/coins/monero/tests/decoys.rs
@@ -1,0 +1,85 @@
+use monero_serai::{
+  transaction::Transaction,
+  wallet::{SpendableOutput, decoys::LOCK_WINDOW},
+  rpc::{Rpc, OutputResponse},
+  Protocol,
+};
+
+mod runner;
+
+test!(
+  select_latest_output_as_decoy,
+  (
+    // First make an initial tx0
+    |_, mut builder: Builder, addr| async move {
+      builder.add_payment(addr, 2000000000000);
+      (builder.build().unwrap(), ())
+    },
+    |rpc: Rpc<_>, tx: Transaction, mut scanner: Scanner, _| async move {
+      let output = scanner.scan_transaction(&tx).not_locked().swap_remove(0);
+      assert_eq!(output.commitment().amount, 2000000000000);
+      SpendableOutput::from(&rpc, output).await.unwrap()
+    },
+  ),
+  (
+    // Then make a second tx1
+    |protocol: Protocol, rpc: Rpc<_>, mut builder: Builder, addr, state: _| async move {
+      let output_tx0: SpendableOutput = state;
+      let decoys = Decoys::select(
+        &mut OsRng,
+        &rpc,
+        protocol.ring_len(),
+        rpc.get_height().await.unwrap(),
+        &[output_tx0.clone()],
+      )
+      .await
+      .unwrap();
+
+      let inputs = [output_tx0.clone()].into_iter().zip(decoys).collect::<Vec<_>>();
+      builder.add_inputs(&inputs);
+      builder.add_payment(addr, 1000000000000);
+
+      (builder.build().unwrap(), (protocol, output_tx0))
+    },
+    // Then make sure DSA selects freshly unlocked output from tx1 as a decoy
+    |rpc: Rpc<_>, tx: Transaction, mut scanner: Scanner, state: (_, _)| async move {
+      use rand_core::OsRng;
+
+      let height = rpc.get_height().await.unwrap();
+
+      let output_tx1 =
+        SpendableOutput::from(&rpc, scanner.scan_transaction(&tx).not_locked().swap_remove(0))
+          .await
+          .unwrap();
+
+      // Make sure output from tx1 is in the block in which it unlocks
+      let out_tx1: OutputResponse =
+        rpc.get_outs(&[output_tx1.global_index]).await.unwrap().swap_remove(0);
+      assert_eq!(out_tx1.height, height - LOCK_WINDOW);
+      assert!(out_tx1.unlocked);
+
+      // Select decoys using spendable output from tx0 as the real, and make sure DSA selects
+      // the freshly unlocked output from tx1 as a decoy
+      let (protocol, output_tx0): (Protocol, SpendableOutput) = state;
+      let mut selected_fresh_decoy = false;
+      let mut attempts = 1000;
+      while !selected_fresh_decoy && attempts > 0 {
+        let decoys = Decoys::select(
+          &mut OsRng, // TODO: use a seeded RNG to consistently select the latest output
+          &rpc,
+          protocol.ring_len(),
+          height,
+          &[output_tx0.clone()],
+        )
+        .await
+        .unwrap();
+
+        selected_fresh_decoy = decoys[0].indexes().contains(&output_tx1.global_index);
+        attempts -= 1;
+      }
+
+      assert!(selected_fresh_decoy);
+      assert_eq!(height, rpc.get_height().await.unwrap());
+    },
+  ),
+);

--- a/coins/monero/tests/decoys.rs
+++ b/coins/monero/tests/decoys.rs
@@ -25,13 +25,12 @@ test!(
     // Then make a second tx1
     |protocol: Protocol, rpc: Rpc<_>, mut builder: Builder, addr, state: _| async move {
       let output_tx0: SpendableOutput = state;
-      let decoys = Decoys::select(
+      let decoys = Decoys::fingerprintable_canonical_select(
         &mut OsRng,
         &rpc,
         protocol.ring_len(),
         rpc.get_height().await.unwrap(),
         &[output_tx0.clone()],
-        true, /*fingerprintable_canonical*/
       )
       .await
       .unwrap();
@@ -65,13 +64,12 @@ test!(
       let mut selected_fresh_decoy = false;
       let mut attempts = 1000;
       while !selected_fresh_decoy && attempts > 0 {
-        let decoys = Decoys::select(
+        let decoys = Decoys::fingerprintable_canonical_select(
           &mut OsRng, // TODO: use a seeded RNG to consistently select the latest output
           &rpc,
           protocol.ring_len(),
           height,
           &[output_tx0.clone()],
-          true, /*fingerprintable_canonical*/
         )
         .await
         .unwrap();
@@ -110,7 +108,6 @@ test!(
         protocol.ring_len(),
         rpc.get_height().await.unwrap(),
         &[output_tx0.clone()],
-        false, /*fingerprintable_canonical*/
       )
       .await
       .unwrap();
@@ -150,7 +147,6 @@ test!(
           protocol.ring_len(),
           height,
           &[output_tx0.clone()],
-          false, /*fingerprintable_canonical*/
         )
         .await
         .unwrap();

--- a/coins/monero/tests/decoys.rs
+++ b/coins/monero/tests/decoys.rs
@@ -1,8 +1,8 @@
 use monero_serai::{
   transaction::Transaction,
-  wallet::{SpendableOutput, decoys::LOCK_WINDOW},
+  wallet::SpendableOutput,
   rpc::{Rpc, OutputResponse},
-  Protocol,
+  Protocol, DEFAULT_LOCK_WINDOW,
 };
 
 mod runner;
@@ -55,7 +55,7 @@ test!(
       // Make sure output from tx1 is in the block in which it unlocks
       let out_tx1: OutputResponse =
         rpc.get_outs(&[output_tx1.global_index]).await.unwrap().swap_remove(0);
-      assert_eq!(out_tx1.height, height - LOCK_WINDOW);
+      assert_eq!(out_tx1.height, height - DEFAULT_LOCK_WINDOW);
       assert!(out_tx1.unlocked);
 
       // Select decoys using spendable output from tx0 as the real, and make sure DSA selects

--- a/coins/monero/tests/decoys.rs
+++ b/coins/monero/tests/decoys.rs
@@ -8,7 +8,7 @@ use monero_serai::{
 mod runner;
 
 test!(
-  select_latest_output_as_decoy,
+  select_latest_output_as_decoy_canonical,
   (
     // First make an initial tx0
     |_, mut builder: Builder, addr| async move {
@@ -31,6 +31,7 @@ test!(
         protocol.ring_len(),
         rpc.get_height().await.unwrap(),
         &[output_tx0.clone()],
+        true, /*fingerprintable_canonical*/
       )
       .await
       .unwrap();
@@ -70,6 +71,86 @@ test!(
           protocol.ring_len(),
           height,
           &[output_tx0.clone()],
+          true, /*fingerprintable_canonical*/
+        )
+        .await
+        .unwrap();
+
+        selected_fresh_decoy = decoys[0].indexes().contains(&output_tx1.global_index);
+        attempts -= 1;
+      }
+
+      assert!(selected_fresh_decoy);
+      assert_eq!(height, rpc.get_height().await.unwrap());
+    },
+  ),
+);
+
+test!(
+  select_latest_output_as_decoy,
+  (
+    // First make an initial tx0
+    |_, mut builder: Builder, addr| async move {
+      builder.add_payment(addr, 2000000000000);
+      (builder.build().unwrap(), ())
+    },
+    |rpc: Rpc<_>, tx: Transaction, mut scanner: Scanner, _| async move {
+      let output = scanner.scan_transaction(&tx).not_locked().swap_remove(0);
+      assert_eq!(output.commitment().amount, 2000000000000);
+      SpendableOutput::from(&rpc, output).await.unwrap()
+    },
+  ),
+  (
+    // Then make a second tx1
+    |protocol: Protocol, rpc: Rpc<_>, mut builder: Builder, addr, state: _| async move {
+      let output_tx0: SpendableOutput = state;
+      let decoys = Decoys::select(
+        &mut OsRng,
+        &rpc,
+        protocol.ring_len(),
+        rpc.get_height().await.unwrap(),
+        &[output_tx0.clone()],
+        false, /*fingerprintable_canonical*/
+      )
+      .await
+      .unwrap();
+
+      let inputs = [output_tx0.clone()].into_iter().zip(decoys).collect::<Vec<_>>();
+      builder.add_inputs(&inputs);
+      builder.add_payment(addr, 1000000000000);
+
+      (builder.build().unwrap(), (protocol, output_tx0))
+    },
+    // Then make sure DSA selects freshly unlocked output from tx1 as a decoy
+    |rpc: Rpc<_>, tx: Transaction, mut scanner: Scanner, state: (_, _)| async move {
+      use rand_core::OsRng;
+
+      let height = rpc.get_height().await.unwrap();
+
+      let output_tx1 =
+        SpendableOutput::from(&rpc, scanner.scan_transaction(&tx).not_locked().swap_remove(0))
+          .await
+          .unwrap();
+
+      // Make sure output from tx1 is in the block in which it unlocks
+      let out_tx1: OutputResponse =
+        rpc.get_outs(&[output_tx1.global_index]).await.unwrap().swap_remove(0);
+      assert_eq!(out_tx1.height, height - DEFAULT_LOCK_WINDOW);
+      assert!(out_tx1.unlocked);
+
+      // Select decoys using spendable output from tx0 as the real, and make sure DSA selects
+      // the freshly unlocked output from tx1 as a decoy
+      let (protocol, output_tx0): (Protocol, SpendableOutput) = state;
+      let mut selected_fresh_decoy = false;
+      let mut attempts = 1000;
+      while !selected_fresh_decoy && attempts > 0 {
+        let decoys = Decoys::select(
+          &mut OsRng, // TODO: use a seeded RNG to consistently select the latest output
+          &rpc,
+          protocol.ring_len(),
+          height,
+          &[output_tx0.clone()],
+          false, /*fingerprintable_canonical*/
         )
         .await
         .unwrap();

--- a/coins/monero/tests/runner.rs
+++ b/coins/monero/tests/runner.rs
@@ -268,13 +268,12 @@ macro_rules! test {
           let temp = Box::new({
             let mut builder = builder.clone();
 
-            let decoys = Decoys::select(
+            let decoys = Decoys::fingerprintable_canonical_select(
               &mut OsRng,
               &rpc,
               protocol.ring_len(),
               rpc.get_height().await.unwrap(),
               &[miner_tx.clone()],
-              true, /*fingerprintable_canonical*/
             )
             .await
             .unwrap();

--- a/coins/monero/tests/runner.rs
+++ b/coins/monero/tests/runner.rs
@@ -264,7 +264,7 @@ macro_rules! test {
               &mut OsRng,
               &rpc,
               protocol.ring_len(),
-              rpc.get_height().await.unwrap() - 1,
+              rpc.get_height().await.unwrap(),
               &[miner_tx.clone()]
             )
             .await

--- a/coins/monero/tests/send.rs
+++ b/coins/monero/tests/send.rs
@@ -28,7 +28,7 @@ async fn add_inputs(
     &mut OsRng,
     rpc,
     protocol.ring_len(),
-    rpc.get_height().await.unwrap() - 1,
+    rpc.get_height().await.unwrap(),
     &spendable_outputs,
   )
   .await

--- a/coins/monero/tests/send.rs
+++ b/coins/monero/tests/send.rs
@@ -30,6 +30,7 @@ async fn add_inputs(
     protocol.ring_len(),
     rpc.get_height().await.unwrap(),
     &spendable_outputs,
+    true, /*fingerprintable_canonical*/
   )
   .await
   .unwrap();

--- a/coins/monero/tests/send.rs
+++ b/coins/monero/tests/send.rs
@@ -24,13 +24,12 @@ async fn add_inputs(
     spendable_outputs.push(SpendableOutput::from(rpc, output).await.unwrap());
   }
 
-  let decoys = Decoys::select(
+  let decoys = Decoys::fingerprintable_canonical_select(
     &mut OsRng,
     rpc,
     protocol.ring_len(),
     rpc.get_height().await.unwrap(),
     &spendable_outputs,
-    true, /*fingerprintable_canonical*/
   )
   .await
   .unwrap();

--- a/processor/src/networks/monero.rs
+++ b/processor/src/networks/monero.rs
@@ -344,6 +344,7 @@ impl Monero {
       protocol.ring_len(),
       block_number + 1,
       &spendable_outputs,
+      true, /*fingerprintable_canonical*/
     )
     .await
     .map_err(map_rpc_err)?;
@@ -748,6 +749,7 @@ impl Network for Monero {
       protocol.ring_len(),
       self.rpc.get_height().await.unwrap(),
       &outputs,
+      true, /*fingerprintable_canonical*/
     )
     .await
     .unwrap();

--- a/processor/src/networks/monero.rs
+++ b/processor/src/networks/monero.rs
@@ -746,7 +746,7 @@ impl Network for Monero {
       &mut OsRng,
       &self.rpc,
       protocol.ring_len(),
-      self.rpc.get_height().await.unwrap() - 1,
+      self.rpc.get_height().await.unwrap(),
       &outputs,
     )
     .await

--- a/processor/src/networks/monero.rs
+++ b/processor/src/networks/monero.rs
@@ -338,13 +338,12 @@ impl Monero {
 
     // All signers need to select the same decoys
     // All signers use the same height and a seeded RNG to make sure they do so.
-    let decoys = Decoys::select(
+    let decoys = Decoys::fingerprintable_canonical_select(
       &mut ChaCha20Rng::from_seed(transcript.rng_seed(b"decoys")),
       &self.rpc,
       protocol.ring_len(),
       block_number + 1,
       &spendable_outputs,
-      true, /*fingerprintable_canonical*/
     )
     .await
     .map_err(map_rpc_err)?;
@@ -743,13 +742,12 @@ impl Network for Monero {
 
     let protocol = self.rpc.get_protocol().await.unwrap();
 
-    let decoys = Decoys::select(
+    let decoys = Decoys::fingerprintable_canonical_select(
       &mut OsRng,
       &self.rpc,
       protocol.ring_len(),
       self.rpc.get_height().await.unwrap(),
       &outputs,
-      true, /*fingerprintable_canonical*/
     )
     .await
     .unwrap();

--- a/tests/full-stack/src/tests/mint_and_burn.rs
+++ b/tests/full-stack/src/tests/mint_and_burn.rs
@@ -100,7 +100,7 @@ async fn mint_and_burn_test() {
         let rpc = producer_handles.monero(ops).await;
         let mut res = Vec::with_capacity(count);
         for _ in 0 .. count {
-          let block = rpc.get_block(rpc.generate_blocks(&addr, 1).await.unwrap()[0]).await.unwrap();
+          let block = rpc.get_block(rpc.generate_blocks(&addr, 1).await.unwrap().0[0]).await.unwrap();
 
           let mut txs = Vec::with_capacity(block.txs.len());
           for tx in &block.txs {

--- a/tests/full-stack/src/tests/mint_and_burn.rs
+++ b/tests/full-stack/src/tests/mint_and_burn.rs
@@ -366,6 +366,7 @@ async fn mint_and_burn_test() {
         Protocol::v16.ring_len(),
         rpc.get_height().await.unwrap(),
         &[output.clone()],
+        true,/*fingerprintable_canonical*/
       )
       .await
       .unwrap()

--- a/tests/full-stack/src/tests/mint_and_burn.rs
+++ b/tests/full-stack/src/tests/mint_and_burn.rs
@@ -364,7 +364,7 @@ async fn mint_and_burn_test() {
         &mut OsRng,
         &rpc,
         Protocol::v16.ring_len(),
-        rpc.get_height().await.unwrap() - 1,
+        rpc.get_height().await.unwrap(),
         &[output.clone()],
       )
       .await

--- a/tests/full-stack/src/tests/mint_and_burn.rs
+++ b/tests/full-stack/src/tests/mint_and_burn.rs
@@ -360,13 +360,12 @@ async fn mint_and_burn_test() {
         .unwrap()
         .swap_remove(0);
 
-      let decoys = Decoys::select(
+      let decoys = Decoys::fingerprintable_canonical_select(
         &mut OsRng,
         &rpc,
         Protocol::v16.ring_len(),
         rpc.get_height().await.unwrap(),
         &[output.clone()],
-        true,/*fingerprintable_canonical*/
       )
       .await
       .unwrap()

--- a/tests/processor/src/networks.rs
+++ b/tests/processor/src/networks.rs
@@ -308,13 +308,12 @@ impl Wallet {
               .expect("prior transaction was never published"),
           );
         }
-        let mut decoys = Decoys::select(
+        let mut decoys = Decoys::fingerprintable_canonical_select(
           &mut OsRng,
           &rpc,
           Protocol::v16.ring_len(),
           rpc.get_height().await.unwrap(),
           &these_inputs,
-          true, /*fingerprintable_canonical*/
         )
         .await
         .unwrap();

--- a/tests/processor/src/networks.rs
+++ b/tests/processor/src/networks.rs
@@ -314,6 +314,7 @@ impl Wallet {
           Protocol::v16.ring_len(),
           rpc.get_height().await.unwrap(),
           &these_inputs,
+          true, /*fingerprintable_canonical*/
         )
         .await
         .unwrap();

--- a/tests/processor/src/networks.rs
+++ b/tests/processor/src/networks.rs
@@ -312,7 +312,7 @@ impl Wallet {
           &mut OsRng,
           &rpc,
           Protocol::v16.ring_len(),
-          rpc.get_height().await.unwrap() - 1,
+          rpc.get_height().await.unwrap(),
           &these_inputs,
         )
         .await


### PR DESCRIPTION
- DSA only selected coinbase outputs and didn't match the wallet2 implementation
- Added test to make sure DSA will select a decoy output from the most recent unlocked block
- Made usage of "height" in DSA consistent with other usage of "height" in Monero code (height == num blocks in chain)
- Rely on monerod RPC response for output's unlocked status

_______

Could use another round after this PR to verify the DSA matches wallet2 in its entirety.

~~Planning to use wallet2 to generate 100k decoys at a specific height on mainnet, output the selections to a CSV file, then do the same with the `monero-serai` DSA, and make sure the height distributions align.~~ (DONE: https://github.com/serai-dex/serai/pull/384#issuecomment-1870597406)