### PR TITLE
Add a cosigning protocol to ensure finalizations are unique

### DIFF
--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -37,6 +37,7 @@ processor-messages = { package = "serai-processor-messages", path = "../processo
 message-queue = { package = "serai-message-queue", path = "../message-queue" }
 tributary = { package = "tributary-chain", path = "./tributary" }
 
+sp-application-crypto = { git = "https://github.com/serai-dex/substrate", default-features = false, features = ["std"] }
 serai-client = { path = "../substrate/client", default-features = false, features = ["serai"] }
 
 hex = { version = "0.4", default-features = false, features = ["std"] }

--- a/coordinator/src/cosign_evaluator.rs
+++ b/coordinator/src/cosign_evaluator.rs
@@ -1,0 +1,207 @@
+use core::time::Duration;
+use std::{
+  sync::{Arc, Mutex, RwLock},
+  collections::{HashSet, HashMap},
+};
+
+use tokio::{sync::mpsc, time::sleep};
+
+use scale::Encode;
+use sp_application_crypto::RuntimePublic;
+use serai_client::{
+  primitives::{NETWORKS, NetworkId, Signature},
+  validator_sets::primitives::{Session, ValidatorSet},
+  SeraiError, Serai,
+};
+
+use serai_db::{DbTxn, Db};
+
+use processor_messages::coordinator::cosign_block_msg;
+
+use crate::{
+  p2p::{CosignedBlock, P2pMessageKind, P2p},
+  substrate::SubstrateDb,
+};
+
+pub struct CosignEvaluator<D: Db> {
+  db: Mutex<D>,
+  serai: Arc<Serai>,
+  stakes: RwLock<Option<HashMap<NetworkId, u64>>>,
+  latest_cosigns: RwLock<HashMap<NetworkId, (u64, CosignedBlock)>>,
+}
+
+impl<D: Db> CosignEvaluator<D> {
+  fn update_latest_cosign(&self) {
+    let stakes_lock = self.stakes.read().unwrap();
+    // If we haven't gotten the stake data yet, return
+    let Some(stakes) = stakes_lock.as_ref() else { return };
+
+    let latest_cosigns = self.latest_cosigns.read().unwrap();
+    let mut highest_block = 0;
+    for (block_num, _) in latest_cosigns.values() {
+      let mut networks = HashSet::new();
+      for (network, (sub_block_num, _)) in &*latest_cosigns {
+        if sub_block_num >= block_num {
+          networks.insert(network);
+        }
+      }
+      let sum_stake =
+        networks.into_iter().map(|network| stakes.get(network).unwrap_or(&0)).sum::<u64>();
+      let total_stake = stakes.values().cloned().sum::<u64>();
+      let needed_stake = ((total_stake * 2) / 3) + 1;
+      if (total_stake == 0) || (sum_stake > needed_stake) {
+        highest_block = highest_block.max(*block_num);
+      }
+    }
+
+    let mut db_lock = self.db.lock().unwrap();
+    let mut txn = db_lock.txn();
+    if highest_block > SubstrateDb::<D>::latest_cosigned_block(&txn) {
+      log::info!("setting latest cosigned block to {}", highest_block);
+      SubstrateDb::<D>::set_latest_cosigned_block(&mut txn, highest_block);
+    }
+    txn.commit();
+  }
+
+  async fn update_stakes(&self) -> Result<(), SeraiError> {
+    let serai = self.serai.as_of(self.serai.latest_block_hash().await?);
+
+    let mut stakes = HashMap::new();
+    for network in NETWORKS {
+      // Use if this network has published a Batch for a short-circuit of if they've ever set a key
+      let set_key = serai.in_instructions().last_batch_for_network(network).await?.is_some();
+      if set_key {
+        stakes.insert(
+          network,
+          serai
+            .validator_sets()
+            .total_allocated_stake(network)
+            .await?
+            .expect("network which published a batch didn't have a stake set")
+            .0,
+        );
+      }
+    }
+
+    // Since we've successfully built stakes, set it
+    *self.stakes.write().unwrap() = Some(stakes);
+
+    self.update_latest_cosign();
+
+    Ok(())
+  }
+
+  // Uses Err to signify a message should be retried
+  async fn handle_new_cosign(&self, cosign: CosignedBlock) -> Result<(), SeraiError> {
+    let Some(block) = self.serai.block(cosign.block).await? else {
+      log::warn!("received cosign for an unknown block");
+      return Ok(());
+    };
+
+    // If this an old cosign, don't bother handling it
+    if block.number() <
+      self.latest_cosigns.read().unwrap().get(&cosign.network).map(|cosign| cosign.0).unwrap_or(0)
+    {
+      log::debug!("received old cosign from {:?}", cosign.network);
+      return Ok(());
+    }
+
+    // Get the key for this network as of the prior block
+    let serai = self.serai.as_of(block.header().parent_hash.into());
+
+    let Some(latest_session) = serai.validator_sets().session(cosign.network).await? else {
+      log::warn!("received cosign from {:?}, which doesn't yet have a session", cosign.network);
+      return Ok(());
+    };
+    let prior_session = Session(latest_session.0.saturating_sub(1));
+    let set_with_keys = if serai
+      .validator_sets()
+      .keys(ValidatorSet { network: cosign.network, session: prior_session })
+      .await?
+      .is_some()
+    {
+      ValidatorSet { network: cosign.network, session: prior_session }
+    } else {
+      ValidatorSet { network: cosign.network, session: latest_session }
+    };
+
+    let Some(keys) = serai.validator_sets().keys(set_with_keys).await? else {
+      log::warn!("received cosign for a block we didn't have keys for");
+      return Ok(());
+    };
+
+    if !keys.0.verify(&cosign_block_msg(cosign.block), &Signature(cosign.signature)) {
+      log::warn!("received cosigned block with an invalid signature");
+      return Ok(());
+    }
+
+    self.latest_cosigns.write().unwrap().insert(cosign.network, (block.number(), cosign));
+
+    self.update_latest_cosign();
+
+    Ok(())
+  }
+
+  #[allow(clippy::new_ret_no_self)]
+  pub fn new<P: P2p>(db: D, p2p: P, serai: Arc<Serai>) -> mpsc::UnboundedSender<CosignedBlock> {
+    let evaluator = Arc::new(Self {
+      db: Mutex::new(db),
+      serai,
+      stakes: RwLock::new(None),
+      latest_cosigns: RwLock::new(HashMap::new()),
+    });
+
+    // Spawn a task to update stakes regularly
+    tokio::spawn({
+      let evaluator = evaluator.clone();
+      async move {
+        loop {
+          // Run this until it passes
+          while evaluator.update_stakes().await.is_err() {
+            log::warn!("couldn't update stakes in the cosign evaluator");
+            // Try again in 10 seconds
+            sleep(Duration::from_secs(10)).await;
+          }
+          // Run it every 10 minutes as we don't need the exact stake data for this to be valid
+          sleep(Duration::from_secs(10 * 60)).await;
+        }
+      }
+    });
+
+    // Spawn a task to receive cosigns and handle them
+    let (send, mut recv) = mpsc::unbounded_channel();
+    tokio::spawn({
+      let evaluator = evaluator.clone();
+      async move {
+        while let Some(msg) = recv.recv().await {
+          while evaluator.handle_new_cosign(msg).await.is_err() {
+            // Try again in 10 seconds
+            sleep(Duration::from_secs(10)).await;
+          }
+        }
+      }
+    });
+
+    // Spawn a task to rebroadcast the most recent cosigns
+    tokio::spawn({
+      async move {
+        loop {
+          let cosigns = evaluator
+            .latest_cosigns
+            .read()
+            .unwrap()
+            .values()
+            .map(|cosign| cosign.1)
+            .collect::<Vec<_>>();
+          for cosign in cosigns {
+            P2p::broadcast(&p2p, P2pMessageKind::CosignedBlock, cosign.encode()).await;
+          }
+          sleep(Duration::from_secs(60)).await;
+        }
+      }
+    });
+
+    // Return the channel to send cosigns
+    send
+  }
+}

--- a/coordinator/src/cosign_evaluator.rs
+++ b/coordinator/src/cosign_evaluator.rs
@@ -36,6 +36,8 @@ impl<D: Db> CosignEvaluator<D> {
     // If we haven't gotten the stake data yet, return
     let Some(stakes) = stakes_lock.as_ref() else { return };
 
+    let total_stake = stakes.values().cloned().sum::<u64>();
+
     let latest_cosigns = self.latest_cosigns.read().unwrap();
     let mut highest_block = 0;
     for (block_num, _) in latest_cosigns.values() {
@@ -47,7 +49,6 @@ impl<D: Db> CosignEvaluator<D> {
       }
       let sum_stake =
         networks.into_iter().map(|network| stakes.get(network).unwrap_or(&0)).sum::<u64>();
-      let total_stake = stakes.values().cloned().sum::<u64>();
       let needed_stake = ((total_stake * 2) / 3) + 1;
       if (total_stake == 0) || (sum_stake > needed_stake) {
         highest_block = highest_block.max(*block_num);

--- a/coordinator/src/cosign_evaluator.rs
+++ b/coordinator/src/cosign_evaluator.rs
@@ -136,6 +136,7 @@ impl<D: Db> CosignEvaluator<D> {
       return Ok(());
     }
 
+    log::info!("received cosign for block {} by {:?}", block.number(), cosign.network);
     self.latest_cosigns.write().unwrap().insert(cosign.network, (block.number(), cosign));
 
     self.update_latest_cosign();

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -854,7 +854,7 @@ async fn handle_cosigns_and_batch_publication<D: Db, P: P2p>(
         break;
       };
       log::info!(
-        "{network:?} {session:?} co-signing block #{block} (hash {}...)",
+        "{network:?} {session:?} cosigning block #{block} (hash {}...)",
         hex::encode(&hash[.. 8])
       );
       let tx = Transaction::CosignSubstrateBlock(hash);

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -655,10 +655,9 @@ async fn handle_processor_message<D: Db, P: P2p>(
               MainDb::<D>::set_handover_batch(&mut txn, spec.set(), last_received);
               // If this isn't the first batch, meaning we do have to verify all prior batches, and
               // the prior Batch hasn't been verified yet...
-              let prior_batch = last_received - 1;
               if (last_received != 0) &&
                 MainDb::<D>::last_verified_batch(&txn, msg.network)
-                  .map(|last_verified| last_verified < prior_batch)
+                  .map(|last_verified| last_verified < (last_received - 1))
                   .unwrap_or(true)
               {
                 // Withhold this TX until we verify all prior `Batch`s

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -827,6 +827,9 @@ async fn handle_cosigns_and_batch_publication<D: Db, P: P2p>(
 ) {
   let mut tributaries = HashMap::new();
   'outer: loop {
+    // TODO: Create a better async flow for this, as this does still hammer this task
+    tokio::task::yield_now().await;
+
     match tributary_event.try_recv() {
       Ok(event) => match event {
         TributaryEvent::NewTributary(tributary) => {
@@ -941,8 +944,6 @@ async fn handle_cosigns_and_batch_publication<D: Db, P: P2p>(
 
       txn.commit();
     }
-
-    tokio::task::yield_now().await;
   }
 }
 

--- a/coordinator/src/substrate/db.rs
+++ b/coordinator/src/substrate/db.rs
@@ -44,7 +44,7 @@ impl<T: DbTxn> CosignTxn<T> {
   }
 }
 impl CosignTransactions {
-  // Append a co-sign transaction.
+  // Append a cosign transaction.
   pub fn append_cosign<T: DbTxn>(
     txn: &mut CosignTxn<T>,
     set: ValidatorSet,

--- a/coordinator/src/substrate/db.rs
+++ b/coordinator/src/substrate/db.rs
@@ -11,6 +11,7 @@ use serai_client::{
 
 create_db! {
   NewSubstrateDb {
+    CosignTriggered: () -> (),
     IntendedCosign: () -> (u64, Option<u64>),
     BlockHasEvents: (block: u64) -> u8,
     CosignTransactions: (network: NetworkId) -> Vec<(Session, u64, [u8; 32])>

--- a/coordinator/src/substrate/mod.rs
+++ b/coordinator/src/substrate/mod.rs
@@ -386,7 +386,8 @@ async fn handle_new_blocks<D: Db, Pro: Processors>(
       serai: &Serai,
       block: u64,
     ) -> Result<HasEvents, SeraiError> {
-      match BlockHasEvents::get(txn, block) {
+      let cached = BlockHasEvents::get(txn, block);
+      match cached {
         None => {
           let serai = serai.as_of(
             serai
@@ -475,7 +476,7 @@ async fn handle_new_blocks<D: Db, Pro: Processors>(
         // That means if this block is setting new keys (which won't lock in until we process this
         // block), we won't freeze up waiting for the yet-to-be-processed keys to sign this block
         let actual_block = serai
-          .block_by_number(block - 1)
+          .block_by_number(block)
           .await?
           .expect("couldn't get block which should've been finalized");
         let serai = serai.as_of(actual_block.header().parent_hash.into());

--- a/coordinator/src/substrate/mod.rs
+++ b/coordinator/src/substrate/mod.rs
@@ -367,15 +367,15 @@ async fn handle_new_blocks<D: Db, Pro: Processors>(
   let latest_number = serai.latest_block().await?.number();
 
   // TODO: If this block directly builds off a cosigned block *and* doesn't contain events, mark
-  // co-signed,
+  // cosigned,
   // TODO: Can we remove any of these events while maintaining security?
   {
     // If:
-    //   A) This block has events and it's been at least X blocks since the last co-sign or
+    //   A) This block has events and it's been at least X blocks since the last cosign or
     //   B) This block doesn't have events but it's been X blocks since a skipped block which did
     //      have events or
-    //   C) This block key gens (which changes who the co-signers are)
-    // co-sign this block.
+    //   C) This block key gens (which changes who the cosigners are)
+    // cosign this block.
     const COSIGN_DISTANCE: u64 = 5 * 60 / 6; // 5 minutes, expressed in blocks
 
     #[derive(Clone, Copy, PartialEq, Eq, Debug, Encode, Decode)]
@@ -452,7 +452,7 @@ async fn handle_new_blocks<D: Db, Pro: Processors>(
     let mut has_no_cosigners = None;
     let mut cosign = vec![];
 
-    // Block we should co-sign no matter what if no prior blocks qualified for co-signing
+    // Block we should cosign no matter what if no prior blocks qualified for cosigning
     let maximally_latent_cosign_block =
       skipped_block.map(|skipped_block| skipped_block + COSIGN_DISTANCE);
     for block in (last_intended_to_cosign_block + 1) ..= latest_number {
@@ -461,11 +461,11 @@ async fn handle_new_blocks<D: Db, Pro: Processors>(
       let block_has_events = block_has_events(&mut txn, serai, block).await?;
       // If this block is within the distance,
       if block < distance_end_exclusive {
-        // and set a key, co-sign it
+        // and set a key, cosign it
         if block_has_events == HasEvents::KeyGen {
           IntendedCosign::set_intended_cosign(&mut txn, block);
           set = true;
-          // Carry skipped if it isn't included by co-signing this block
+          // Carry skipped if it isn't included by cosigning this block
           if let Some(skipped) = skipped_block {
             if skipped > block {
               IntendedCosign::set_skipped_cosign(&mut txn, block);

--- a/coordinator/src/substrate/mod.rs
+++ b/coordinator/src/substrate/mod.rs
@@ -478,7 +478,7 @@ async fn handle_new_blocks<D: Db, Pro: Processors>(
           .block_by_number(block - 1)
           .await?
           .expect("couldn't get block which should've been finalized");
-        let serai = serai.as_of(actual_block.parent());
+        let serai = serai.as_of(actual_block.header().parent_hash.into());
 
         for network in serai_client::primitives::NETWORKS {
           // Get the latest session to have set keys

--- a/coordinator/src/substrate/mod.rs
+++ b/coordinator/src/substrate/mod.rs
@@ -366,6 +366,9 @@ async fn handle_new_blocks<D: Db, Pro: Processors>(
   // Check if there's been a new Substrate block
   let latest_number = serai.latest_block().await?.number();
 
+  // TODO: If this block directly builds off a cosigned block *and* doesn't contain events, mark
+  // co-signed,
+  // TODO: Can we remove any of these events while maintaining security?
   {
     // If:
     //   A) This block has events and it's been at least X blocks since the last co-sign or
@@ -668,7 +671,9 @@ pub(crate) async fn get_expected_next_batch(serai: &Serai, network: NetworkId) -
 
 /// Verifies `Batch`s which have already been indexed from Substrate.
 ///
-/// This has a slight malleability in that doesn't verify *who* published a Batch is as expected.
+/// Spins if a distinct `Batch` is detected on-chain.
+///
+/// This has a slight malleability in that doesn't verify *who* published a `Batch` is as expected.
 /// This is deemed fine.
 pub(crate) async fn verify_published_batches<D: Db>(
   txn: &mut D::Transaction<'_>,

--- a/coordinator/src/tests/tributary/handle_p2p.rs
+++ b/coordinator/src/tests/tributary/handle_p2p.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 
 use rand_core::OsRng;
 
-use tokio::{sync::broadcast, time::sleep};
+use tokio::{
+  sync::{mpsc, broadcast},
+  time::sleep,
+};
 
 use serai_db::MemDb;
 
@@ -32,7 +35,8 @@ async fn handle_p2p_test() {
     let tributary = Arc::new(tributary);
     tributary_arcs.push(tributary.clone());
     let (new_tributary_send, new_tributary_recv) = broadcast::channel(5);
-    tokio::spawn(handle_p2p_task(p2p, new_tributary_recv));
+    let (cosign_send, _) = mpsc::unbounded_channel();
+    tokio::spawn(handle_p2p_task(p2p, cosign_send, new_tributary_recv));
     new_tributary_send
       .send(TributaryEvent::NewTributary(ActiveTributary { spec: spec.clone(), tributary }))
       .map_err(|_| "failed to send ActiveTributary")

--- a/coordinator/src/tests/tributary/mod.rs
+++ b/coordinator/src/tests/tributary/mod.rs
@@ -171,6 +171,12 @@ fn serialize_transaction() {
   {
     let mut block = [0; 32];
     OsRng.fill_bytes(&mut block);
+    test_read_write(Transaction::CosignSubstrateBlock(block));
+  }
+
+  {
+    let mut block = [0; 32];
+    OsRng.fill_bytes(&mut block);
     let mut batch = [0; 5];
     OsRng.fill_bytes(&mut batch);
     test_read_write(Transaction::Batch(block, batch));

--- a/coordinator/src/tributary/handle.rs
+++ b/coordinator/src/tributary/handle.rs
@@ -513,6 +513,7 @@ pub(crate) async fn handle_application_tx<
       let key = loop {
         let Some(key_pair) = TributaryDb::<D>::key_pair(txn, spec.set()) else {
           // This can happen based on a timing condition
+          log::warn!("CosignSubstrateBlock yet keys weren't set yet");
           tokio::time::sleep(core::time::Duration::from_secs(1)).await;
           continue;
         };

--- a/coordinator/src/tributary/handle.rs
+++ b/coordinator/src/tributary/handle.rs
@@ -18,7 +18,7 @@ use tributary::{Signed, TransactionKind, TransactionTrait};
 
 use processor_messages::{
   key_gen::{self, KeyGenId},
-  coordinator::{self, BatchSignId},
+  coordinator::{self, SubstrateSignId},
   sign::{self, SignId},
 };
 
@@ -542,7 +542,7 @@ pub(crate) async fn handle_application_tx<
             .send(
               spec.set().network,
               coordinator::CoordinatorMessage::BatchPreprocesses {
-                id: BatchSignId { key, id: data.plan, attempt: data.attempt },
+                id: SubstrateSignId { key, id: data.plan, attempt: data.attempt },
                 preprocesses,
               },
             )
@@ -573,7 +573,7 @@ pub(crate) async fn handle_application_tx<
             .send(
               spec.set().network,
               coordinator::CoordinatorMessage::BatchShares {
-                id: BatchSignId { key, id: data.plan, attempt: data.attempt },
+                id: SubstrateSignId { key, id: data.plan, attempt: data.attempt },
                 shares: shares
                   .into_iter()
                   .map(|(validator, share)| (validator, share.try_into().unwrap()))

--- a/coordinator/src/tributary/handle.rs
+++ b/coordinator/src/tributary/handle.rs
@@ -498,6 +498,8 @@ pub(crate) async fn handle_application_tx<
       }
     }
 
+    Transaction::CosignSubstrateBlock(hash) => todo!("TODO(now)"),
+
     Transaction::Batch(_, batch) => {
       // Because this Batch has achieved synchrony, its batch ID should be authorized
       TributaryDb::<D>::recognize_topic(txn, genesis, Topic::Batch(batch));

--- a/coordinator/src/tributary/handle.rs
+++ b/coordinator/src/tributary/handle.rs
@@ -510,15 +510,16 @@ pub(crate) async fn handle_application_tx<
         SubstrateSignableId::CosigningSubstrateBlock(hash),
       );
 
+      let key = TributaryDb::<D>::key_pair(txn, spec.set())
+        .expect("cosigning SubstrateBlock despite not setting the key pair")
+        .0
+        .into();
       processors
         .send(
           spec.set().network,
           coordinator::CoordinatorMessage::CosignSubstrateBlock {
             id: SubstrateSignId {
-              key: TributaryDb::<D>::key_pair(txn, spec.set())
-                .expect("cosigning SubstrateBlock despite not setting the key pair")
-                .0
-                .into(),
+              key,
               id: SubstrateSignableId::CosigningSubstrateBlock(hash),
               attempt: 0,
             },
@@ -573,7 +574,7 @@ pub(crate) async fn handle_application_tx<
           processors
             .send(
               spec.set().network,
-              coordinator::CoordinatorMessage::BatchPreprocesses {
+              coordinator::CoordinatorMessage::SubstratePreprocesses {
                 id: SubstrateSignId { key, id: data.plan, attempt: data.attempt },
                 preprocesses,
               },
@@ -604,7 +605,7 @@ pub(crate) async fn handle_application_tx<
           processors
             .send(
               spec.set().network,
-              coordinator::CoordinatorMessage::BatchShares {
+              coordinator::CoordinatorMessage::SubstrateShares {
                 id: SubstrateSignId { key, id: data.plan, attempt: data.attempt },
                 shares: shares
                   .into_iter()

--- a/coordinator/src/tributary/mod.rs
+++ b/coordinator/src/tributary/mod.rs
@@ -1,4 +1,7 @@
-use core::ops::{Deref, Range};
+use core::{
+  ops::{Deref, Range},
+  fmt::Debug,
+};
 use std::io::{self, Read, Write};
 
 use zeroize::Zeroizing;
@@ -15,6 +18,7 @@ use schnorr::SchnorrSignature;
 use frost::Participant;
 
 use scale::{Encode, Decode};
+use processor_messages::coordinator::SubstrateSignableId;
 
 use serai_client::{
   primitives::{NetworkId, PublicKey},
@@ -167,8 +171,8 @@ impl TributarySpec {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct SignData<const N: usize> {
-  pub plan: [u8; N],
+pub struct SignData<Id: Clone + PartialEq + Eq + Debug + Encode + Decode> {
+  pub plan: Id,
   pub attempt: u32,
 
   pub data: Vec<Vec<u8>>,
@@ -176,10 +180,10 @@ pub struct SignData<const N: usize> {
   pub signed: Signed,
 }
 
-impl<const N: usize> ReadWrite for SignData<N> {
+impl<Id: Clone + PartialEq + Eq + Debug + Encode + Decode> ReadWrite for SignData<Id> {
   fn read<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-    let mut plan = [0; N];
-    reader.read_exact(&mut plan)?;
+    let plan = Id::decode(&mut scale::IoReader(&mut *reader))
+      .map_err(|_| io::Error::new(io::ErrorKind::Other, "invalid plan in SignData"))?;
 
     let mut attempt = [0; 4];
     reader.read_exact(&mut attempt)?;
@@ -208,7 +212,7 @@ impl<const N: usize> ReadWrite for SignData<N> {
   }
 
   fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
-    writer.write_all(&self.plan)?;
+    writer.write_all(&self.plan.encode())?;
     writer.write_all(&self.attempt.to_le_bytes())?;
 
     writer.write_all(&[u8::try_from(self.data.len()).unwrap()])?;
@@ -266,11 +270,11 @@ pub enum Transaction {
   // IDs
   SubstrateBlock(u64),
 
-  BatchPreprocess(SignData<5>),
-  BatchShare(SignData<5>),
+  SubstratePreprocess(SignData<SubstrateSignableId>),
+  SubstrateShare(SignData<SubstrateSignableId>),
 
-  SignPreprocess(SignData<32>),
-  SignShare(SignData<32>),
+  SignPreprocess(SignData<[u8; 32]>),
+  SignShare(SignData<[u8; 32]>),
   // This is defined as an Unsigned transaction in order to de-duplicate SignCompleted amongst
   // reporters (who should all report the same thing)
   // We do still track the signer in order to prevent a single signer from publishing arbitrarily
@@ -437,8 +441,8 @@ impl ReadWrite for Transaction {
         Ok(Transaction::SubstrateBlock(u64::from_le_bytes(block)))
       }
 
-      8 => SignData::read(reader).map(Transaction::BatchPreprocess),
-      9 => SignData::read(reader).map(Transaction::BatchShare),
+      8 => SignData::read(reader).map(Transaction::SubstratePreprocess),
+      9 => SignData::read(reader).map(Transaction::SubstrateShare),
 
       10 => SignData::read(reader).map(Transaction::SignPreprocess),
       11 => SignData::read(reader).map(Transaction::SignShare),
@@ -559,11 +563,11 @@ impl ReadWrite for Transaction {
         writer.write_all(&block.to_le_bytes())
       }
 
-      Transaction::BatchPreprocess(data) => {
+      Transaction::SubstratePreprocess(data) => {
         writer.write_all(&[8])?;
         data.write(writer)
       }
-      Transaction::BatchShare(data) => {
+      Transaction::SubstrateShare(data) => {
         writer.write_all(&[9])?;
         data.write(writer)
       }
@@ -604,8 +608,8 @@ impl TransactionTrait for Transaction {
       Transaction::Batch(_, _) => TransactionKind::Provided("batch"),
       Transaction::SubstrateBlock(_) => TransactionKind::Provided("serai"),
 
-      Transaction::BatchPreprocess(data) => TransactionKind::Signed(&data.signed),
-      Transaction::BatchShare(data) => TransactionKind::Signed(&data.signed),
+      Transaction::SubstratePreprocess(data) => TransactionKind::Signed(&data.signed),
+      Transaction::SubstrateShare(data) => TransactionKind::Signed(&data.signed),
 
       Transaction::SignPreprocess(data) => TransactionKind::Signed(&data.signed),
       Transaction::SignShare(data) => TransactionKind::Signed(&data.signed),
@@ -623,7 +627,7 @@ impl TransactionTrait for Transaction {
   }
 
   fn verify(&self) -> Result<(), TransactionError> {
-    if let Transaction::BatchShare(data) = self {
+    if let Transaction::SubstrateShare(data) = self {
       for data in &data.data {
         if data.len() != 32 {
           Err(TransactionError::InvalidContent)?;
@@ -676,8 +680,8 @@ impl Transaction {
         Transaction::Batch(_, _) => panic!("signing Batch"),
         Transaction::SubstrateBlock(_) => panic!("signing SubstrateBlock"),
 
-        Transaction::BatchPreprocess(ref mut data) => &mut data.signed,
-        Transaction::BatchShare(ref mut data) => &mut data.signed,
+        Transaction::SubstratePreprocess(ref mut data) => &mut data.signed,
+        Transaction::SubstrateShare(ref mut data) => &mut data.signed,
 
         Transaction::SignPreprocess(ref mut data) => &mut data.signed,
         Transaction::SignShare(ref mut data) => &mut data.signed,

--- a/coordinator/src/tributary/nonce_decider.rs
+++ b/coordinator/src/tributary/nonce_decider.rs
@@ -86,6 +86,9 @@ impl NonceDecider {
         assert_eq!(*attempt, 0);
         Some(Some(2))
       }
+
+      Transaction::CosignSubstrateBlock(_) => None,
+
       Transaction::Batch(_, _) => None,
       Transaction::SubstrateBlock(_) => None,
       Transaction::BatchPreprocess(data) => {

--- a/coordinator/src/tributary/nonce_decider.rs
+++ b/coordinator/src/tributary/nonce_decider.rs
@@ -1,11 +1,13 @@
 use serai_db::{Get, DbTxn, create_db};
 
+use processor_messages::coordinator::SubstrateSignableId;
+
 use crate::tributary::Transaction;
 
 use scale::Encode;
 
-const BATCH_CODE: u8 = 0;
-const BATCH_SIGNING_CODE: u8 = 1;
+const SUBSTRATE_CODE: u8 = 0;
+const SUBSTRATE_SIGNING_CODE: u8 = 1;
 const PLAN_CODE: u8 = 2;
 const PLAN_SIGNING_CODE: u8 = 3;
 
@@ -30,9 +32,13 @@ impl NextNonceDb {
 /// transactions in response. Enables rebooting/rebuilding validators with full safety.
 pub struct NonceDecider;
 impl NonceDecider {
-  pub fn handle_batch(txn: &mut impl DbTxn, genesis: [u8; 32], batch: [u8; 5]) -> u32 {
+  pub fn handle_substrate_signable(
+    txn: &mut impl DbTxn,
+    genesis: [u8; 32],
+    id: SubstrateSignableId,
+  ) -> u32 {
     let nonce_for = NextNonceDb::allocate_nonce(txn, genesis);
-    ItemNonceDb::set(txn, genesis, BATCH_CODE, &batch, &nonce_for);
+    ItemNonceDb::set(txn, genesis, SUBSTRATE_CODE, &id.encode(), &nonce_for);
     nonce_for
   }
 
@@ -53,12 +59,16 @@ impl NonceDecider {
   // TODO: The processor won't yield shares for this if the signing protocol aborts. We need to
   // detect when we're expecting shares for an aborted protocol and insert a dummy transaction
   // there.
-  pub fn selected_for_signing_batch(txn: &mut impl DbTxn, genesis: [u8; 32], batch: [u8; 5]) {
+  pub fn selected_for_signing_substrate(
+    txn: &mut impl DbTxn,
+    genesis: [u8; 32],
+    id: SubstrateSignableId,
+  ) {
     let nonce_for = NextNonceDb::allocate_nonce(txn, genesis);
-    ItemNonceDb::set(txn, genesis, BATCH_SIGNING_CODE, &batch, &nonce_for);
+    ItemNonceDb::set(txn, genesis, SUBSTRATE_SIGNING_CODE, &id.encode(), &nonce_for);
   }
 
-  // TODO: Same TODO as selected_for_signing_batch
+  // TODO: Same TODO as selected_for_signing_substrate
   pub fn selected_for_signing_plan(txn: &mut impl DbTxn, genesis: [u8; 32], plan: [u8; 32]) {
     let nonce_for = NextNonceDb::allocate_nonce(txn, genesis);
     ItemNonceDb::set(txn, genesis, PLAN_SIGNING_CODE, &plan, &nonce_for);
@@ -91,21 +101,21 @@ impl NonceDecider {
 
       Transaction::Batch(_, _) => None,
       Transaction::SubstrateBlock(_) => None,
-      Transaction::BatchPreprocess(data) => {
+      Transaction::SubstratePreprocess(data) => {
         assert_eq!(data.attempt, 0);
-        Some(ItemNonceDb::get(getter, genesis, BATCH_CODE, &data.plan))
+        Some(ItemNonceDb::get(getter, genesis, SUBSTRATE_CODE, &data.plan.encode()))
       }
-      Transaction::BatchShare(data) => {
+      Transaction::SubstrateShare(data) => {
         assert_eq!(data.attempt, 0);
-        Some(ItemNonceDb::get(getter, genesis, BATCH_SIGNING_CODE, &data.plan))
+        Some(ItemNonceDb::get(getter, genesis, SUBSTRATE_SIGNING_CODE, &data.plan.encode()))
       }
       Transaction::SignPreprocess(data) => {
         assert_eq!(data.attempt, 0);
-        Some(ItemNonceDb::get(getter, genesis, PLAN_CODE, &data.plan))
+        Some(ItemNonceDb::get(getter, genesis, PLAN_CODE, &data.plan.encode()))
       }
       Transaction::SignShare(data) => {
         assert_eq!(data.attempt, 0);
-        Some(ItemNonceDb::get(getter, genesis, PLAN_SIGNING_CODE, &data.plan))
+        Some(ItemNonceDb::get(getter, genesis, PLAN_SIGNING_CODE, &data.plan.encode()))
       }
       Transaction::SignCompleted { .. } => None,
     }

--- a/processor/messages/src/lib.rs
+++ b/processor/messages/src/lib.rs
@@ -156,10 +156,18 @@ pub mod sign {
 pub mod coordinator {
   use super::*;
 
+  #[derive(
+    Clone, Copy, PartialEq, Eq, Hash, Debug, Zeroize, Encode, Decode, Serialize, Deserialize,
+  )]
+  pub enum SubstrateSignableId {
+    Batch([u8; 5]),
+    Block([u8; 32]),
+  }
+
   #[derive(Clone, PartialEq, Eq, Hash, Debug, Zeroize, Encode, Decode, Serialize, Deserialize)]
   pub struct SubstrateSignId {
     pub key: [u8; 32],
-    pub id: [u8; 5],
+    pub id: SubstrateSignableId,
     pub attempt: u32,
   }
 

--- a/processor/messages/src/lib.rs
+++ b/processor/messages/src/lib.rs
@@ -157,7 +157,7 @@ pub mod coordinator {
   use super::*;
 
   #[derive(Clone, PartialEq, Eq, Hash, Debug, Zeroize, Encode, Decode, Serialize, Deserialize)]
-  pub struct BatchSignId {
+  pub struct SubstrateSignId {
     pub key: [u8; 32],
     pub id: [u8; 5],
     pub attempt: u32,
@@ -166,10 +166,10 @@ pub mod coordinator {
   #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
   pub enum CoordinatorMessage {
     // Uses Vec<u8> instead of [u8; 64] since serde Deserialize isn't implemented for [u8; 64]
-    BatchPreprocesses { id: BatchSignId, preprocesses: HashMap<Participant, Vec<u8>> },
-    BatchShares { id: BatchSignId, shares: HashMap<Participant, [u8; 32]> },
+    BatchPreprocesses { id: SubstrateSignId, preprocesses: HashMap<Participant, Vec<u8>> },
+    BatchShares { id: SubstrateSignId, shares: HashMap<Participant, [u8; 32]> },
     // Re-attempt a batch signing protocol.
-    BatchReattempt { id: BatchSignId },
+    BatchReattempt { id: SubstrateSignId },
   }
 
   impl CoordinatorMessage {
@@ -203,9 +203,9 @@ pub mod coordinator {
   #[derive(Clone, PartialEq, Eq, Debug, Zeroize, Serialize, Deserialize)]
   pub enum ProcessorMessage {
     SubstrateBlockAck { network: NetworkId, block: u64, plans: Vec<PlanMeta> },
-    InvalidParticipant { id: BatchSignId, participant: Participant },
-    BatchPreprocess { id: BatchSignId, block: BlockHash, preprocesses: Vec<Vec<u8>> },
-    BatchShare { id: BatchSignId, shares: Vec<[u8; 32]> },
+    InvalidParticipant { id: SubstrateSignId, participant: Participant },
+    BatchPreprocess { id: SubstrateSignId, block: BlockHash, preprocesses: Vec<Vec<u8>> },
+    BatchShare { id: SubstrateSignId, shares: Vec<[u8; 32]> },
   }
 }
 
@@ -420,7 +420,7 @@ impl ProcessorMessage {
           coordinator::ProcessorMessage::SubstrateBlockAck { network, block, .. } => {
             (0, (network, block).encode())
           }
-          // Unique since BatchSignId
+          // Unique since SubstrateSignId
           coordinator::ProcessorMessage::InvalidParticipant { id, .. } => (1, id.encode()),
           coordinator::ProcessorMessage::BatchPreprocess { id, .. } => (2, id.encode()),
           coordinator::ProcessorMessage::BatchShare { id, .. } => (3, id.encode()),

--- a/processor/src/cosigner.rs
+++ b/processor/src/cosigner.rs
@@ -1,0 +1,286 @@
+use core::fmt;
+use std::collections::HashMap;
+
+use rand_core::OsRng;
+
+use ciphersuite::group::GroupEncoding;
+use frost::{
+  curve::Ristretto,
+  ThresholdKeys, FrostError,
+  algorithm::Algorithm,
+  sign::{
+    Writable, PreprocessMachine, SignMachine, SignatureMachine, AlgorithmMachine,
+    AlgorithmSignMachine, AlgorithmSignatureMachine,
+  },
+};
+use frost_schnorrkel::Schnorrkel;
+
+use log::{info, warn};
+
+use scale::Encode;
+
+use messages::coordinator::*;
+use crate::{Get, DbTxn, create_db};
+
+create_db! {
+  CosignerDb {
+    Completed: (id: [u8; 32]) -> (),
+    Attempt: (id: [u8; 32], attempt: u32) -> ()
+  }
+}
+
+type Preprocess = <AlgorithmMachine<Ristretto, Schnorrkel> as PreprocessMachine>::Preprocess;
+type SignatureShare = <AlgorithmSignMachine<Ristretto, Schnorrkel> as SignMachine<
+  <Schnorrkel as Algorithm<Ristretto>>::Signature,
+>>::SignatureShare;
+
+pub struct Cosigner {
+  #[allow(dead_code)] // False positive
+  keys: Vec<ThresholdKeys<Ristretto>>,
+
+  id: [u8; 32],
+  attempt: u32,
+  #[allow(clippy::type_complexity)]
+  preprocessing: Option<(Vec<AlgorithmSignMachine<Ristretto, Schnorrkel>>, Vec<Preprocess>)>,
+  #[allow(clippy::type_complexity)]
+  signing: Option<(AlgorithmSignatureMachine<Ristretto, Schnorrkel>, Vec<SignatureShare>)>,
+}
+
+impl fmt::Debug for Cosigner {
+  fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fmt
+      .debug_struct("Cosigner")
+      .field("id", &self.id)
+      .field("attempt", &self.attempt)
+      .field("preprocessing", &self.preprocessing.is_some())
+      .field("signing", &self.signing.is_some())
+      .finish_non_exhaustive()
+  }
+}
+
+impl Cosigner {
+  pub fn new(
+    txn: &mut impl DbTxn,
+    keys: Vec<ThresholdKeys<Ristretto>>,
+    id: [u8; 32],
+    attempt: u32,
+  ) -> Option<(Cosigner, ProcessorMessage)> {
+    assert!(!keys.is_empty());
+
+    if Completed::get(txn, id).is_some() {
+      return None;
+    }
+
+    if Attempt::get(txn, id, attempt).is_some() {
+      warn!(
+        "already attempted cosigning {}, attempt #{}. this is an error if we didn't reboot",
+        hex::encode(id),
+        attempt,
+      );
+      return None;
+    }
+    Attempt::set(txn, id, attempt, &());
+
+    info!("cosigning block {} with attempt #{}", hex::encode(id), attempt);
+
+    let mut machines = vec![];
+    let mut preprocesses = vec![];
+    let mut serialized_preprocesses = vec![];
+    for keys in &keys {
+      // b"substrate" is a literal from sp-core
+      let machine = AlgorithmMachine::new(Schnorrkel::new(b"substrate"), keys.clone());
+
+      let (machine, preprocess) = machine.preprocess(&mut OsRng);
+      machines.push(machine);
+      serialized_preprocesses.push(preprocess.serialize());
+      preprocesses.push(preprocess);
+    }
+    let preprocessing = Some((machines, preprocesses));
+
+    let substrate_sign_id = SubstrateSignId {
+      key: keys[0].group_key().to_bytes(),
+      id: SubstrateSignableId::CosigningSubstrateBlock(id),
+      attempt,
+    };
+
+    Some((
+      Cosigner { keys, id, attempt, preprocessing, signing: None },
+      ProcessorMessage::CosignPreprocess {
+        id: substrate_sign_id,
+        preprocesses: serialized_preprocesses,
+      },
+    ))
+  }
+
+  #[must_use]
+  pub async fn handle(
+    &mut self,
+    txn: &mut impl DbTxn,
+    msg: CoordinatorMessage,
+  ) -> Option<ProcessorMessage> {
+    match msg {
+      CoordinatorMessage::CosignSubstrateBlock { .. } => {
+        panic!("Cosigner passed CosignSubstrateBlock")
+      }
+
+      CoordinatorMessage::SubstratePreprocesses { id, preprocesses } => {
+        assert_eq!(id.key, self.keys[0].group_key().to_bytes());
+        let SubstrateSignableId::CosigningSubstrateBlock(block) = id.id else {
+          panic!("cosigner passed Batch")
+        };
+        if block != self.id {
+          panic!("given preprocesses for a distinct block than cosigner is signing")
+        }
+        if id.attempt != self.attempt {
+          panic!("given preprocesses for a distinct attempt than cosigner is signing")
+        }
+
+        let (machines, our_preprocesses) = match self.preprocessing.take() {
+          // Either rebooted or RPC error, or some invariant
+          None => {
+            warn!(
+              "not preprocessing for {}. this is an error if we didn't reboot",
+              hex::encode(block),
+            );
+            return None;
+          }
+          Some(preprocess) => preprocess,
+        };
+
+        let mut parsed = HashMap::new();
+        for l in {
+          let mut keys = preprocesses.keys().cloned().collect::<Vec<_>>();
+          keys.sort();
+          keys
+        } {
+          let mut preprocess_ref = preprocesses.get(&l).unwrap().as_slice();
+          let Ok(res) = machines[0].read_preprocess(&mut preprocess_ref) else {
+            return Some(ProcessorMessage::InvalidParticipant { id, participant: l });
+          };
+          if !preprocess_ref.is_empty() {
+            return Some(ProcessorMessage::InvalidParticipant { id, participant: l });
+          }
+          parsed.insert(l, res);
+        }
+        let preprocesses = parsed;
+
+        // Only keep a single machine as we only need one to get the signature
+        let mut signature_machine = None;
+        let mut shares = vec![];
+        let mut serialized_shares = vec![];
+        for (m, machine) in machines.into_iter().enumerate() {
+          let mut preprocesses = preprocesses.clone();
+          for (i, our_preprocess) in our_preprocesses.clone().into_iter().enumerate() {
+            if i != m {
+              assert!(preprocesses.insert(self.keys[i].params().i(), our_preprocess).is_none());
+            }
+          }
+
+          let (machine, share) = match machine.sign(preprocesses, &cosign_block_msg(self.id)) {
+            Ok(res) => res,
+            Err(e) => match e {
+              FrostError::InternalError(_) |
+              FrostError::InvalidParticipant(_, _) |
+              FrostError::InvalidSigningSet(_) |
+              FrostError::InvalidParticipantQuantity(_, _) |
+              FrostError::DuplicatedParticipant(_) |
+              FrostError::MissingParticipant(_) => unreachable!(),
+
+              FrostError::InvalidPreprocess(l) | FrostError::InvalidShare(l) => {
+                return Some(ProcessorMessage::InvalidParticipant { id, participant: l })
+              }
+            },
+          };
+          if m == 0 {
+            signature_machine = Some(machine);
+          }
+
+          let mut share_bytes = [0; 32];
+          share_bytes.copy_from_slice(&share.serialize());
+          serialized_shares.push(share_bytes);
+
+          shares.push(share);
+        }
+        self.signing = Some((signature_machine.unwrap(), shares));
+
+        // Broadcast our shares
+        Some(ProcessorMessage::SubstrateShare { id, shares: serialized_shares })
+      }
+
+      CoordinatorMessage::SubstrateShares { id, shares } => {
+        assert_eq!(id.key, self.keys[0].group_key().to_bytes());
+        let SubstrateSignableId::CosigningSubstrateBlock(block) = id.id else {
+          panic!("cosigner passed Batch")
+        };
+        if block != self.id {
+          panic!("given preprocesses for a distinct block than cosigner is signing")
+        }
+        if id.attempt != self.attempt {
+          panic!("given preprocesses for a distinct attempt than cosigner is signing")
+        }
+
+        let (machine, our_shares) = match self.signing.take() {
+          // Rebooted, RPC error, or some invariant
+          None => {
+            // If preprocessing has this ID, it means we were never sent the preprocess by the
+            // coordinator
+            if self.preprocessing.is_some() {
+              panic!("never preprocessed yet signing?");
+            }
+
+            warn!(
+              "not preprocessing for {}. this is an error if we didn't reboot",
+              hex::encode(block)
+            );
+            return None;
+          }
+          Some(signing) => signing,
+        };
+
+        let mut parsed = HashMap::new();
+        for l in {
+          let mut keys = shares.keys().cloned().collect::<Vec<_>>();
+          keys.sort();
+          keys
+        } {
+          let mut share_ref = shares.get(&l).unwrap().as_slice();
+          let Ok(res) = machine.read_share(&mut share_ref) else {
+            return Some(ProcessorMessage::InvalidParticipant { id, participant: l });
+          };
+          if !share_ref.is_empty() {
+            return Some(ProcessorMessage::InvalidParticipant { id, participant: l });
+          }
+          parsed.insert(l, res);
+        }
+        let mut shares = parsed;
+
+        for (i, our_share) in our_shares.into_iter().enumerate().skip(1) {
+          assert!(shares.insert(self.keys[i].params().i(), our_share).is_none());
+        }
+
+        let sig = match machine.complete(shares) {
+          Ok(res) => res,
+          Err(e) => match e {
+            FrostError::InternalError(_) |
+            FrostError::InvalidParticipant(_, _) |
+            FrostError::InvalidSigningSet(_) |
+            FrostError::InvalidParticipantQuantity(_, _) |
+            FrostError::DuplicatedParticipant(_) |
+            FrostError::MissingParticipant(_) => unreachable!(),
+
+            FrostError::InvalidPreprocess(l) | FrostError::InvalidShare(l) => {
+              return Some(ProcessorMessage::InvalidParticipant { id, participant: l })
+            }
+          },
+        };
+
+        info!("cosigned {} with attempt #{}", hex::encode(block), id.attempt);
+
+        Completed::set(txn, block, &());
+
+        Some(ProcessorMessage::CosignedBlock { block, signature: sig.to_bytes().to_vec() })
+      }
+      CoordinatorMessage::BatchReattempt { .. } => panic!("BatchReattempt passed to Cosigner"),
+    }
+  }
+}

--- a/processor/src/main.rs
+++ b/processor/src/main.rs
@@ -611,6 +611,7 @@ async fn run<N: Network, D: Db, Co: Coordinator>(mut raw_db: D, network: N, mut 
             for batch in batches {
               info!("created batch {} ({} instructions)", batch.id, batch.instructions.len());
 
+              // The coordinator expects BatchPreprocess to immediately follow Batch
               coordinator.send(
                 messages::substrate::ProcessorMessage::Batch { batch: batch.clone() }
               ).await;

--- a/processor/src/main.rs
+++ b/processor/src/main.rs
@@ -13,7 +13,12 @@ use serai_client::{
   validator_sets::primitives::{ValidatorSet, KeyPair},
 };
 
-use messages::{coordinator::PlanMeta, CoordinatorMessage};
+use messages::{
+  coordinator::{
+    SubstrateSignableId, PlanMeta, CoordinatorMessage as CoordinatorCoordinatorMessage,
+  },
+  CoordinatorMessage,
+};
 
 use serai_env as env;
 
@@ -43,6 +48,9 @@ use key_gen::{KeyConfirmed, KeyGen};
 
 mod signer;
 use signer::Signer;
+
+mod cosigner;
+use cosigner::Cosigner;
 
 mod substrate_signer;
 use substrate_signer::SubstrateSigner;
@@ -86,6 +94,9 @@ struct TributaryMutable<N: Network, D: Db> {
 
   // There should only be one SubstrateSigner at a time (see #277)
   substrate_signer: Option<SubstrateSigner<D>>,
+
+  // Solely mutated by the tributary.
+  cosigner: Option<Cosigner>,
 }
 
 // Items which are mutably borrowed by Substrate.
@@ -218,16 +229,58 @@ async fn handle_coordinator_msg<D: Db, N: Network, Co: Coordinator>(
     }
 
     CoordinatorMessage::Coordinator(msg) => {
-      if let Some(msg) = tributary_mutable
-        .substrate_signer
-        .as_mut()
-        .expect(
-          "coordinator told us to sign a batch when we don't have a Substrate signer at this time",
-        )
-        .handle(txn, msg)
-        .await
-      {
-        coordinator.send(msg).await;
+      let is_batch = match msg {
+        CoordinatorCoordinatorMessage::CosignSubstrateBlock { .. } => false,
+        CoordinatorCoordinatorMessage::SubstratePreprocesses { ref id, .. } => {
+          matches!(&id.id, SubstrateSignableId::Batch(_))
+        }
+        CoordinatorCoordinatorMessage::SubstrateShares { ref id, .. } => {
+          matches!(&id.id, SubstrateSignableId::Batch(_))
+        }
+        CoordinatorCoordinatorMessage::BatchReattempt { .. } => true,
+      };
+      if is_batch {
+        if let Some(msg) = tributary_mutable
+          .substrate_signer
+          .as_mut()
+          .expect(
+            "coordinator told us to sign a batch when we don't currently have a Substrate signer",
+          )
+          .handle(txn, msg)
+          .await
+        {
+          coordinator.send(msg).await;
+        }
+      } else {
+        match msg {
+          CoordinatorCoordinatorMessage::CosignSubstrateBlock { id } => {
+            let SubstrateSignableId::CosigningSubstrateBlock(block) = id.id else {
+              panic!("CosignSubstrateBlock id didn't have a CosigningSubstrateBlock")
+            };
+            let Some(keys) = tributary_mutable.key_gen.substrate_keys_by_substrate_key(&id.key)
+            else {
+              panic!("didn't have key shares for the key we were told to cosign with");
+            };
+            if let Some((cosigner, msg)) = Cosigner::new(txn, keys, block, id.attempt) {
+              tributary_mutable.cosigner = Some(cosigner);
+              coordinator.send(msg).await;
+            } else {
+              log::warn!("Cosigner::new returned None");
+            }
+          }
+          _ => {
+            if let Some(cosigner) = tributary_mutable.cosigner.as_mut() {
+              if let Some(msg) = cosigner.handle(txn, msg).await {
+                coordinator.send(msg).await;
+              }
+            } else {
+              log::warn!(
+                "received message for cosigner yet didn't have a cosigner. {}",
+                "this is an error if we didn't reboot",
+              );
+            }
+          }
+        }
       }
     }
 
@@ -240,6 +293,7 @@ async fn handle_coordinator_msg<D: Db, N: Network, Co: Coordinator>(
           if context.network_latest_finalized_block.0 == [0; 32] {
             assert!(tributary_mutable.signers.is_empty());
             assert!(tributary_mutable.substrate_signer.is_none());
+            assert!(tributary_mutable.cosigner.is_none());
             // We can't check this as existing is no longer pub
             // assert!(substrate_mutable.existing.as_ref().is_none());
 
@@ -337,7 +391,7 @@ async fn handle_coordinator_msg<D: Db, N: Network, Co: Coordinator>(
             }
           }
 
-          // Since this block was acknowledged, we no longer have to sign the batches for it
+          // Since this block was acknowledged, we no longer have to sign the batches within it
           if let Some(substrate_signer) = tributary_mutable.substrate_signer.as_mut() {
             for batch_id in batches {
               substrate_signer.batch_signed(txn, batch_id);
@@ -480,7 +534,11 @@ async fn boot<N: Network, D: Db, Co: Coordinator>(
   // This hedges against being dropped due to full mempools, temporarily too low of a fee...
   tokio::spawn(Signer::<N, D>::rebroadcast_task(raw_db.clone(), network.clone()));
 
-  (main_db, TributaryMutable { key_gen, substrate_signer, signers }, multisig_manager)
+  (
+    main_db,
+    TributaryMutable { key_gen, substrate_signer, cosigner: None, signers },
+    multisig_manager,
+  )
 }
 
 #[allow(clippy::await_holding_lock)] // Needed for txn, unfortunately can't be down-scoped

--- a/processor/src/substrate_signer.rs
+++ b/processor/src/substrate_signer.rs
@@ -259,7 +259,7 @@ impl<D: Db> SubstrateSigner<D> {
         panic!("SubstrateSigner passed CosignSubstrateBlock")
       }
 
-      CoordinatorMessage::BatchPreprocesses { id, preprocesses } => {
+      CoordinatorMessage::SubstratePreprocesses { id, preprocesses } => {
         let (key, id, attempt) = self.verify_id(&id).ok()?;
 
         let substrate_sign_id =
@@ -346,12 +346,12 @@ impl<D: Db> SubstrateSigner<D> {
 
         // Broadcast our shares
         Some(
-          (ProcessorMessage::BatchShare { id: substrate_sign_id, shares: serialized_shares })
+          (ProcessorMessage::SubstrateShare { id: substrate_sign_id, shares: serialized_shares })
             .into(),
         )
       }
 
-      CoordinatorMessage::BatchShares { id, shares } => {
+      CoordinatorMessage::SubstrateShares { id, shares } => {
         let (key, id, attempt) = self.verify_id(&id).ok()?;
 
         let substrate_sign_id =

--- a/processor/src/substrate_signer.rs
+++ b/processor/src/substrate_signer.rs
@@ -68,6 +68,7 @@ type SignatureShare = <AlgorithmSignMachine<Ristretto, Schnorrkel> as SignMachin
   <Schnorrkel as Algorithm<Ristretto>>::Signature,
 >>::SignatureShare;
 
+// TODO: Rename BatchSigner
 pub struct SubstrateSigner<D: Db> {
   db: PhantomData<D>,
 

--- a/processor/src/substrate_signer.rs
+++ b/processor/src/substrate_signer.rs
@@ -48,13 +48,13 @@ impl<D: Db> SubstrateSignerDb<D> {
     getter.get(Self::completed_key(id)).is_some()
   }
 
-  fn attempt_key(id: &BatchSignId) -> Vec<u8> {
+  fn attempt_key(id: &SubstrateSignId) -> Vec<u8> {
     Self::sign_key(b"attempt", id.encode())
   }
-  fn attempt(txn: &mut D::Transaction<'_>, id: &BatchSignId) {
+  fn attempt(txn: &mut D::Transaction<'_>, id: &SubstrateSignId) {
     txn.put(Self::attempt_key(id), []);
   }
-  fn has_attempt<G: Get>(getter: &G, id: &BatchSignId) -> bool {
+  fn has_attempt<G: Get>(getter: &G, id: &SubstrateSignId) -> bool {
     getter.get(Self::attempt_key(id)).is_some()
   }
 
@@ -110,7 +110,7 @@ impl<D: Db> SubstrateSigner<D> {
     }
   }
 
-  fn verify_id(&self, id: &BatchSignId) -> Result<(), ()> {
+  fn verify_id(&self, id: &SubstrateSignId) -> Result<(), ()> {
     // Check the attempt lines up
     match self.attempt.get(&id.id) {
       // If we don't have an attempt logged, it's because the coordinator is faulty OR because we
@@ -176,7 +176,7 @@ impl<D: Db> SubstrateSigner<D> {
     // Update the attempt number
     self.attempt.insert(id, attempt);
 
-    let id = BatchSignId { key: self.keys[0].group_key().to_bytes(), id, attempt };
+    let id = SubstrateSignId { key: self.keys[0].group_key().to_bytes(), id, attempt };
     info!("signing batch {} #{}", hex::encode(id.id), id.attempt);
 
     // If we reboot mid-sign, the current design has us abort all signs and wait for latter

--- a/processor/src/tests/mod.rs
+++ b/processor/src/tests/mod.rs
@@ -7,6 +7,7 @@ pub(crate) use scanner::{test_scanner, test_no_deadlock_in_multisig_completed};
 mod signer;
 pub(crate) use signer::{sign, test_signer};
 
+mod cosigner;
 mod substrate_signer;
 
 mod wallet;

--- a/processor/src/tests/substrate_signer.rs
+++ b/processor/src/tests/substrate_signer.rs
@@ -18,7 +18,7 @@ use serai_client::{primitives::*, in_instructions::primitives::*};
 
 use messages::{
   substrate,
-  coordinator::{self, BatchSignId, CoordinatorMessage},
+  coordinator::{self, SubstrateSignId, CoordinatorMessage},
   ProcessorMessage,
 };
 use crate::substrate_signer::SubstrateSigner;
@@ -48,7 +48,7 @@ async fn test_substrate_signer() {
     ],
   };
 
-  let actual_id = BatchSignId {
+  let actual_id = SubstrateSignId {
     key: keys.values().next().unwrap().group_key().to_bytes(),
     id: (batch.network, batch.id).encode().try_into().unwrap(),
     attempt: 0,

--- a/processor/src/tests/substrate_signer.rs
+++ b/processor/src/tests/substrate_signer.rs
@@ -18,7 +18,7 @@ use serai_client::{primitives::*, in_instructions::primitives::*};
 
 use messages::{
   substrate,
-  coordinator::{self, SubstrateSignId, CoordinatorMessage},
+  coordinator::{self, SubstrateSignableId, SubstrateSignId, CoordinatorMessage},
   ProcessorMessage,
 };
 use crate::substrate_signer::SubstrateSigner;
@@ -50,7 +50,7 @@ async fn test_substrate_signer() {
 
   let actual_id = SubstrateSignId {
     key: keys.values().next().unwrap().group_key().to_bytes(),
-    id: (batch.network, batch.id).encode().try_into().unwrap(),
+    id: SubstrateSignableId::Batch((batch.network, batch.id).encode().try_into().unwrap()),
     attempt: 0,
   };
 

--- a/substrate/client/src/serai/validator_sets.rs
+++ b/substrate/client/src/serai/validator_sets.rs
@@ -55,6 +55,13 @@ impl<'a> SeraiValidatorSets<'a> {
     self.0.storage(PALLET, "AllocationPerKeyShare", Some(vec![scale_value(network)])).await
   }
 
+  pub async fn total_allocated_stake(
+    &self,
+    network: NetworkId,
+  ) -> Result<Option<Amount>, SeraiError> {
+    self.0.storage(PALLET, "TotalAllocatedStake", Some(vec![scale_value(network)])).await
+  }
+
   pub async fn allocation(
     &self,
     network: NetworkId,

--- a/tests/coordinator/src/lib.rs
+++ b/tests/coordinator/src/lib.rs
@@ -223,9 +223,11 @@ impl Processor {
 
   /// Receive a message from the coordinator as a processor.
   pub async fn recv_message(&mut self) -> CoordinatorMessage {
-    let msg = tokio::time::timeout(Duration::from_secs(10), self.queue.next(Service::Coordinator))
-      .await
-      .unwrap();
+    // Set a timeout of an entire 6 minutes as cosigning may be delayed by up to 5 minutes
+    let msg =
+      tokio::time::timeout(Duration::from_secs(6 * 60), self.queue.next(Service::Coordinator))
+        .await
+        .unwrap();
     assert_eq!(msg.from, Service::Coordinator);
     assert_eq!(msg.id, self.next_recv_id);
     self.queue.ack(Service::Coordinator, msg.id).await;

--- a/tests/coordinator/src/tests/batch.rs
+++ b/tests/coordinator/src/tests/batch.rs
@@ -23,7 +23,7 @@ use serai_client::{
     InInstructionsEvent,
   },
 };
-use messages::{coordinator::BatchSignId, SubstrateContext, CoordinatorMessage};
+use messages::{coordinator::SubstrateSignId, SubstrateContext, CoordinatorMessage};
 
 use crate::{*, tests::*};
 
@@ -35,7 +35,7 @@ pub async fn batch(
 ) -> u64 {
   let mut id = [0; 5];
   OsRng.fill_bytes(&mut id);
-  let id = BatchSignId {
+  let id = SubstrateSignId {
     key: (<Ristretto as Ciphersuite>::generator() * **substrate_key).to_bytes(),
     id,
     attempt: 0,

--- a/tests/coordinator/src/tests/batch.rs
+++ b/tests/coordinator/src/tests/batch.rs
@@ -86,7 +86,10 @@ pub async fn batch(
   let first_preprocesses = processors[known_signer].recv_message().await;
   let participants = match first_preprocesses {
     CoordinatorMessage::Coordinator(
-      messages::coordinator::CoordinatorMessage::BatchPreprocesses { id: this_id, preprocesses },
+      messages::coordinator::CoordinatorMessage::SubstratePreprocesses {
+        id: this_id,
+        preprocesses,
+      },
     ) => {
       assert_eq!(&id, &this_id);
       assert_eq!(preprocesses.len(), THRESHOLD - 1);
@@ -120,7 +123,7 @@ pub async fn batch(
     assert_eq!(
       processor.recv_message().await,
       CoordinatorMessage::Coordinator(
-        messages::coordinator::CoordinatorMessage::BatchPreprocesses {
+        messages::coordinator::CoordinatorMessage::SubstratePreprocesses {
           id: id.clone(),
           preprocesses
         }
@@ -132,7 +135,7 @@ pub async fn batch(
     let processor =
       &mut processors[processor_is.iter().position(|p_i| u16::from(*p_i) == u16::from(i)).unwrap()];
     processor
-      .send_message(messages::coordinator::ProcessorMessage::BatchShare {
+      .send_message(messages::coordinator::ProcessorMessage::SubstrateShare {
         id: id.clone(),
         shares: vec![[u8::try_from(u16::from(i)).unwrap(); 32]],
       })
@@ -151,7 +154,7 @@ pub async fn batch(
 
     assert_eq!(
       processor.recv_message().await,
-      CoordinatorMessage::Coordinator(messages::coordinator::CoordinatorMessage::BatchShares {
+      CoordinatorMessage::Coordinator(messages::coordinator::CoordinatorMessage::SubstrateShares {
         id: id.clone(),
         shares,
       })

--- a/tests/coordinator/src/tests/batch.rs
+++ b/tests/coordinator/src/tests/batch.rs
@@ -23,7 +23,10 @@ use serai_client::{
     InInstructionsEvent,
   },
 };
-use messages::{coordinator::SubstrateSignId, SubstrateContext, CoordinatorMessage};
+use messages::{
+  coordinator::{SubstrateSignableId, SubstrateSignId},
+  SubstrateContext, CoordinatorMessage,
+};
 
 use crate::{*, tests::*};
 
@@ -37,7 +40,7 @@ pub async fn batch(
   OsRng.fill_bytes(&mut id);
   let id = SubstrateSignId {
     key: (<Ristretto as Ciphersuite>::generator() * **substrate_key).to_bytes(),
-    id,
+    id: SubstrateSignableId::Batch(id),
     attempt: 0,
   };
 

--- a/tests/coordinator/src/tests/cosign.rs
+++ b/tests/coordinator/src/tests/cosign.rs
@@ -1,0 +1,172 @@
+use std::collections::{HashSet, HashMap};
+
+use zeroize::Zeroizing;
+use rand_core::{RngCore, OsRng};
+
+use ciphersuite::{group::GroupEncoding, Ciphersuite, Ristretto};
+use dkg::Participant;
+
+use serai_client::primitives::Signature;
+use messages::{
+  coordinator::{SubstrateSignableId, cosign_block_msg},
+  CoordinatorMessage,
+};
+
+use crate::{*, tests::*};
+
+pub async fn potentially_cosign(
+  processors: &mut [Processor],
+  primary_processor: usize,
+  processor_is: &[u8],
+  substrate_key: &Zeroizing<<Ristretto as Ciphersuite>::F>,
+) -> CoordinatorMessage {
+  let msg = processors[primary_processor].recv_message().await;
+  let messages::CoordinatorMessage::Coordinator(
+    messages::coordinator::CoordinatorMessage::CosignSubstrateBlock { id },
+  ) = msg.clone()
+  else {
+    return msg;
+  };
+  let SubstrateSignableId::CosigningSubstrateBlock(block) = id.id else {
+    panic!("CosignSubstrateBlock didn't have CosigningSubstrateBlock id")
+  };
+
+  for (i, processor) in processors.iter_mut().enumerate() {
+    if i == primary_processor {
+      continue;
+    }
+    assert_eq!(msg, processor.recv_message().await);
+  }
+
+  // Select a random participant to exclude, so we know for sure who *is* participating
+  assert_eq!(COORDINATORS - THRESHOLD, 1);
+  let excluded_signer =
+    usize::try_from(OsRng.next_u64() % u64::try_from(processors.len()).unwrap()).unwrap();
+  for (i, processor) in processors.iter_mut().enumerate() {
+    if i == excluded_signer {
+      continue;
+    }
+
+    processor
+      .send_message(messages::coordinator::ProcessorMessage::CosignPreprocess {
+        id: id.clone(),
+        preprocesses: vec![[processor_is[i]; 64].to_vec()],
+      })
+      .await;
+  }
+
+  // Send from the excluded signer so they don't stay stuck
+  processors[excluded_signer]
+    .send_message(messages::coordinator::ProcessorMessage::CosignPreprocess {
+      id: id.clone(),
+      preprocesses: vec![[processor_is[excluded_signer]; 64].to_vec()],
+    })
+    .await;
+
+  // Read from a known signer to find out who was selected to sign
+  let known_signer = (excluded_signer + 1) % COORDINATORS;
+  let first_preprocesses = processors[known_signer].recv_message().await;
+  let participants = match first_preprocesses {
+    CoordinatorMessage::Coordinator(
+      messages::coordinator::CoordinatorMessage::SubstratePreprocesses {
+        id: this_id,
+        preprocesses,
+      },
+    ) => {
+      assert_eq!(&id, &this_id);
+      assert_eq!(preprocesses.len(), THRESHOLD - 1);
+      let known_signer_i = Participant::new(u16::from(processor_is[known_signer])).unwrap();
+      assert!(!preprocesses.contains_key(&known_signer_i));
+
+      let mut participants = preprocesses.keys().cloned().collect::<HashSet<_>>();
+      for (p, preprocess) in preprocesses {
+        assert_eq!(preprocess, vec![u8::try_from(u16::from(p)).unwrap(); 64]);
+      }
+      participants.insert(known_signer_i);
+      participants
+    }
+    _ => panic!("coordinator didn't send back SubstratePreprocesses"),
+  };
+
+  for i in participants.clone() {
+    if u16::from(i) == u16::from(processor_is[known_signer]) {
+      continue;
+    }
+
+    let processor =
+      &mut processors[processor_is.iter().position(|p_i| u16::from(*p_i) == u16::from(i)).unwrap()];
+    let mut preprocesses = participants
+      .clone()
+      .into_iter()
+      .map(|i| (i, [u8::try_from(u16::from(i)).unwrap(); 64].to_vec()))
+      .collect::<HashMap<_, _>>();
+    preprocesses.remove(&i);
+
+    assert_eq!(
+      processor.recv_message().await,
+      CoordinatorMessage::Coordinator(
+        messages::coordinator::CoordinatorMessage::SubstratePreprocesses {
+          id: id.clone(),
+          preprocesses
+        }
+      )
+    );
+  }
+
+  for i in participants.clone() {
+    let processor =
+      &mut processors[processor_is.iter().position(|p_i| u16::from(*p_i) == u16::from(i)).unwrap()];
+    processor
+      .send_message(messages::coordinator::ProcessorMessage::SubstrateShare {
+        id: id.clone(),
+        shares: vec![[u8::try_from(u16::from(i)).unwrap(); 32]],
+      })
+      .await;
+  }
+  for i in participants.clone() {
+    let processor =
+      &mut processors[processor_is.iter().position(|p_i| u16::from(*p_i) == u16::from(i)).unwrap()];
+    let mut shares = participants
+      .clone()
+      .into_iter()
+      .map(|i| (i, [u8::try_from(u16::from(i)).unwrap(); 32]))
+      .collect::<HashMap<_, _>>();
+    shares.remove(&i);
+
+    assert_eq!(
+      processor.recv_message().await,
+      CoordinatorMessage::Coordinator(messages::coordinator::CoordinatorMessage::SubstrateShares {
+        id: id.clone(),
+        shares,
+      })
+    );
+  }
+
+  // Expand to a key pair as Schnorrkel expects
+  // It's the private key + 32-bytes of entropy for nonces + the public key
+  let mut schnorrkel_key_pair = [0; 96];
+  schnorrkel_key_pair[.. 32].copy_from_slice(&substrate_key.to_repr());
+  OsRng.fill_bytes(&mut schnorrkel_key_pair[32 .. 64]);
+  schnorrkel_key_pair[64 ..]
+    .copy_from_slice(&(<Ristretto as Ciphersuite>::generator() * **substrate_key).to_bytes());
+  let signature = Signature(
+    schnorrkel::keys::Keypair::from_bytes(&schnorrkel_key_pair)
+      .unwrap()
+      .sign_simple(b"substrate", &cosign_block_msg(block))
+      .to_bytes(),
+  );
+
+  for (i, processor) in processors.iter_mut().enumerate() {
+    if i == excluded_signer {
+      continue;
+    }
+    processor
+      .send_message(messages::coordinator::ProcessorMessage::CosignedBlock {
+        block,
+        signature: signature.0.to_vec(),
+      })
+      .await;
+  }
+
+  processors[primary_processor].recv_message().await
+}

--- a/tests/coordinator/src/tests/mod.rs
+++ b/tests/coordinator/src/tests/mod.rs
@@ -9,6 +9,9 @@ use crate::*;
 mod key_gen;
 pub use key_gen::key_gen;
 
+mod cosign;
+pub use cosign::potentially_cosign;
+
 mod batch;
 pub use batch::batch;
 

--- a/tests/coordinator/src/tests/sign.rs
+++ b/tests/coordinator/src/tests/sign.rs
@@ -328,9 +328,9 @@ async fn sign_test() {
       let plan_id = plan_id;
 
       // We should now get a SubstrateBlock
-      for processor in processors.iter_mut() {
+      for i in 0 .. processors.len() {
         assert_eq!(
-          processor.recv_message().await,
+          potentially_cosign(&mut processors, i, &participant_is, &substrate_key).await,
           messages::CoordinatorMessage::Substrate(
             messages::substrate::CoordinatorMessage::SubstrateBlock {
               context: SubstrateContext {
@@ -346,7 +346,7 @@ async fn sign_test() {
         );
 
         // Send the ACK, claiming there's a plan to sign
-        processor
+        processors[i]
           .send_message(messages::ProcessorMessage::Coordinator(
             messages::coordinator::ProcessorMessage::SubstrateBlockAck {
               network: NetworkId::Bitcoin,

--- a/tests/full-stack/src/tests/mint_and_burn.rs
+++ b/tests/full-stack/src/tests/mint_and_burn.rs
@@ -555,7 +555,7 @@ async fn mint_and_burn_test() {
         // Check for up to 5 minutes
         let mut found = false;
         let mut i = 0;
-        while i < (5 * 6) {
+        while i < (15 * 6) {
           if let Ok(hash) = rpc.get_block_hash(start_bitcoin_block).await {
             let block = rpc.get_block(&hash).await.unwrap();
             start_bitcoin_block += 1;

--- a/tests/processor/src/tests/batch.rs
+++ b/tests/processor/src/tests/batch.rs
@@ -96,7 +96,7 @@ pub(crate) async fn sign_batch(
 
     if preprocesses.contains_key(&i) {
       coordinator
-        .send_message(messages::coordinator::CoordinatorMessage::BatchPreprocesses {
+        .send_message(messages::coordinator::CoordinatorMessage::SubstratePreprocesses {
           id: id.clone(),
           preprocesses: clone_without(&preprocesses, &i),
         })
@@ -111,7 +111,7 @@ pub(crate) async fn sign_batch(
     if preprocesses.contains_key(&i) {
       match coordinator.recv_message().await {
         messages::ProcessorMessage::Coordinator(
-          messages::coordinator::ProcessorMessage::BatchShare {
+          messages::coordinator::ProcessorMessage::SubstrateShare {
             id: this_id,
             shares: mut these_shares,
           },
@@ -130,7 +130,7 @@ pub(crate) async fn sign_batch(
 
     if preprocesses.contains_key(&i) {
       coordinator
-        .send_message(messages::coordinator::CoordinatorMessage::BatchShares {
+        .send_message(messages::coordinator::CoordinatorMessage::SubstrateShares {
           id: id.clone(),
           shares: clone_without(&shares, &i),
         })

--- a/tests/processor/src/tests/batch.rs
+++ b/tests/processor/src/tests/batch.rs
@@ -29,7 +29,7 @@ pub(crate) async fn recv_batch_preprocesses(
 ) -> (SubstrateSignId, HashMap<Participant, Vec<u8>>) {
   let id = SubstrateSignId {
     key: *substrate_key,
-    id: (batch.network, batch.id).encode().try_into().unwrap(),
+    id: SubstrateSignableId::Batch((batch.network, batch.id).encode().try_into().unwrap()),
     attempt,
   };
 

--- a/tests/processor/src/tests/batch.rs
+++ b/tests/processor/src/tests/batch.rs
@@ -26,8 +26,8 @@ pub(crate) async fn recv_batch_preprocesses(
   substrate_key: &[u8; 32],
   batch: &Batch,
   attempt: u32,
-) -> (BatchSignId, HashMap<Participant, Vec<u8>>) {
-  let id = BatchSignId {
+) -> (SubstrateSignId, HashMap<Participant, Vec<u8>>) {
+  let id = SubstrateSignId {
     key: *substrate_key,
     id: (batch.network, batch.id).encode().try_into().unwrap(),
     attempt,
@@ -86,7 +86,7 @@ pub(crate) async fn recv_batch_preprocesses(
 pub(crate) async fn sign_batch(
   coordinators: &mut [Coordinator],
   key: [u8; 32],
-  id: BatchSignId,
+  id: SubstrateSignId,
   preprocesses: HashMap<Participant, Vec<u8>>,
 ) -> SignedBatch {
   assert_eq!(preprocesses.len(), THRESHOLD);


### PR DESCRIPTION
Resolves https://github.com/serai-dex/serai/issues/339.

Now, if the Serai validators equivocate, they also need to perfectly split the validator sets for external networks and additionally have 34% of them equivocate.

Implemented as a completely off-chain protocol with evaluations linear to the amount of sets (and cosigning linear to the size of the set signing).