### PR TITLE
Update monero-wallet-rpc to 0.18.3.1 to enable further testing of fee code

### DIFF
--- a/.github/actions/monero-wallet-rpc/action.yml
+++ b/.github/actions/monero-wallet-rpc/action.yml
@@ -5,7 +5,7 @@ inputs:
   version:
     description: "Version to download and run"
     required: false
-    default: v0.18.2.0
+    default: v0.18.3.1
 
 runs:
   using: "composite"


### PR DESCRIPTION
0.18.3.1 includes https://github.com/monero-project/monero/pull/8882, a necessary requirement.

Doesn't bump any of the nodes due to 0.18.3.x being recently released, without clear reason to update.