### PR TITLE
Database Macro

### DIFF
--- a/common/db/src/create_db.rs
+++ b/common/db/src/create_db.rs
@@ -23,12 +23,12 @@ pub fn db_key(db_dst: &'static [u8], item_dst: &'static [u8], key: impl AsRef<[u
 /// # Example
 ///
 /// ```no_run
-/// create_db!({
+/// create_db!(
 ///   TrubutariesDb {
 ///     AttemptsDb: (key_bytes: &[u8], attempt_id: u32) -> u64,
 ///     ExpiredDb: (genesis: [u8; 32]) -> Vec<u8>
 ///   }
-/// })
+/// )
 /// ```
 #[macro_export]
 macro_rules! create_db {

--- a/common/db/src/create_db.rs
+++ b/common/db/src/create_db.rs
@@ -22,7 +22,7 @@ pub fn db_key(db_dst: &'static [u8], item_dst: &'static [u8], key: impl AsRef<[u
 ///
 /// # Example
 ///
-/// ```no_run
+/// ```ignore
 /// create_db!(
 ///   TrubutariesDb {
 ///     AttemptsDb: (key_bytes: &[u8], attempt_id: u32) -> u64,

--- a/common/db/src/create_db.rs
+++ b/common/db/src/create_db.rs
@@ -22,7 +22,7 @@ pub fn db_key(db_dst: &'static [u8], item_dst: &'static [u8], key: impl AsRef<[u
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// create_db!({
 ///   TrubutariesDb {
 ///     AttemptsDb: (key_bytes: &[u8], attempt_id: u32) -> u64,

--- a/common/db/src/create_db.rs
+++ b/common/db/src/create_db.rs
@@ -1,0 +1,59 @@
+pub fn db_key(db_dst: &'static [u8], item_dst: &'static [u8], key: impl AsRef<[u8]>) -> Vec<u8> {
+    let db_len = u8::try_from(db_dst.len()).unwrap();
+    let dst_len = u8::try_from(item_dst.len()).unwrap();
+    [[db_len].as_ref(), db_dst, [dst_len].as_ref(), item_dst, key.as_ref()].concat()
+}
+
+/// Creates a series of structs which provide namespacing for keys
+/// 
+/// # Description
+/// 
+/// Creates a unit struct and a default implementation for the `key`, `get`, and `set`. The macro
+/// uses a syntax similar to defining a function. Parameters are concatenated to produce a key,
+/// they must be `scale` encodable. The return type is used to auto encode and decode the database
+/// value bytes using `bincode`.
+/// 
+/// # Arguments
+/// 
+/// * `db_name` - A database name
+/// * `field_name` - An item name
+/// * `args` - Comma seperated list of key arguments
+/// * `field_type` - The return type
+/// 
+/// # Example
+/// 
+/// ```
+/// create_db!({
+///   TrubutariesDb {
+///     AttemptsDb: (key_bytes: &[u8], attempt_id: u32) -> u64, 
+///     ExpiredDb: (genesis: [u8; 32]) -> Vec<u8>
+///   }
+/// })
+/// ```
+#[macro_export]
+macro_rules! create_db {
+  ($db_name: ident
+    { $($field_name: ident: ($($arg: ident: $arg_type: ty),*) -> $field_type: ty),*}
+  ) => {
+    $(
+      #[derive(Clone, Debug)]
+      pub struct $field_name;
+      impl $field_name {
+        pub fn key($($arg: $arg_type),*) -> Vec<u8> {
+          $crate::db_key(stringify!($db_name).as_bytes(), stringify!($field_name).as_bytes(), (vec![] as Vec<u8>, $($arg),*).encode())
+        }
+        #[allow(dead_code)]
+        pub fn set(txn: &mut impl DbTxn $(, $arg: $arg_type)*,  data: &impl serde::Serialize) {
+          let key = $field_name::key($($arg),*);
+          txn.put(&key, bincode::serialize(data).unwrap());
+        }
+        #[allow(dead_code)]
+        pub fn get(getter: &impl Get, $($arg: $arg_type),*) -> Option<$field_type> {
+          getter.get($field_name::key($($arg),*)).map(|data| {
+            bincode::deserialize(data.as_ref()).unwrap()
+          })
+        }
+      }
+    )*
+  };
+}

--- a/common/db/src/create_db.rs
+++ b/common/db/src/create_db.rs
@@ -1,31 +1,31 @@
 pub fn db_key(db_dst: &'static [u8], item_dst: &'static [u8], key: impl AsRef<[u8]>) -> Vec<u8> {
-    let db_len = u8::try_from(db_dst.len()).unwrap();
-    let dst_len = u8::try_from(item_dst.len()).unwrap();
-    [[db_len].as_ref(), db_dst, [dst_len].as_ref(), item_dst, key.as_ref()].concat()
+  let db_len = u8::try_from(db_dst.len()).unwrap();
+  let dst_len = u8::try_from(item_dst.len()).unwrap();
+  [[db_len].as_ref(), db_dst, [dst_len].as_ref(), item_dst, key.as_ref()].concat()
 }
 
 /// Creates a series of structs which provide namespacing for keys
-/// 
+///
 /// # Description
-/// 
+///
 /// Creates a unit struct and a default implementation for the `key`, `get`, and `set`. The macro
 /// uses a syntax similar to defining a function. Parameters are concatenated to produce a key,
 /// they must be `scale` encodable. The return type is used to auto encode and decode the database
 /// value bytes using `bincode`.
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `db_name` - A database name
 /// * `field_name` - An item name
 /// * `args` - Comma seperated list of key arguments
 /// * `field_type` - The return type
-/// 
+///
 /// # Example
-/// 
+///
 /// ```
 /// create_db!({
 ///   TrubutariesDb {
-///     AttemptsDb: (key_bytes: &[u8], attempt_id: u32) -> u64, 
+///     AttemptsDb: (key_bytes: &[u8], attempt_id: u32) -> u64,
 ///     ExpiredDb: (genesis: [u8; 32]) -> Vec<u8>
 ///   }
 /// })
@@ -40,7 +40,11 @@ macro_rules! create_db {
       pub struct $field_name;
       impl $field_name {
         pub fn key($($arg: $arg_type),*) -> Vec<u8> {
-          $crate::db_key(stringify!($db_name).as_bytes(), stringify!($field_name).as_bytes(), (vec![] as Vec<u8>, $($arg),*).encode())
+          $crate::db_key(
+            stringify!($db_name).as_bytes(),
+            stringify!($field_name).as_bytes(),
+            (vec![] as Vec<u8>, $($arg),*).encode()
+          )
         }
         #[allow(dead_code)]
         pub fn set(txn: &mut impl DbTxn $(, $arg: $arg_type)*,  data: &impl serde::Serialize) {

--- a/common/db/src/lib.rs
+++ b/common/db/src/lib.rs
@@ -1,3 +1,6 @@
+mod create_db;
+pub use create_db::*;
+
 mod mem;
 pub use mem::*;
 
@@ -5,8 +8,7 @@ pub use mem::*;
 mod rocks;
 #[cfg(feature = "rocksdb")]
 pub use rocks::{RocksDB, new_rocksdb};
-mod create_db;
-pub use create_db::*;
+
 /// An object implementing get.
 pub trait Get {
   fn get(&self, key: impl AsRef<[u8]>) -> Option<Vec<u8>>;

--- a/common/db/src/lib.rs
+++ b/common/db/src/lib.rs
@@ -5,7 +5,8 @@ pub use mem::*;
 mod rocks;
 #[cfg(feature = "rocksdb")]
 pub use rocks::{RocksDB, new_rocksdb};
-
+mod create_db;
+pub use create_db::*;
 /// An object implementing get.
 pub trait Get {
   fn get(&self, key: impl AsRef<[u8]>) -> Option<Vec<u8>>;

--- a/processor/src/key_gen.rs
+++ b/processor/src/key_gen.rs
@@ -1,6 +1,6 @@
-use core::marker::PhantomData;
 use std::collections::HashMap;
 
+use serai_db::create_db;
 use zeroize::Zeroizing;
 
 use rand_core::SeedableRng;
@@ -27,80 +27,22 @@ pub struct KeyConfirmed<C: Ciphersuite> {
   pub network_keys: Vec<ThresholdKeys<C>>,
 }
 
-#[derive(Clone, Debug)]
-struct KeyGenDb<N: Network, D: Db>(PhantomData<D>, PhantomData<N>);
-impl<N: Network, D: Db> KeyGenDb<N, D> {
-  fn key_gen_key(dst: &'static [u8], key: impl AsRef<[u8]>) -> Vec<u8> {
-    D::key(b"KEY_GEN", dst, key)
+create_db!(
+  KeyGenDb {
+    ParamsDb: (key: &ValidatorSet) -> (ThresholdParams, u16),
+    // Not scoped to the set since that'd have latter attempts overwrite former
+    // A former attempt may become the finalized attempt, even if it doesn't in a timely manner
+    // Overwriting its commitments would be accordingly poor
+    CommitmentsDb: (key: &KeyGenId) -> HashMap<Participant, Vec<u8>>,
+    GeneratedKeysDb: (set: &ValidatorSet, substrate_key: &[u8; 32], network_key: &[u8]) -> Vec<u8>,
+    KeysDb: (key: &Vec<u8>) -> Vec<u8>
   }
+);
 
-  fn params_key(set: &ValidatorSet) -> Vec<u8> {
-    Self::key_gen_key(b"params", set.encode())
-  }
-  fn save_params(
-    txn: &mut D::Transaction<'_>,
-    set: &ValidatorSet,
-    params: &ThresholdParams,
-    shares: u16,
-  ) {
-    txn.put(Self::params_key(set), bincode::serialize(&(params, shares)).unwrap());
-  }
-  fn params<G: Get>(getter: &G, set: &ValidatorSet) -> Option<(ThresholdParams, u16)> {
-    getter.get(Self::params_key(set)).map(|bytes| bincode::deserialize(&bytes).unwrap())
-  }
-
-  // Not scoped to the set since that'd have latter attempts overwrite former
-  // A former attempt may become the finalized attempt, even if it doesn't in a timely manner
-  // Overwriting its commitments would be accordingly poor
-  fn commitments_key(id: &KeyGenId) -> Vec<u8> {
-    Self::key_gen_key(b"commitments", id.encode())
-  }
-  fn save_commitments(
-    txn: &mut D::Transaction<'_>,
-    id: &KeyGenId,
-    commitments: &HashMap<Participant, Vec<u8>>,
-  ) {
-    txn.put(Self::commitments_key(id), bincode::serialize(commitments).unwrap());
-  }
-  fn commitments<G: Get>(getter: &G, id: &KeyGenId) -> HashMap<Participant, Vec<u8>> {
-    bincode::deserialize::<HashMap<Participant, Vec<u8>>>(
-      &getter.get(Self::commitments_key(id)).unwrap(),
-    )
-    .unwrap()
-  }
-
-  fn generated_keys_key(set: ValidatorSet, key_pair: (&[u8; 32], &[u8])) -> Vec<u8> {
-    Self::key_gen_key(b"generated_keys", (set, key_pair).encode())
-  }
-  fn save_keys(
-    txn: &mut D::Transaction<'_>,
-    id: &KeyGenId,
-    substrate_keys: &[ThresholdCore<Ristretto>],
-    network_keys: &[ThresholdKeys<N::Curve>],
-  ) {
-    let mut keys = Zeroizing::new(vec![]);
-    for (substrate_keys, network_keys) in substrate_keys.iter().zip(network_keys) {
-      keys.extend(substrate_keys.serialize().as_slice());
-      keys.extend(network_keys.serialize().as_slice());
-    }
-    txn.put(
-      Self::generated_keys_key(
-        id.set,
-        (
-          &substrate_keys[0].group_key().to_bytes(),
-          network_keys[0].group_key().to_bytes().as_ref(),
-        ),
-      ),
-      &keys,
-    );
-  }
-
-  fn keys_key(key: &<N::Curve as Ciphersuite>::G) -> Vec<u8> {
-    Self::key_gen_key(b"keys", key.to_bytes())
-  }
+impl KeysDb {
   #[allow(clippy::type_complexity)]
-  fn read_keys<G: Get>(
-    getter: &G,
+  fn read_keys<N: Network>(
+    getter: &impl Get,
     key: &[u8],
   ) -> Option<(Vec<u8>, (Vec<ThresholdKeys<Ristretto>>, Vec<ThresholdKeys<N::Curve>>))> {
     let keys_vec = getter.get(key)?;
@@ -116,8 +58,9 @@ impl<N: Network, D: Db> KeyGenDb<N, D> {
     }
     Some((keys_vec, (substrate_keys, network_keys)))
   }
-  fn confirm_keys(
-    txn: &mut D::Transaction<'_>,
+
+  fn confirm_keys<N: Network>(
+    txn: &mut impl DbTxn,
     set: ValidatorSet,
     key_pair: KeyPair,
   ) -> (Vec<ThresholdKeys<Ristretto>>, Vec<ThresholdKeys<N::Curve>>) {
@@ -132,17 +75,30 @@ impl<N: Network, D: Db> KeyGenDb<N, D> {
       },
       keys.1[0].group_key().to_bytes().as_ref(),
     );
-    txn.put(Self::keys_key(&keys.1[0].group_key()), keys_vec);
+    txn.put(KeysDb::key(&keys.1[0].group_key().to_bytes().as_ref().into()), keys_vec);
     keys
   }
+
   #[allow(clippy::type_complexity)]
-  fn keys<G: Get>(
-    getter: &G,
+  fn keys<N: Network>(
+    getter: &impl Get,
     key: &<N::Curve as Ciphersuite>::G,
-  ) -> Option<(Vec<ThresholdKeys<Ristretto>>, Vec<ThresholdKeys<N::Curve>>)> {
-    let res = Self::read_keys(getter, &Self::keys_key(key))?.1;
+  ) -> Option<(ThresholdKeys<Ristretto>, ThresholdKeys<N::Curve>)> {
+    let res = Self::read_keys::<N>(getter, &KeysDb::key(&key.to_bytes().as_ref().into()))?.1;
     assert_eq!(&res.1[0].group_key(), key);
     Some(res)
+  }
+}
+impl GeneratedKeysDb {
+  fn save_keys<N: Network>(
+    txn: &mut impl DbTxn,
+    id: &KeyGenId,
+    substrate_keys: &ThresholdCore<Ristretto>,
+    network_keys: &ThresholdKeys<N::Curve>,
+  ) {
+    let mut keys = substrate_keys.serialize();
+    keys.extend(network_keys.serialize().iter());
+    txn.put(Self::key(&id.set, &substrate_keys.group_key().to_bytes(), network_keys.group_key().to_bytes().as_ref()), keys);
   }
 }
 
@@ -168,7 +124,7 @@ impl<N: Network, D: Db> KeyGen<N, D> {
 
   pub fn in_set(&self, set: &ValidatorSet) -> bool {
     // We determine if we're in set using if we have the parameters for a set's key generation
-    KeyGenDb::<N, D>::params(&self.db, set).is_some()
+    ParamsDb::get(&self.db, set).is_some()
   }
 
   #[allow(clippy::type_complexity)]
@@ -185,7 +141,7 @@ impl<N: Network, D: Db> KeyGen<N, D> {
     // The only other concern is if it's set when it's not safe to use
     // The keys are only written on confirmation, and the transaction writing them is atomic to
     // every associated operation
-    KeyGenDb::<N, D>::keys(&self.db, key)
+    KeysDb::keys::<N>(&self.db, key)
   }
 
   pub async fn handle(
@@ -313,7 +269,7 @@ impl<N: Network, D: Db> KeyGen<N, D> {
           self.active_share.remove(&id.set).is_none()
         {
           // If we haven't handled this set before, save the params
-          KeyGenDb::<N, D>::save_params(txn, &id.set, &params, shares);
+          ParamsDb::set(txn, &id.set, &params, shares);
         }
 
         let (machines, commitments) = key_gen_machines(id, params, shares);
@@ -332,7 +288,7 @@ impl<N: Network, D: Db> KeyGen<N, D> {
           panic!("commitments when already handled commitments");
         }
 
-        let (params, share_quantity) = KeyGenDb::<N, D>::params(txn, &id.set).unwrap();
+        let (params, share_quantity) = ParamsDb::get(txn, &id.set).unwrap();
 
         // Unwrap the machines, rebuilding them if we didn't have them in our cache
         // We won't if the processor rebooted
@@ -344,7 +300,7 @@ impl<N: Network, D: Db> KeyGen<N, D> {
           .remove(&id.set)
           .unwrap_or_else(|| key_gen_machines(id, params, share_quantity));
 
-        KeyGenDb::<N, D>::save_commitments(txn, &id, &commitments);
+        CommitmentsDb::set(txn, &id, &commitments);
         let (machines, shares) = secret_share_machines(id, params, prior, commitments);
 
         self.active_share.insert(id.set, (machines, shares.clone()));
@@ -355,12 +311,12 @@ impl<N: Network, D: Db> KeyGen<N, D> {
       CoordinatorMessage::Shares { id, shares } => {
         info!("Received shares for {:?}", id);
 
-        let (params, share_quantity) = KeyGenDb::<N, D>::params(txn, &id.set).unwrap();
+        let (params, share_quantity) = ParamsDb::get(txn, &id.set).unwrap();
 
         // Same commentary on inconsistency as above exists
         let (machines, our_shares) = self.active_share.remove(&id.set).unwrap_or_else(|| {
           let prior = key_gen_machines(id, params, share_quantity);
-          secret_share_machines(id, params, prior, KeyGenDb::<N, D>::commitments(txn, &id))
+          secret_share_machines(id, params, prior, CommitmentsDb::get::<N>(txn, &id))
         });
 
         let mut rng = share_rng(id);
@@ -437,7 +393,7 @@ impl<N: Network, D: Db> KeyGen<N, D> {
           }
         }
 
-        KeyGenDb::<N, D>::save_keys(txn, &id, &substrate_keys, &network_keys);
+        GeneratedKeysDb::save_keys::<N>(txn, &id, &substrate_keys, &network_keys);
 
         ProcessorMessage::GeneratedKeyPair {
           id,
@@ -454,7 +410,7 @@ impl<N: Network, D: Db> KeyGen<N, D> {
     set: ValidatorSet,
     key_pair: KeyPair,
   ) -> KeyConfirmed<N::Curve> {
-    let (substrate_keys, network_keys) = KeyGenDb::<N, D>::confirm_keys(txn, set, key_pair.clone());
+    let (substrate_keys, network_keys) = KeysDb::confirm_keys::<N>(txn, set, key_pair);
 
     info!(
       "Confirmed key pair {} {} for set {:?}",

--- a/processor/src/key_gen.rs
+++ b/processor/src/key_gen.rs
@@ -58,6 +58,7 @@ impl KeysDb {
     }
     Some((keys_vec, (substrate_keys, network_keys)))
   }
+);
 
   fn confirm_keys<N: Network>(
     txn: &mut impl DbTxn,
@@ -87,6 +88,18 @@ impl KeysDb {
     let res = Self::read_keys::<N>(getter, &KeysDb::key(&key.to_bytes().as_ref().into()))?.1;
     assert_eq!(&res.1[0].group_key(), key);
     Some(res)
+  }
+}
+impl GeneratedKeysDb {
+  fn save_keys<N: Network>(
+    txn: &mut impl DbTxn,
+    id: &KeyGenId,
+    substrate_keys: &ThresholdCore<Ristretto>,
+    network_keys: &ThresholdKeys<N::Curve>,
+  ) {
+    let mut keys = substrate_keys.serialize();
+    keys.extend(network_keys.serialize().iter());
+    txn.put(Self::key(&id.set, &substrate_keys.group_key().to_bytes(), network_keys.group_key().to_bytes().as_ref()), keys);
   }
 }
 impl GeneratedKeysDb {

--- a/processor/src/key_gen.rs
+++ b/processor/src/key_gen.rs
@@ -58,7 +58,6 @@ impl KeysDb {
     }
     Some((keys_vec, (substrate_keys, network_keys)))
   }
-);
 
   fn confirm_keys<N: Network>(
     txn: &mut impl DbTxn,
@@ -84,7 +83,7 @@ impl KeysDb {
   fn keys<N: Network>(
     getter: &impl Get,
     key: &<N::Curve as Ciphersuite>::G,
-  ) -> Option<(ThresholdKeys<Ristretto>, ThresholdKeys<N::Curve>)> {
+  ) -> Option<(Vec<ThresholdKeys<Ristretto>>, Vec<ThresholdKeys<N::Curve>>)> {
     let res = Self::read_keys::<N>(getter, &KeysDb::key(&key.to_bytes().as_ref().into()))?.1;
     assert_eq!(&res.1[0].group_key(), key);
     Some(res)
@@ -99,7 +98,14 @@ impl GeneratedKeysDb {
   ) {
     let mut keys = substrate_keys.serialize();
     keys.extend(network_keys.serialize().iter());
-    txn.put(Self::key(&id.set, &substrate_keys.group_key().to_bytes(), network_keys.group_key().to_bytes().as_ref()), keys);
+    txn.put(
+      Self::key(
+        &id.set,
+        &substrate_keys.group_key().to_bytes(),
+        network_keys.group_key().to_bytes().as_ref(),
+      ),
+      keys,
+    );
   }
 }
 impl GeneratedKeysDb {


### PR DESCRIPTION
### Description

This pull request closes #364. The Serai code-base is full of repetitive database code used to namespace keys. The provided macro generates the database and item DSTs necessary for a new key. The macro supports zero or more `scale` encodable arguments in the generation of the key and will likewise automatically `bincode` serialize/de-serialize the database value resulting in better DX and hopefully less bugs. 

### Considerations

- The macro outputs an empty struct so that methods can be added using an `impl` block
- `bincode` was chosen over scale because it supports a wider range of types. It's still possible to store `scale` bytes in the form of a `Vec<u8>` and transform later as is the case now
- Many of the existing databases are generic (e.g., `Network`) which can't be auto generated by the macro. Moving forward, helper methods should receive those generic arguments instead.

### Example
```rust
create_db!(
  KeyGenDb {
    ParamsDb: (vs: &ValidatorSet) -> ThresholdParams,
    CommitmentsDb: (key: &KeyGenId) -> HashMap<Participant, Vec<u8>>,
    GeneratedKeysDb: (set: &ValidatorSet, key_one: &[u8; 32], key_two: &[u8]) -> Vec<u8>,
    KeysDb: (key: &Vec<u8>) -> Vec<u8>
  }
);
```
In this case 3 databases are created, but let's focus on `ParamsDB`. `ParamsDB` gets a "KeyGenDB" database DST and a "ParamsDB" item DST, whose `get` and `set` become:
```rust
impl ParamsDB {
  pub fn get(getter: &impl Get, vs: &ValidatorSet) -> Option<ThresholdParams> {
    // brevity
  }
  pub fn set(txn: &mut DbTxn, vs: &ValidatorSet, value: ThresholdParams) {
    //brevity
  }
}
```

### Future Work
The pull request is being opened now so that future work builds off of this macro while we convert old databases and pass tests.