### PR TITLE
fix key fn not being called in getter

### DIFF
--- a/processor/src/multisigs/db.rs
+++ b/processor/src/multisigs/db.rs
@@ -112,7 +112,7 @@ impl<N: Network, D: Db> MultisigsDb<N, D> {
     getter: &G,
     tx: <N::Transaction as Transaction<N>>::Id,
   ) -> Option<[u8; 32]> {
-    getter.get(tx.as_ref()).map(|id| id.try_into().unwrap())
+    getter.get(Self::resolved_key(tx.as_ref())).map(|id| id.try_into().unwrap())
   }
   pub fn plan_by_key_with_self_change<G: Get>(
     getter: &G,


### PR DESCRIPTION
Fixed this line of code in the multisigs/db.rs file
```rust
pub fn resolved_plan<G: Get>(
    getter: &G,
    tx: <N::Transaction as Transaction<N>>::Id,
  ) -> Option<[u8; 32]> {
    getter.get(Self::resolved_key(tx.as_ref())).map(|id| id.try_into().unwrap())
}
```

