### PR TITLE
Migrate tributary/mempool to create_db macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9671,6 +9671,7 @@ name = "tributary-chain"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bincode",
  "blake2",
  "ciphersuite",
  "flexible-transcript",
@@ -9682,6 +9683,7 @@ dependencies = [
  "rand_chacha",
  "schnorr-signatures",
  "serai-db",
+ "serde",
  "subtle",
  "tendermint-machine",
  "thiserror",

--- a/coordinator/tributary/Cargo.toml
+++ b/coordinator/tributary/Cargo.toml
@@ -29,6 +29,8 @@ log = { version = "0.4", default-features = false, features = ["std"] }
 serai-db = { path = "../../common/db" }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["std", "derive"] }
+serde = { version = "1", default-features = false, features = ["derive"] }
+bincode = { version = "1", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["std"] }
 tendermint = { package = "tendermint-machine", path = "./tendermint" }
 


### PR DESCRIPTION
This is a continuation of pr #408. Migration of `coordinator/tributary/mempool` into a couple of internally used databases.