### PR TITLE
Dockerfile Parts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,3 +66,11 @@ jobs:
 
       - name: Run rustfmt
         run: cargo +${{ steps.nightly.outputs.version }} fmt -- --check
+
+  dockerfiles:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+      - name: Verify Dockerfiles are up to date
+        # Runs the file which generates them and checks the diff has no lines
+        run: cd orchestration && ./dockerfiles.sh && git diff | wc -l | grep -x "0"

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -5,7 +5,7 @@
 ##### Ubuntu
 
 ```
-sudo apt-get install -y build-essential cmake clang-11 git curl python3-pip protobuf-compiler libssl-dev pkg-config
+sudo apt-get install -y build-essential clang-11 pkg-config cmake git curl protobuf-compiler
 ```
 
 ### Install rustup

--- a/orchestration/Dockerfile.parts/Dockerfile.alpine.start
+++ b/orchestration/Dockerfile.parts/Dockerfile.alpine.start
@@ -1,0 +1,6 @@
+FROM alpine:latest as image
+
+COPY --from=mimalloc libmimalloc.so /usr/lib
+ENV LD_PRELOAD=libmimalloc.so
+
+RUN apk update && apk upgrade

--- a/orchestration/Dockerfile.parts/Dockerfile.debian.start
+++ b/orchestration/Dockerfile.parts/Dockerfile.debian.start
@@ -1,0 +1,6 @@
+FROM debian:bookworm-slim as image
+
+COPY --from=mimalloc libmimalloc.so /usr/lib
+RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload
+
+RUN apt update && apt upgrade -y && apt autoremove -y && apt clean

--- a/orchestration/Dockerfile.parts/Dockerfile.serai.build
+++ b/orchestration/Dockerfile.parts/Dockerfile.serai.build
@@ -8,6 +8,9 @@ RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
 # Add dev dependencies
 RUN apt install -y pkg-config clang
 
+# Dependencies for the Serai node
+RUN apt install -y make protobuf-compiler
+
 # Add files for build
 ADD common /serai/common
 ADD crypto /serai/crypto

--- a/orchestration/Dockerfile.parts/Dockerfile.serai.build
+++ b/orchestration/Dockerfile.parts/Dockerfile.serai.build
@@ -1,0 +1,35 @@
+FROM rust:1.73-slim-bookworm as builder
+
+COPY --from=mimalloc libmimalloc.so /usr/lib
+RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload
+
+RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
+
+# Add dev dependencies
+RUN apt install -y pkg-config clang
+
+# Add files for build
+ADD common /serai/common
+ADD crypto /serai/crypto
+ADD coins /serai/coins
+ADD message-queue /serai/message-queue
+ADD processor /serai/processor
+ADD coordinator /serai/coordinator
+ADD substrate /serai/substrate
+ADD mini /serai/mini
+ADD tests /serai/tests
+ADD Cargo.toml /serai
+ADD Cargo.lock /serai
+ADD AGPL-3.0 /serai
+
+WORKDIR /serai
+
+# Add the wasm toolchain
+RUN rustup target add wasm32-unknown-unknown
+
+# Mount the caches and build
+RUN --mount=type=cache,target=/root/.cargo \
+  --mount=type=cache,target=/usr/local/cargo/registry \
+  --mount=type=cache,target=/usr/local/cargo/git \
+  --mount=type=cache,target=/serai/target \
+  mkdir /serai/bin && \

--- a/orchestration/Dockerfile.parts/mimalloc/Dockerfile.alpine
+++ b/orchestration/Dockerfile.parts/mimalloc/Dockerfile.alpine
@@ -1,0 +1,10 @@
+FROM alpine:latest as mimalloc
+
+RUN apk update && apk upgrade && apk --no-cache add gcc g++ libc-dev make cmake git
+RUN git clone https://github.com/microsoft/mimalloc && \
+  cd mimalloc && \
+  mkdir -p out/secure && \
+  cd out/secure && \
+  cmake -DMI_SECURE=ON ../.. && \
+  make && \
+  cp ./libmimalloc-secure.so ../../../libmimalloc.so

--- a/orchestration/Dockerfile.parts/mimalloc/Dockerfile.debian
+++ b/orchestration/Dockerfile.parts/mimalloc/Dockerfile.debian
@@ -1,0 +1,10 @@
+FROM debian:bookworm-slim as mimalloc
+
+RUN apt update && apt upgrade -y && apt install -y gcc g++ make cmake git
+RUN git clone https://github.com/microsoft/mimalloc && \
+  cd mimalloc && \
+  mkdir -p out/secure && \
+  cd out/secure && \
+  cmake -DMI_SECURE=ON ../.. && \
+  make && \
+  cp ./libmimalloc-secure.so ../../../libmimalloc.so

--- a/orchestration/README.md
+++ b/orchestration/README.md
@@ -20,6 +20,7 @@ All commands are assumed to be ran from `/deploy`, not the root folder.
 
 * `message-queue` - The message queue service.
 * `processor`     - Serai processor for one external network.
+* `coordinator`   - Serai coordinator for the entire Serai stack.
 
 * `serai`      - Serai node
 * `cluster-sm` - "Alice", "Bob", "Charlie", and "Dave" Serai nodes, all as

--- a/orchestration/coins/bitcoin/Dockerfile
+++ b/orchestration/coins/bitcoin/Dockerfile
@@ -41,7 +41,7 @@ RUN useradd --system --create-home --shell /sbin/nologin bitcoin
 USER bitcoin
 WORKDIR /home/bitcoin
 
-COPY --from=builder --chown=bitcoin bitcoind /bin
+COPY --from=bitcoin --chown=bitcoin bitcoind /bin
 COPY ./scripts /scripts
 
 EXPOSE 8332 8333 18332 18333 18443 18444

--- a/orchestration/coins/bitcoin/Dockerfile.bitcoin
+++ b/orchestration/coins/bitcoin/Dockerfile.bitcoin
@@ -1,13 +1,3 @@
-FROM debian:bookworm-slim as mimalloc
-
-RUN apt update && apt upgrade -y && apt install -y gcc g++ make cmake git
-RUN git clone https://github.com/microsoft/mimalloc && \
-  cd mimalloc && \
-  mkdir -p out/secure && \
-  cd out/secure && \
-  cmake -DMI_SECURE=ON ../.. && \
-  make && \
-  cp ./libmimalloc-secure.so ../../../libmimalloc.so
 FROM alpine:latest as bitcoin
 
 ENV BITCOIN_VERSION=25.1
@@ -30,19 +20,3 @@ RUN grep bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz SHA256SUMS | sha256s
 # Prepare Image
 RUN tar xzvf bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz
 RUN mv bitcoin-${BITCOIN_VERSION}/bin/bitcoind .
-FROM debian:bookworm-slim as image
-
-COPY --from=mimalloc libmimalloc.so /usr/lib
-RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload
-
-RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
-# Switch to a non-root user
-RUN useradd --system --create-home --shell /sbin/nologin bitcoin
-USER bitcoin
-WORKDIR /home/bitcoin
-
-COPY --from=builder --chown=bitcoin bitcoind /bin
-COPY ./scripts /scripts
-
-EXPOSE 8332 8333 18332 18333 18443 18444
-# VOLUME ["/home/bitcoin/.bitcoin"]

--- a/orchestration/coins/bitcoin/Dockerfile.bitcoin.end
+++ b/orchestration/coins/bitcoin/Dockerfile.bitcoin.end
@@ -1,0 +1,10 @@
+# Switch to a non-root user
+RUN useradd --system --create-home --shell /sbin/nologin bitcoin
+USER bitcoin
+WORKDIR /home/bitcoin
+
+COPY --from=builder --chown=bitcoin bitcoind /bin
+COPY ./scripts /scripts
+
+EXPOSE 8332 8333 18332 18333 18443 18444
+# VOLUME ["/home/bitcoin/.bitcoin"]

--- a/orchestration/coins/bitcoin/Dockerfile.bitcoin.end
+++ b/orchestration/coins/bitcoin/Dockerfile.bitcoin.end
@@ -3,7 +3,7 @@ RUN useradd --system --create-home --shell /sbin/nologin bitcoin
 USER bitcoin
 WORKDIR /home/bitcoin
 
-COPY --from=builder --chown=bitcoin bitcoind /bin
+COPY --from=bitcoin --chown=bitcoin bitcoind /bin
 COPY ./scripts /scripts
 
 EXPOSE 8332 8333 18332 18333 18443 18444

--- a/orchestration/coins/monero/Dockerfile.monero
+++ b/orchestration/coins/monero/Dockerfile.monero
@@ -1,13 +1,3 @@
-FROM alpine:latest as mimalloc
-
-RUN apk update && apk upgrade && apk --no-cache add gcc g++ libc-dev make cmake git
-RUN git clone https://github.com/microsoft/mimalloc && \
-  cd mimalloc && \
-  mkdir -p out/secure && \
-  cd out/secure && \
-  cmake -DMI_SECURE=ON ../.. && \
-  make && \
-  cp ./libmimalloc-secure.so ../../../libmimalloc.so
 FROM alpine:latest as monero
 
 # https://downloads.getmonero.org/cli/monero-linux-x64-v0.18.3.1.tar.bz2
@@ -31,22 +21,3 @@ RUN gpg --keyserver hkp://keyserver.ubuntu.com:80 --keyserver-options no-self-si
 
 # Extract it
 RUN tar -xvjf monero-linux-x64-v${MONERO_VERSION}.tar.bz2 --strip-components=1
-FROM alpine:latest as image
-
-COPY --from=mimalloc libmimalloc.so /usr/lib
-ENV LD_PRELOAD=libmimalloc.so
-
-RUN apk update && apk upgrade
-RUN apk --no-cache add gcompat
-
-# Switch to a non-root user
-# System user (not a human), shell of nologin, no password assigned
-RUN adduser -S -s /sbin/nologin -D monero
-USER monero
-
-WORKDIR /home/monero
-COPY --from=monero --chown=monero monerod /bin
-ADD scripts /scripts
-
-EXPOSE 18080 18081
-# VOLUME /home/monero/.bitmonero

--- a/orchestration/coins/monero/Dockerfile.monero.end
+++ b/orchestration/coins/monero/Dockerfile.monero.end
@@ -1,0 +1,13 @@
+RUN apk --no-cache add gcompat
+
+# Switch to a non-root user
+# System user (not a human), shell of nologin, no password assigned
+RUN adduser -S -s /sbin/nologin -D monero
+USER monero
+
+WORKDIR /home/monero
+COPY --from=monero --chown=monero monerod /bin
+ADD scripts /scripts
+
+EXPOSE 18080 18081
+# VOLUME /home/monero/.bitmonero

--- a/orchestration/coordinator/Dockerfile
+++ b/orchestration/coordinator/Dockerfile
@@ -1,11 +1,22 @@
+FROM debian:bookworm-slim as mimalloc
+
+RUN apt update && apt upgrade -y && apt install -y gcc g++ make cmake git
+RUN git clone https://github.com/microsoft/mimalloc && \
+  cd mimalloc && \
+  mkdir -p out/secure && \
+  cd out/secure && \
+  cmake -DMI_SECURE=ON ../.. && \
+  make && \
+  cp ./libmimalloc-secure.so ../../../libmimalloc.so
 FROM rust:1.73-slim-bookworm as builder
-LABEL description="STAGE 1: Build"
 
-# Upgrade and add dev dependencies
-RUN apt update && apt upgrade -y && apt install -y pkg-config clang && apt autoremove -y && apt clean
+COPY --from=mimalloc libmimalloc.so /usr/lib
+RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload
 
-# Add the wasm toolchain
-RUN rustup target add wasm32-unknown-unknown
+RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
+
+# Add dev dependencies
+RUN apt install -y pkg-config clang
 
 # Add files for build
 ADD common /serai/common
@@ -23,36 +34,25 @@ ADD AGPL-3.0 /serai
 
 WORKDIR /serai
 
+# Add the wasm toolchain
+RUN rustup target add wasm32-unknown-unknown
+
 # Mount the caches and build
 RUN --mount=type=cache,target=/root/.cargo \
   --mount=type=cache,target=/usr/local/cargo/registry \
   --mount=type=cache,target=/usr/local/cargo/git \
   --mount=type=cache,target=/serai/target \
-  cd coordinator && \
-  cargo build --release --all-features && \
   mkdir /serai/bin && \
+  cargo build -p serai-coordinator --release --all-features && \
   mv /serai/target/release/serai-coordinator /serai/bin
-
-# Also build mimalloc
-FROM debian:bookworm-slim as mimalloc
-
-RUN apt update && apt upgrade -y && apt install -y gcc g++ make cmake git
-RUN git clone https://github.com/microsoft/mimalloc && \
-  cd mimalloc && \
-  mkdir -p out/secure && \
-  cd out/secure && \
-  cmake -DMI_SECURE=ON ../.. && \
-  make && \
-  cp ./libmimalloc-secure.so ../../../libmimalloc.so
-
-# Build the actual image
 FROM debian:bookworm-slim as image
 
 COPY --from=mimalloc libmimalloc.so /usr/lib
 RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload
 
-# Upgrade packages and install ca-certificates
-RUN apt update && apt upgrade -y && apt install -y ca-certificates && apt autoremove && apt clean
+RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
+# Install ca-certificates
+RUN apt install -y ca-certificates
 
 # Switch to a non-root user
 RUN useradd --system --create-home --shell /sbin/nologin coordinator
@@ -60,7 +60,7 @@ USER coordinator
 
 WORKDIR /home/coordinator
 
-# Copy necessary files to run node
+# Copy the Coordinator binary and relevant license
 COPY --from=builder --chown=processsor /serai/bin/serai-coordinator /bin/
 COPY --from=builder --chown=processsor /serai/AGPL-3.0 .
 

--- a/orchestration/coordinator/Dockerfile
+++ b/orchestration/coordinator/Dockerfile
@@ -18,6 +18,9 @@ RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
 # Add dev dependencies
 RUN apt install -y pkg-config clang
 
+# Dependencies for the Serai node
+RUN apt install -y make protobuf-compiler
+
 # Add files for build
 ADD common /serai/common
 ADD crypto /serai/crypto

--- a/orchestration/coordinator/Dockerfile.coordinator
+++ b/orchestration/coordinator/Dockerfile.coordinator
@@ -1,0 +1,2 @@
+  cargo build -p serai-coordinator --release --all-features && \
+  mv /serai/target/release/serai-coordinator /serai/bin

--- a/orchestration/coordinator/Dockerfile.coordinator.end
+++ b/orchestration/coordinator/Dockerfile.coordinator.end
@@ -1,0 +1,15 @@
+# Install ca-certificates
+RUN apt install -y ca-certificates
+
+# Switch to a non-root user
+RUN useradd --system --create-home --shell /sbin/nologin coordinator
+USER coordinator
+
+WORKDIR /home/coordinator
+
+# Copy the Coordinator binary and relevant license
+COPY --from=builder --chown=processsor /serai/bin/serai-coordinator /bin/
+COPY --from=builder --chown=processsor /serai/AGPL-3.0 .
+
+# Run coordinator
+CMD ["serai-coordinator"]

--- a/orchestration/docker-compose.yml
+++ b/orchestration/docker-compose.yml
@@ -67,12 +67,23 @@ services:
     expose:
       - "2287"
 
-  processor:
+  bitcoin-processor:
     profiles:
-      - processor
+      - bitcoin-processor
     build:
       context: ../
-      dockerfile: ./orchestration/processor/Dockerfile
+      dockerfile: ./orchestration/processor/bitcoin/Dockerfile
+    restart: unless-stopped
+    volumes:
+      - "./processor/scripts:/scripts"
+    entrypoint: /scripts/entry-dev.sh
+
+  monero-processor:
+    profiles:
+      - monero-processor
+    build:
+      context: ../
+      dockerfile: ./orchestration/processor/monero/Dockerfile
     restart: unless-stopped
     volumes:
       - "./processor/scripts:/scripts"

--- a/orchestration/dockerfiles.sh
+++ b/orchestration/dockerfiles.sh
@@ -23,14 +23,23 @@ cat \
   ./Dockerfile.parts/Dockerfile.debian.start \
   ./message-queue/Dockerfile.message-queue.end >> ./message-queue/Dockerfile
 
-# Processor
-rm ./processor/Dockerfile
+# Bitcoin Processor
+rm ./processor/bitcoin/Dockerfile
 cat \
   ./Dockerfile.parts/mimalloc/Dockerfile.debian \
   ./Dockerfile.parts/Dockerfile.serai.build \
-  ./processor/Dockerfile.processor \
+  ./processor/bitcoin/Dockerfile.processor.bitcoin \
   ./Dockerfile.parts/Dockerfile.debian.start \
-  ./processor/Dockerfile.processor.end >> ./processor/Dockerfile
+  ./processor/Dockerfile.processor.end >> ./processor/bitcoin/Dockerfile
+
+# Monero Processor
+rm ./processor/monero/Dockerfile
+cat \
+  ./Dockerfile.parts/mimalloc/Dockerfile.debian \
+  ./Dockerfile.parts/Dockerfile.serai.build \
+  ./processor/monero/Dockerfile.processor.monero \
+  ./Dockerfile.parts/Dockerfile.debian.start \
+  ./processor/Dockerfile.processor.end >> ./processor/monero/Dockerfile
 
 # Coordinator
 rm ./coordinator/Dockerfile

--- a/orchestration/dockerfiles.sh
+++ b/orchestration/dockerfiles.sh
@@ -1,0 +1,51 @@
+# Bitcoin
+rm ./coins/bitcoin/Dockerfile
+cat \
+  ./Dockerfile.parts/mimalloc/Dockerfile.debian \
+  ./coins/bitcoin/Dockerfile.bitcoin \
+  ./Dockerfile.parts/Dockerfile.debian.start \
+  ./coins/bitcoin/Dockerfile.bitcoin.end >> ./coins/bitcoin/Dockerfile
+
+# Monero
+rm ./coins/monero/Dockerfile
+cat \
+  ./Dockerfile.parts/mimalloc/Dockerfile.alpine \
+  ./coins/monero/Dockerfile.monero \
+  ./Dockerfile.parts/Dockerfile.alpine.start \
+  ./coins/monero/Dockerfile.monero.end >> ./coins/monero/Dockerfile
+
+# Message Queue
+rm ./message-queue/Dockerfile
+cat \
+  ./Dockerfile.parts/mimalloc/Dockerfile.debian \
+  ./Dockerfile.parts/Dockerfile.serai.build \
+  ./message-queue/Dockerfile.message-queue \
+  ./Dockerfile.parts/Dockerfile.debian.start \
+  ./message-queue/Dockerfile.message-queue.end >> ./message-queue/Dockerfile
+
+# Processor
+rm ./processor/Dockerfile
+cat \
+  ./Dockerfile.parts/mimalloc/Dockerfile.debian \
+  ./Dockerfile.parts/Dockerfile.serai.build \
+  ./processor/Dockerfile.processor \
+  ./Dockerfile.parts/Dockerfile.debian.start \
+  ./processor/Dockerfile.processor.end >> ./processor/Dockerfile
+
+# Coordinator
+rm ./coordinator/Dockerfile
+cat \
+  ./Dockerfile.parts/mimalloc/Dockerfile.debian \
+  ./Dockerfile.parts/Dockerfile.serai.build \
+  ./coordinator/Dockerfile.coordinator \
+  ./Dockerfile.parts/Dockerfile.debian.start \
+  ./coordinator/Dockerfile.coordinator.end >> ./coordinator/Dockerfile
+
+# Node
+rm ./serai/Dockerfile
+cat \
+  ./Dockerfile.parts/mimalloc/Dockerfile.debian \
+  ./Dockerfile.parts/Dockerfile.serai.build \
+  ./serai/Dockerfile.serai \
+  ./Dockerfile.parts/Dockerfile.debian.start \
+  ./serai/Dockerfile.serai.end >> ./serai/Dockerfile

--- a/orchestration/message-queue/Dockerfile
+++ b/orchestration/message-queue/Dockerfile
@@ -18,6 +18,9 @@ RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
 # Add dev dependencies
 RUN apt install -y pkg-config clang
 
+# Dependencies for the Serai node
+RUN apt install -y make protobuf-compiler
+
 # Add files for build
 ADD common /serai/common
 ADD crypto /serai/crypto

--- a/orchestration/message-queue/Dockerfile
+++ b/orchestration/message-queue/Dockerfile
@@ -1,8 +1,22 @@
-FROM rust:1.73-slim-bookworm as builder
-LABEL description="STAGE 1: Build"
+FROM debian:bookworm-slim as mimalloc
 
-# Upgrade and add dev dependencies
-RUN apt update && apt upgrade -y && apt install -y pkg-config clang libssl-dev && apt autoremove -y && apt clean
+RUN apt update && apt upgrade -y && apt install -y gcc g++ make cmake git
+RUN git clone https://github.com/microsoft/mimalloc && \
+  cd mimalloc && \
+  mkdir -p out/secure && \
+  cd out/secure && \
+  cmake -DMI_SECURE=ON ../.. && \
+  make && \
+  cp ./libmimalloc-secure.so ../../../libmimalloc.so
+FROM rust:1.73-slim-bookworm as builder
+
+COPY --from=mimalloc libmimalloc.so /usr/lib
+RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload
+
+RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
+
+# Add dev dependencies
+RUN apt install -y pkg-config clang
 
 # Add files for build
 ADD common /serai/common
@@ -20,37 +34,23 @@ ADD AGPL-3.0 /serai
 
 WORKDIR /serai
 
+# Add the wasm toolchain
+RUN rustup target add wasm32-unknown-unknown
+
 # Mount the caches and build
 RUN --mount=type=cache,target=/root/.cargo \
   --mount=type=cache,target=/usr/local/cargo/registry \
   --mount=type=cache,target=/usr/local/cargo/git \
   --mount=type=cache,target=/serai/target \
-  cd message-queue && \
-  cargo build --release --all-features && \
   mkdir /serai/bin && \
+  cargo build --release --all-features -p serai-message-queue && \
   mv /serai/target/release/serai-message-queue /serai/bin
-
-# Also build mimalloc
-FROM debian:bookworm-slim as mimalloc
-
-RUN apt update && apt upgrade -y && apt install -y gcc g++ make cmake git
-RUN git clone https://github.com/microsoft/mimalloc && \
-  cd mimalloc && \
-  mkdir -p out/secure && \
-  cd out/secure && \
-  cmake -DMI_SECURE=ON ../.. && \
-  make && \
-  cp ./libmimalloc-secure.so ../../../libmimalloc.so
-
-# Build the actual image
 FROM debian:bookworm-slim as image
 
 COPY --from=mimalloc libmimalloc.so /usr/lib
 RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload
 
-# Upgrade packages
-RUN apt update && apt upgrade -y
-
+RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
 # Switch to a non-root user
 RUN useradd --system --home /home/message-queue --create-home --shell /sbin/nologin messagequeue
 USER messagequeue

--- a/orchestration/message-queue/Dockerfile.message-queue
+++ b/orchestration/message-queue/Dockerfile.message-queue
@@ -1,0 +1,2 @@
+  cargo build --release --all-features -p serai-message-queue && \
+  mv /serai/target/release/serai-message-queue /serai/bin

--- a/orchestration/message-queue/Dockerfile.message-queue.end
+++ b/orchestration/message-queue/Dockerfile.message-queue.end
@@ -1,0 +1,13 @@
+# Switch to a non-root user
+RUN useradd --system --home /home/message-queue --create-home --shell /sbin/nologin messagequeue
+USER messagequeue
+
+WORKDIR /home/message-queue
+
+# Copy the Message Queue binary and relevant license
+COPY --from=builder --chown=messagequeue /serai/bin/serai-message-queue /bin
+COPY --from=builder --chown=messagequeue /serai/AGPL-3.0 .
+
+# Run message-queue
+EXPOSE 2287
+CMD ["serai-message-queue"]

--- a/orchestration/processor/Dockerfile
+++ b/orchestration/processor/Dockerfile
@@ -1,8 +1,22 @@
-FROM rust:1.73-slim-bookworm as builder
-LABEL description="STAGE 1: Build"
+FROM debian:bookworm-slim as mimalloc
 
-# Upgrade and add dev dependencies
-RUN apt update && apt upgrade -y && apt install -y pkg-config clang && apt autoremove -y && apt clean
+RUN apt update && apt upgrade -y && apt install -y gcc g++ make cmake git
+RUN git clone https://github.com/microsoft/mimalloc && \
+  cd mimalloc && \
+  mkdir -p out/secure && \
+  cd out/secure && \
+  cmake -DMI_SECURE=ON ../.. && \
+  make && \
+  cp ./libmimalloc-secure.so ../../../libmimalloc.so
+FROM rust:1.73-slim-bookworm as builder
+
+COPY --from=mimalloc libmimalloc.so /usr/lib
+RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload
+
+RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
+
+# Add dev dependencies
+RUN apt install -y pkg-config clang
 
 # Add files for build
 ADD common /serai/common
@@ -28,31 +42,17 @@ RUN --mount=type=cache,target=/root/.cargo \
   --mount=type=cache,target=/usr/local/cargo/registry \
   --mount=type=cache,target=/usr/local/cargo/git \
   --mount=type=cache,target=/serai/target \
-  cd processor && \
-  cargo build --release --all-features && \
   mkdir /serai/bin && \
+  cargo build --release --all-features -p serai-processor && \
   mv /serai/target/release/serai-processor /serai/bin
-
-# Also build mimalloc
-FROM debian:bookworm-slim as mimalloc
-
-RUN apt update && apt upgrade -y && apt install -y gcc g++ make cmake git
-RUN git clone https://github.com/microsoft/mimalloc && \
-  cd mimalloc && \
-  mkdir -p out/secure && \
-  cd out/secure && \
-  cmake -DMI_SECURE=ON ../.. && \
-  make && \
-  cp ./libmimalloc-secure.so ../../../libmimalloc.so
-
-# Build the actual image
 FROM debian:bookworm-slim as image
 
 COPY --from=mimalloc libmimalloc.so /usr/lib
 RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload
 
-# Upgrade packages and install ca-certificates
-RUN apt update && apt upgrade -y && apt install -y ca-certificates
+RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
+# Install ca-certificates
+RUN apt install -y ca-certificates
 
 # Switch to a non-root user
 RUN useradd --system --create-home --shell /sbin/nologin processor
@@ -60,7 +60,7 @@ USER processor
 
 WORKDIR /home/processor
 
-# Copy necessary files to run node
+# Copy the Processor binary and relevant license
 COPY --from=builder --chown=processsor /serai/bin/serai-processor /bin/
 COPY --from=builder --chown=processsor /serai/AGPL-3.0 .
 

--- a/orchestration/processor/Dockerfile.processor
+++ b/orchestration/processor/Dockerfile.processor
@@ -1,0 +1,2 @@
+  cargo build --release --all-features -p serai-processor && \
+  mv /serai/target/release/serai-processor /serai/bin

--- a/orchestration/processor/Dockerfile.processor
+++ b/orchestration/processor/Dockerfile.processor
@@ -1,2 +1,0 @@
-  cargo build --release --all-features -p serai-processor && \
-  mv /serai/target/release/serai-processor /serai/bin

--- a/orchestration/processor/Dockerfile.processor.end
+++ b/orchestration/processor/Dockerfile.processor.end
@@ -1,0 +1,15 @@
+# Install ca-certificates
+RUN apt install -y ca-certificates
+
+# Switch to a non-root user
+RUN useradd --system --create-home --shell /sbin/nologin processor
+USER processor
+
+WORKDIR /home/processor
+
+# Copy the Processor binary and relevant license
+COPY --from=builder --chown=processsor /serai/bin/serai-processor /bin/
+COPY --from=builder --chown=processsor /serai/AGPL-3.0 .
+
+# Run processor
+CMD ["serai-processor"]

--- a/orchestration/processor/bitcoin/Dockerfile
+++ b/orchestration/processor/bitcoin/Dockerfile
@@ -18,6 +18,9 @@ RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
 # Add dev dependencies
 RUN apt install -y pkg-config clang
 
+# Dependencies for the Serai node
+RUN apt install -y make protobuf-compiler
+
 # Add files for build
 ADD common /serai/common
 ADD crypto /serai/crypto

--- a/orchestration/processor/bitcoin/Dockerfile
+++ b/orchestration/processor/bitcoin/Dockerfile
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/root/.cargo \
   --mount=type=cache,target=/usr/local/cargo/git \
   --mount=type=cache,target=/serai/target \
   mkdir /serai/bin && \
-  cargo build --release --all-features -p serai-processor && \
+  cargo build --release --features bitcoin -p serai-processor && \
   mv /serai/target/release/serai-processor /serai/bin
 FROM debian:bookworm-slim as image
 

--- a/orchestration/processor/bitcoin/Dockerfile.processor.bitcoin
+++ b/orchestration/processor/bitcoin/Dockerfile.processor.bitcoin
@@ -1,0 +1,2 @@
+  cargo build --release --features bitcoin -p serai-processor && \
+  mv /serai/target/release/serai-processor /serai/bin

--- a/orchestration/processor/monero/Dockerfile
+++ b/orchestration/processor/monero/Dockerfile
@@ -18,6 +18,9 @@ RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
 # Add dev dependencies
 RUN apt install -y pkg-config clang
 
+# Dependencies for the Serai node
+RUN apt install -y make protobuf-compiler
+
 # Add files for build
 ADD common /serai/common
 ADD crypto /serai/crypto

--- a/orchestration/processor/monero/Dockerfile
+++ b/orchestration/processor/monero/Dockerfile
@@ -1,0 +1,68 @@
+FROM debian:bookworm-slim as mimalloc
+
+RUN apt update && apt upgrade -y && apt install -y gcc g++ make cmake git
+RUN git clone https://github.com/microsoft/mimalloc && \
+  cd mimalloc && \
+  mkdir -p out/secure && \
+  cd out/secure && \
+  cmake -DMI_SECURE=ON ../.. && \
+  make && \
+  cp ./libmimalloc-secure.so ../../../libmimalloc.so
+FROM rust:1.73-slim-bookworm as builder
+
+COPY --from=mimalloc libmimalloc.so /usr/lib
+RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload
+
+RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
+
+# Add dev dependencies
+RUN apt install -y pkg-config clang
+
+# Add files for build
+ADD common /serai/common
+ADD crypto /serai/crypto
+ADD coins /serai/coins
+ADD message-queue /serai/message-queue
+ADD processor /serai/processor
+ADD coordinator /serai/coordinator
+ADD substrate /serai/substrate
+ADD mini /serai/mini
+ADD tests /serai/tests
+ADD Cargo.toml /serai
+ADD Cargo.lock /serai
+ADD AGPL-3.0 /serai
+
+WORKDIR /serai
+
+# Add the wasm toolchain
+RUN rustup target add wasm32-unknown-unknown
+
+# Mount the caches and build
+RUN --mount=type=cache,target=/root/.cargo \
+  --mount=type=cache,target=/usr/local/cargo/registry \
+  --mount=type=cache,target=/usr/local/cargo/git \
+  --mount=type=cache,target=/serai/target \
+  mkdir /serai/bin && \
+  cargo build --release --features monero -p serai-processor && \
+  mv /serai/target/release/serai-processor /serai/bin
+FROM debian:bookworm-slim as image
+
+COPY --from=mimalloc libmimalloc.so /usr/lib
+RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload
+
+RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
+# Install ca-certificates
+RUN apt install -y ca-certificates
+
+# Switch to a non-root user
+RUN useradd --system --create-home --shell /sbin/nologin processor
+USER processor
+
+WORKDIR /home/processor
+
+# Copy the Processor binary and relevant license
+COPY --from=builder --chown=processsor /serai/bin/serai-processor /bin/
+COPY --from=builder --chown=processsor /serai/AGPL-3.0 .
+
+# Run processor
+CMD ["serai-processor"]

--- a/orchestration/processor/monero/Dockerfile.processor.monero
+++ b/orchestration/processor/monero/Dockerfile.processor.monero
@@ -1,0 +1,2 @@
+  cargo build --release --features monero -p serai-processor && \
+  mv /serai/target/release/serai-processor /serai/bin

--- a/orchestration/serai/Dockerfile
+++ b/orchestration/serai/Dockerfile
@@ -18,6 +18,9 @@ RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
 # Add dev dependencies
 RUN apt install -y pkg-config clang
 
+# Dependencies for the Serai node
+RUN apt install -y make protobuf-compiler
+
 # Add files for build
 ADD common /serai/common
 ADD crypto /serai/crypto

--- a/orchestration/serai/Dockerfile
+++ b/orchestration/serai/Dockerfile
@@ -1,11 +1,22 @@
+FROM debian:bookworm-slim as mimalloc
+
+RUN apt update && apt upgrade -y && apt install -y gcc g++ make cmake git
+RUN git clone https://github.com/microsoft/mimalloc && \
+  cd mimalloc && \
+  mkdir -p out/secure && \
+  cd out/secure && \
+  cmake -DMI_SECURE=ON ../.. && \
+  make && \
+  cp ./libmimalloc-secure.so ../../../libmimalloc.so
 FROM rust:1.73-slim-bookworm as builder
-LABEL description="STAGE 1: Build"
 
-# Upgrade and add dev dependencies
-RUN apt update && apt upgrade -y && apt install -y git pkg-config make clang libssl-dev protobuf-compiler && apt autoremove -y && apt clean
+COPY --from=mimalloc libmimalloc.so /usr/lib
+RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload
 
-# Add the wasm toolchain
-RUN rustup target add wasm32-unknown-unknown
+RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
+
+# Add dev dependencies
+RUN apt install -y pkg-config clang
 
 # Add files for build
 ADD common /serai/common
@@ -23,44 +34,30 @@ ADD AGPL-3.0 /serai
 
 WORKDIR /serai
 
+# Add the wasm toolchain
+RUN rustup target add wasm32-unknown-unknown
+
 # Mount the caches and build
 RUN --mount=type=cache,target=/root/.cargo \
   --mount=type=cache,target=/usr/local/cargo/registry \
   --mount=type=cache,target=/usr/local/cargo/git \
   --mount=type=cache,target=/serai/target \
-  cd substrate/node && \
-  cargo build --release && \
   mkdir /serai/bin && \
+  cargo build --release -p serai-node && \
   mv /serai/target/release/serai-node /serai/bin
-
-# Also build mimalloc
-FROM debian:bookworm-slim as mimalloc
-
-RUN apt update && apt upgrade -y && apt install -y gcc g++ make cmake git
-RUN git clone https://github.com/microsoft/mimalloc && \
-  cd mimalloc && \
-  mkdir -p out/secure && \
-  cd out/secure && \
-  cmake -DMI_SECURE=ON ../.. && \
-  make && \
-  cp ./libmimalloc-secure.so ../../../libmimalloc.so
-
-# Build the actual image
 FROM debian:bookworm-slim as image
 
 COPY --from=mimalloc libmimalloc.so /usr/lib
 RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload
 
-# Upgrade packages
-RUN apt update && apt upgrade -y
-
+RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
 # Switch to a non-root user
 RUN useradd --system --home /home/serai --shell /sbin/nologin serai
 USER serai
 
 WORKDIR /home/serai
 
-# Copy necessary files to run node
+# Copy the Serai binary and relevant license
 COPY --from=builder --chown=serai /serai/bin/serai-node /bin/
 COPY --from=builder --chown=serai /serai/AGPL-3.0 .
 

--- a/orchestration/serai/Dockerfile.serai
+++ b/orchestration/serai/Dockerfile.serai
@@ -1,0 +1,2 @@
+  cargo build --release -p serai-node && \
+  mv /serai/target/release/serai-node /serai/bin

--- a/orchestration/serai/Dockerfile.serai.end
+++ b/orchestration/serai/Dockerfile.serai.end
@@ -1,0 +1,13 @@
+# Switch to a non-root user
+RUN useradd --system --home /home/serai --shell /sbin/nologin serai
+USER serai
+
+WORKDIR /home/serai
+
+# Copy the Serai binary and relevant license
+COPY --from=builder --chown=serai /serai/bin/serai-node /bin/
+COPY --from=builder --chown=serai /serai/AGPL-3.0 .
+
+# Run node
+EXPOSE 30333 9615 9933 9944
+CMD ["serai-node"]

--- a/tests/docker/src/lib.rs
+++ b/tests/docker/src/lib.rs
@@ -54,7 +54,14 @@ pub fn build(name: String) {
       if HashSet::from(["bitcoin", "ethereum", "monero"]).contains(name.as_str()) {
         dockerfile_path = dockerfile_path.join("coins");
       }
-      dockerfile_path = dockerfile_path.join(&name).join("Dockerfile");
+      if name.contains("-processor") {
+        dockerfile_path = dockerfile_path
+          .join("processor")
+          .join(name.split('-').next().unwrap())
+          .join("Dockerfile");
+      } else {
+        dockerfile_path = dockerfile_path.join(&name).join("Dockerfile");
+      }
 
       // For all services, if the Dockerfile was edited after the image was built we should rebuild
       let mut last_modified =
@@ -71,7 +78,7 @@ pub fn build(name: String) {
           meta(repo_path.join("substrate").join("primitives")),
           meta(repo_path.join("message-queue")),
         ],
-        "processor" => vec![
+        "bitcoin-processor" | "ethereum-processor" | "monero-processor" => vec![
           meta(repo_path.join("common")),
           meta(repo_path.join("crypto")),
           meta(repo_path.join("coins")),

--- a/tests/processor/src/lib.rs
+++ b/tests/processor/src/lib.rs
@@ -39,7 +39,7 @@ pub fn processor_instance(
     NetworkId::Monero => "monero",
   };
   let image = format!("{network_str}-processor");
-  serai_docker_tests::build("processor".to_string());
+  serai_docker_tests::build(image.clone());
 
   TestBodySpecification::with_image(
     Image::with_repository(format!("serai-dev-{image}")).pull_policy(PullPolicy::Never),


### PR DESCRIPTION
Breaks Dockerfiles into several commonly shared parts and uses a bash script to create the actual Dockerfiles.

Makes `sh` a dev dependency for working with the Dockerfiles.

Resolves #375.