### PR TITLE
Route blame between Processor and Coordinator

### DIFF
--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -439,6 +439,9 @@ async fn handle_processor_message<D: Db, P: P2p>(
             .i(pub_key)
             .expect("processor message to DKG for a session we aren't a validator in");
 
+          // TODO: This is [receiver_share][sender_share] and is later transposed to
+          // [sender_share][receiver_share]. Make this [sender_share][receiver_share] from the
+          // start?
           // `tx_shares` needs to be done here as while it can be serialized from the HashMap
           // without further context, it can't be deserialized without context
           let mut tx_shares = Vec::with_capacity(shares.len());
@@ -497,6 +500,7 @@ async fn handle_processor_message<D: Db, P: P2p>(
             id.attempt,
           );
 
+          // TODO: If a processor fails to generate a key pair, it'll desync here
           match share {
             Ok(share) => {
               vec![Transaction::DkgConfirmed(id.attempt, share, Transaction::empty_signed())]

--- a/coordinator/src/tests/tributary/mod.rs
+++ b/coordinator/src/tests/tributary/mod.rs
@@ -88,6 +88,11 @@ fn serialize_sign_data() {
 
 #[test]
 fn serialize_transaction() {
+  test_read_write(Transaction::RemoveParticipant(
+    frost::Participant::new(u16::try_from(OsRng.next_u64() >> 48).unwrap().saturating_add(1))
+      .unwrap(),
+  ));
+
   {
     let mut commitments = vec![random_vec(&mut OsRng, 512)];
     for _ in 0 .. (OsRng.next_u64() % 100) {
@@ -128,6 +133,22 @@ fn serialize_transaction() {
         let mut nonces = [0; 64];
         OsRng.fill_bytes(&mut nonces);
         nonces
+      },
+      signed: random_signed(&mut OsRng),
+    });
+  }
+
+  for i in 0 .. 2 {
+    test_read_write(Transaction::InvalidDkgShare {
+      attempt: random_u32(&mut OsRng),
+      faulty: frost::Participant::new(
+        u16::try_from(OsRng.next_u64() >> 48).unwrap().saturating_add(1),
+      )
+      .unwrap(),
+      blame: if i == 0 {
+        None
+      } else {
+        Some(random_vec(&mut OsRng, 500)).filter(|blame| !blame.is_empty())
       },
       signed: random_signed(&mut OsRng),
     });

--- a/coordinator/src/tests/tributary/mod.rs
+++ b/coordinator/src/tests/tributary/mod.rs
@@ -141,6 +141,10 @@ fn serialize_transaction() {
   for i in 0 .. 2 {
     test_read_write(Transaction::InvalidDkgShare {
       attempt: random_u32(&mut OsRng),
+      accuser: frost::Participant::new(
+        u16::try_from(OsRng.next_u64() >> 48).unwrap().saturating_add(1),
+      )
+      .unwrap(),
       faulty: frost::Participant::new(
         u16::try_from(OsRng.next_u64() >> 48).unwrap().saturating_add(1),
       )

--- a/coordinator/src/tributary/db.rs
+++ b/coordinator/src/tributary/db.rs
@@ -108,6 +108,27 @@ impl<D: Db> TributaryDb<D> {
     txn.put(key, existing);
   }
 
+  fn share_for_blame_key(genesis: &[u8], from: Participant, to: Participant) -> Vec<u8> {
+    Self::tributary_key(b"share_for_blame", (genesis, u16::from(from), u16::from(to)).encode())
+  }
+  pub fn save_share_for_blame(
+    txn: &mut D::Transaction<'_>,
+    genesis: &[u8],
+    from: Participant,
+    to: Participant,
+    share: &[u8],
+  ) {
+    txn.put(Self::share_for_blame_key(genesis, from, to), share);
+  }
+  pub fn share_for_blame<G: Get>(
+    getter: &G,
+    genesis: &[u8],
+    from: Participant,
+    to: Participant,
+  ) -> Option<Vec<u8>> {
+    getter.get(Self::share_for_blame_key(genesis, from, to))
+  }
+
   // The plan IDs associated with a Substrate block
   fn plan_ids_key(genesis: &[u8], block: u64) -> Vec<u8> {
     Self::tributary_key(b"plan_ids", [genesis, block.to_le_bytes().as_ref()].concat())

--- a/coordinator/src/tributary/db.rs
+++ b/coordinator/src/tributary/db.rs
@@ -87,11 +87,14 @@ impl<D: Db> TributaryDb<D> {
   fn fatal_slashes_key(genesis: [u8; 32]) -> Vec<u8> {
     Self::tributary_key(b"fatal_slashes", genesis)
   }
-  fn fatally_slashed_key(account: [u8; 32]) -> Vec<u8> {
-    Self::tributary_key(b"fatally_slashed", account)
+  fn fatally_slashed_key(genesis: [u8; 32], account: [u8; 32]) -> Vec<u8> {
+    Self::tributary_key(b"fatally_slashed", (genesis, account).encode())
+  }
+  pub fn is_fatally_slashed<G: Get>(getter: &G, genesis: [u8; 32], account: [u8; 32]) -> bool {
+    getter.get(Self::fatally_slashed_key(genesis, account)).is_some()
   }
   pub fn set_fatally_slashed(txn: &mut D::Transaction<'_>, genesis: [u8; 32], account: [u8; 32]) {
-    txn.put(Self::fatally_slashed_key(account), []);
+    txn.put(Self::fatally_slashed_key(genesis, account), []);
 
     let key = Self::fatal_slashes_key(genesis);
     let mut existing = txn.get(&key).unwrap_or(vec![]);

--- a/coordinator/src/tributary/handle.rs
+++ b/coordinator/src/tributary/handle.rs
@@ -441,6 +441,7 @@ pub(crate) async fn handle_application_tx<
         return;
       }
 
+      let share = TributaryDb::<D>::share_for_blame(txn, &genesis, accuser, faulty).unwrap();
       processors
         .send(
           spec.set().network,
@@ -448,7 +449,7 @@ pub(crate) async fn handle_application_tx<
             id: KeyGenId { set: spec.set(), attempt },
             accuser,
             accused: faulty,
-            share: TributaryDb::<D>::share_for_blame(txn, &genesis, accuser, faulty).unwrap(),
+            share,
             blame,
           },
         )

--- a/coordinator/src/tributary/handle.rs
+++ b/coordinator/src/tributary/handle.rs
@@ -178,6 +178,8 @@ pub(crate) async fn handle_application_tx<
   }
 
   match tx {
+    // TODO: Either remove the validator from Tendermint OR form a second Tributary post-DKG
+    Transaction::RemoveParticipant(i) => todo!("TODO(now)"),
     Transaction::DkgCommitments(attempt, commitments, signed) => {
       let Ok(_) = check_sign_data_len::<D>(txn, spec, signed.signer, commitments.len()) else {
         return;
@@ -327,7 +329,11 @@ pub(crate) async fn handle_application_tx<
       }
     }
 
+    Transaction::InvalidDkgShare { attempt, faulty, blame, signed } => todo!("TODO(now)"),
+
     Transaction::DkgConfirmed(attempt, shares, signed) => {
+      // TODO: Error if this participant published InvalidDkgShare
+
       match handle(
         txn,
         &DataSpecification { topic: Topic::Dkg, label: DKG_CONFIRMATION_SHARES, attempt },

--- a/coordinator/src/tributary/mod.rs
+++ b/coordinator/src/tributary/mod.rs
@@ -516,9 +516,14 @@ impl ReadWrite for Transaction {
         writer.write_all(&attempt.to_le_bytes())?;
         writer.write_all(&u16::from(*accuser).to_le_bytes())?;
         writer.write_all(&u16::from(*faulty).to_le_bytes())?;
+
         // Flattens Some(vec![]) to None on the expectation no actual blame will be 0-length
         assert!(blame.as_ref().map(|blame| blame.len()).unwrap_or(1) != 0);
+        let blame_len =
+          u16::try_from(blame.as_ref().unwrap_or(&vec![]).len()).expect("blame exceeded 64 KB");
+        writer.write_all(&blame_len.to_le_bytes())?;
         writer.write_all(blame.as_ref().unwrap_or(&vec![]))?;
+
         signed.write(writer)
       }
 

--- a/coordinator/src/tributary/nonce_decider.rs
+++ b/coordinator/src/tributary/nonce_decider.rs
@@ -85,6 +85,8 @@ impl<D: Db> NonceDecider<D> {
 
   pub fn nonce<G: Get>(getter: &G, genesis: [u8; 32], tx: &Transaction) -> Option<Option<u32>> {
     match tx {
+      Transaction::RemoveParticipant(_) => None,
+
       Transaction::DkgCommitments(attempt, _, _) => {
         assert_eq!(*attempt, 0);
         Some(Some(0))
@@ -92,6 +94,12 @@ impl<D: Db> NonceDecider<D> {
       Transaction::DkgShares { attempt, .. } => {
         assert_eq!(*attempt, 0);
         Some(Some(1))
+      }
+      // InvalidDkgShare and DkgConfirmed share a nonce due to the expected existence of only one
+      // on-chain
+      Transaction::InvalidDkgShare { attempt, .. } => {
+        assert_eq!(*attempt, 0);
+        Some(Some(2))
       }
       Transaction::DkgConfirmed(attempt, _, _) => {
         assert_eq!(*attempt, 0);

--- a/crypto/dkg/src/encryption.rs
+++ b/crypto/dkg/src/encryption.rs
@@ -341,7 +341,7 @@ pub(crate) enum DecryptionError {
 #[derive(Clone)]
 pub(crate) struct Encryption<C: Ciphersuite> {
   context: String,
-  i: Participant,
+  i: Option<Participant>,
   enc_key: Zeroizing<C::F>,
   enc_pub_key: C::G,
   enc_keys: HashMap<Participant, C::G>,
@@ -370,7 +370,11 @@ impl<C: Ciphersuite> Zeroize for Encryption<C> {
 }
 
 impl<C: Ciphersuite> Encryption<C> {
-  pub(crate) fn new<R: RngCore + CryptoRng>(context: String, i: Participant, rng: &mut R) -> Self {
+  pub(crate) fn new<R: RngCore + CryptoRng>(
+    context: String,
+    i: Option<Participant>,
+    rng: &mut R,
+  ) -> Self {
     let enc_key = Zeroizing::new(C::random_nonzero_F(rng));
     Self {
       context,
@@ -404,7 +408,7 @@ impl<C: Ciphersuite> Encryption<C> {
     participant: Participant,
     msg: Zeroizing<E>,
   ) -> EncryptedMessage<C, E> {
-    encrypt(rng, &self.context, self.i, self.enc_keys[&participant], msg)
+    encrypt(rng, &self.context, self.i.unwrap(), self.enc_keys[&participant], msg)
   }
 
   pub(crate) fn decrypt<R: RngCore + CryptoRng, I: Copy + Zeroize, E: Encryptable>(

--- a/crypto/dkg/src/lib.rs
+++ b/crypto/dkg/src/lib.rs
@@ -94,7 +94,7 @@ pub enum DkgError<B: Clone + PartialEq + Eq + Debug> {
 
   /// An invalid proof of knowledge was provided.
   #[cfg_attr(feature = "std", error("invalid proof of knowledge (participant {0})"))]
-  InvalidProofOfKnowledge(Participant),
+  InvalidCommitments(Participant),
   /// An invalid DKG share was provided.
   #[cfg_attr(feature = "std", error("invalid share (participant {participant}, blame {blame})"))]
   InvalidShare { participant: Participant, blame: Option<B> },

--- a/crypto/dkg/src/promote.rs
+++ b/crypto/dkg/src/promote.rs
@@ -109,7 +109,7 @@ where
           &[C1::generator(), C2::generator()],
           &[original_shares[&i], proof.share],
         )
-        .map_err(|_| DkgError::InvalidProofOfKnowledge(i))?;
+        .map_err(|_| DkgError::InvalidCommitments(i))?;
       verification_shares.insert(i, proof.share);
     }
 

--- a/crypto/dleq/src/cross_group/mod.rs
+++ b/crypto/dleq/src/cross_group/mod.rs
@@ -95,9 +95,6 @@ impl<G: PrimeGroup> Generators<G> {
 /// Error for cross-group DLEq proofs.
 #[derive(Error, PartialEq, Eq, Debug)]
 pub enum DLEqError {
-  /// Invalid proof of knowledge.
-  #[error("invalid proof of knowledge")]
-  InvalidProofOfKnowledge,
   /// Invalid proof length.
   #[error("invalid proof length")]
   InvalidProofLength,

--- a/docs/DKG Exclusions.md
+++ b/docs/DKG Exclusions.md
@@ -1,0 +1,23 @@
+Upon an issue with the DKG, the honest validators must remove the malicious
+validators. Ideally, a threshold signature would be used, yet that would require
+a threshold key (which would require authentication by a MuSig signature). A
+MuSig signature which specifies the signing set (or rather, the excluded
+signers) achieves the most efficiency.
+
+While that resolves the on-chain behavior, the Tributary also has to perform
+exclusion. This has the following forms:
+
+1) Rejecting further transactions (required)
+2) Rejecting further participation in Tendermint
+
+With regards to rejecting further participation in Tendermint, it's *ideal* to
+remove the validator from the list of validators. Each validator removed from
+participation, yet not from the list of validators, increases the likelihood of
+the network failing to form consensus.
+
+With regards to the economic security, an honest 67% may remove a faulty
+(explicitly or simply offline) 33%, letting 67% of the remaining 67% (4/9ths)
+take control of the associated private keys. In such a case, the malicious
+parties are defined as the 4/9ths of validators with access to the private key
+and the 33% removed (who together form >67% of the originally intended
+validator set and have presumably provided enough stake to cover losses).

--- a/processor/messages/src/lib.rs
+++ b/processor/messages/src/lib.rs
@@ -50,8 +50,12 @@ pub mod key_gen {
   pub enum ProcessorMessage {
     // Created commitments for the specified key generation protocol.
     Commitments { id: KeyGenId, commitments: Vec<Vec<u8>> },
+    // Participant published invalid commitments.
+    InvalidCommitments { id: KeyGenId, faulty: Participant },
     // Created shares for the specified key generation protocol.
     Shares { id: KeyGenId, shares: Vec<HashMap<Participant, Vec<u8>>> },
+    // Participant published an invalid share.
+    InvalidShare { id: KeyGenId, faulty: Participant, blame: Option<Vec<u8>> },
     // Resulting keys from the specified key generation protocol.
     GeneratedKeyPair { id: KeyGenId, substrate_key: [u8; 32], network_key: Vec<u8> },
   }
@@ -340,8 +344,10 @@ impl ProcessorMessage {
         let (sub, id) = match msg {
           // Unique since KeyGenId
           key_gen::ProcessorMessage::Commitments { id, .. } => (0, id),
-          key_gen::ProcessorMessage::Shares { id, .. } => (1, id),
-          key_gen::ProcessorMessage::GeneratedKeyPair { id, .. } => (2, id),
+          key_gen::ProcessorMessage::InvalidCommitments { id, .. } => (1, id),
+          key_gen::ProcessorMessage::Shares { id, .. } => (2, id),
+          key_gen::ProcessorMessage::InvalidShare { id, .. } => (3, id),
+          key_gen::ProcessorMessage::GeneratedKeyPair { id, .. } => (4, id),
         };
 
         let mut res = vec![PROCESSSOR_UID, TYPE_KEY_GEN_UID, sub];

--- a/processor/messages/src/lib.rs
+++ b/processor/messages/src/lib.rs
@@ -33,13 +33,29 @@ pub mod key_gen {
   pub enum CoordinatorMessage {
     // Instructs the Processor to begin the key generation process.
     // TODO: Should this be moved under Substrate?
-    GenerateKey { id: KeyGenId, params: ThresholdParams, shares: u16 },
+    GenerateKey {
+      id: KeyGenId,
+      params: ThresholdParams,
+      shares: u16,
+    },
     // Received commitments for the specified key generation protocol.
-    Commitments { id: KeyGenId, commitments: HashMap<Participant, Vec<u8>> },
+    Commitments {
+      id: KeyGenId,
+      commitments: HashMap<Participant, Vec<u8>>,
+    },
     // Received shares for the specified key generation protocol.
-    Shares { id: KeyGenId, shares: Vec<HashMap<Participant, Vec<u8>>> },
+    Shares {
+      id: KeyGenId,
+      shares: Vec<HashMap<Participant, Vec<u8>>>,
+    },
     /// Instruction to verify a blame accusation.
-    VerifyBlame { id: KeyGenId, accuser: Participant, accused: Participant, blame: Option<Vec<u8>> },
+    VerifyBlame {
+      id: KeyGenId,
+      accuser: Participant,
+      accused: Participant,
+      share: Vec<u8>,
+      blame: Option<Vec<u8>>,
+    },
   }
 
   impl CoordinatorMessage {
@@ -51,17 +67,39 @@ pub mod key_gen {
   #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
   pub enum ProcessorMessage {
     // Created commitments for the specified key generation protocol.
-    Commitments { id: KeyGenId, commitments: Vec<Vec<u8>> },
+    Commitments {
+      id: KeyGenId,
+      commitments: Vec<Vec<u8>>,
+    },
     // Participant published invalid commitments.
-    InvalidCommitments { id: KeyGenId, faulty: Participant },
+    InvalidCommitments {
+      id: KeyGenId,
+      faulty: Participant,
+    },
     // Created shares for the specified key generation protocol.
-    Shares { id: KeyGenId, shares: Vec<HashMap<Participant, Vec<u8>>> },
+    Shares {
+      id: KeyGenId,
+      shares: Vec<HashMap<Participant, Vec<u8>>>,
+    },
     // Participant published an invalid share.
-    InvalidShare { id: KeyGenId, accuser: Participant, faulty: Participant, blame: Option<Vec<u8>> },
+    #[rustfmt::skip]
+    InvalidShare {
+      id: KeyGenId,
+      accuser: Participant,
+      faulty: Participant,
+      blame: Option<Vec<u8>>,
+    },
     // Resulting keys from the specified key generation protocol.
-    GeneratedKeyPair { id: KeyGenId, substrate_key: [u8; 32], network_key: Vec<u8> },
+    GeneratedKeyPair {
+      id: KeyGenId,
+      substrate_key: [u8; 32],
+      network_key: Vec<u8>,
+    },
     // Blame this participant.
-    Blame { id: KeyGenId, participant: Participant },
+    Blame {
+      id: KeyGenId,
+      participant: Participant,
+    },
   }
 }
 

--- a/processor/messages/src/lib.rs
+++ b/processor/messages/src/lib.rs
@@ -38,6 +38,8 @@ pub mod key_gen {
     Commitments { id: KeyGenId, commitments: HashMap<Participant, Vec<u8>> },
     // Received shares for the specified key generation protocol.
     Shares { id: KeyGenId, shares: Vec<HashMap<Participant, Vec<u8>>> },
+    /// Instruction to verify a blame accusation.
+    VerifyBlame { id: KeyGenId, accuser: Participant, accused: Participant, blame: Option<Vec<u8>> },
   }
 
   impl CoordinatorMessage {
@@ -55,9 +57,11 @@ pub mod key_gen {
     // Created shares for the specified key generation protocol.
     Shares { id: KeyGenId, shares: Vec<HashMap<Participant, Vec<u8>>> },
     // Participant published an invalid share.
-    InvalidShare { id: KeyGenId, faulty: Participant, blame: Option<Vec<u8>> },
+    InvalidShare { id: KeyGenId, accuser: Participant, faulty: Participant, blame: Option<Vec<u8>> },
     // Resulting keys from the specified key generation protocol.
     GeneratedKeyPair { id: KeyGenId, substrate_key: [u8; 32], network_key: Vec<u8> },
+    // Blame this participant.
+    Blame { id: KeyGenId, participant: Participant },
   }
 }
 
@@ -279,6 +283,7 @@ impl CoordinatorMessage {
           key_gen::CoordinatorMessage::GenerateKey { id, .. } => (0, id),
           key_gen::CoordinatorMessage::Commitments { id, .. } => (1, id),
           key_gen::CoordinatorMessage::Shares { id, .. } => (2, id),
+          key_gen::CoordinatorMessage::VerifyBlame { id, .. } => (3, id),
         };
 
         let mut res = vec![COORDINATOR_UID, TYPE_KEY_GEN_UID, sub];
@@ -348,6 +353,7 @@ impl ProcessorMessage {
           key_gen::ProcessorMessage::Shares { id, .. } => (2, id),
           key_gen::ProcessorMessage::InvalidShare { id, .. } => (3, id),
           key_gen::ProcessorMessage::GeneratedKeyPair { id, .. } => (4, id),
+          key_gen::ProcessorMessage::Blame { id, .. } => (5, id),
         };
 
         let mut res = vec![PROCESSSOR_UID, TYPE_KEY_GEN_UID, sub];

--- a/processor/src/multisigs/mod.rs
+++ b/processor/src/multisigs/mod.rs
@@ -938,7 +938,8 @@ impl<D: Db, N: Network> MultisigManager<D, N> {
         }
 
         // Save the plans created while scanning
-        // TODO: Should we combine all of these plans?
+        // TODO: Should we combine all of these plans to reduce the fees incurred from their
+        // execution? They're refunds and forwards. Neither should need isolate Plan/Eventualities.
         MultisigsDb::<N, D>::set_plans_from_scanning(txn, block_number, plans);
 
         // If any outputs were delayed, append them into this block


### PR DESCRIPTION
Implements DKG blame with fatal slashes.

Does not handle re-attempts.

Routes blame during sign yet does not act on it in coordinator.