### PR TITLE
Replace rustls with boring-ssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "antidote"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
+
+[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,7 +338,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
 dependencies = [
- "http",
+ "http 0.2.11",
  "log",
  "url",
 ]
@@ -447,6 +453,26 @@ dependencies = [
  "lazycell",
  "peeking_take_while",
  "prettyplease 0.2.15",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.68.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+dependencies = [
+ "bitflags 2.4.1",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
  "proc-macro2",
  "quote",
  "regex",
@@ -632,8 +658,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.27",
  "hyperlocal",
  "log",
  "pin-project-lite 0.2.13",
@@ -658,6 +684,29 @@ dependencies = [
  "serde",
  "serde_repr",
  "serde_with",
+]
+
+[[package]]
+name = "boring"
+version = "5.0.0"
+source = "git+https://github.com/cloudflare/boring?rev=423c260d87b69a926594ded0dd693b5cf1220452#423c260d87b69a926594ded0dd693b5cf1220452"
+dependencies = [
+ "bitflags 2.4.1",
+ "boring-sys",
+ "foreign-types",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
+name = "boring-sys"
+version = "5.0.0"
+source = "git+https://github.com/cloudflare/boring?rev=423c260d87b69a926594ded0dd693b5cf1220452#423c260d87b69a926594ded0dd693b5cf1220452"
+dependencies = [
+ "bindgen 0.68.1",
+ "cmake",
+ "fs_extra",
+ "fslock",
 ]
 
 [[package]]
@@ -976,6 +1025,15 @@ name = "clap_lex"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -2003,7 +2061,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "hashers",
- "http",
+ "http 0.2.11",
  "instant",
  "jsonwebtoken",
  "once_cell",
@@ -2216,6 +2274,33 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "fork-tree"
@@ -2435,6 +2520,22 @@ name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
 dependencies = [
  "libc",
  "winapi",
@@ -2733,7 +2834,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
  "indexmap 2.1.0",
  "slab",
  "tokio",
@@ -2885,13 +2986,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
+ "pin-project-lite 0.2.13",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.0.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
  "pin-project-lite 0.2.13",
 ]
 
@@ -2930,8 +3065,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa",
@@ -2944,19 +3079,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f9214f3e703236b221f1a9cd88ec8b4adfa5296de01ab96216361f4692f56"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite 0.2.13",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-boring"
+version = "5.0.0"
+source = "git+https://github.com/cloudflare/boring?rev=423c260d87b69a926594ded0dd693b5cf1220452#423c260d87b69a926594ded0dd693b5cf1220452"
+dependencies = [
+ "antidote",
+ "boring",
+ "http 1.0.0",
+ "hyper 1.0.1",
+ "hyper-util",
+ "linked_hash_set",
+ "once_cell",
+ "tokio",
+ "tokio-boring",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.27",
  "log",
  "rustls",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca339002caeb0d159cc6e023dff48e199f081e42fa039895c7c6f38b37f2e9d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "hyper 1.0.1",
+ "pin-project-lite 0.2.13",
+ "socket2 0.5.5",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2967,7 +3158,7 @@ checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
 dependencies = [
  "futures-util",
  "hex",
- "hyper",
+ "hyper 0.14.27",
  "pin-project",
  "tokio",
 ]
@@ -3055,8 +3246,8 @@ dependencies = [
  "attohttpc",
  "bytes",
  "futures",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.27",
  "log",
  "rand",
  "tokio",
@@ -3252,7 +3443,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "globset",
- "hyper",
+ "hyper 0.14.27",
  "jsonrpsee-types",
  "parking_lot 0.12.1",
  "rand",
@@ -3286,8 +3477,8 @@ checksum = "cf4d945a6008c9b03db3354fb3c83ee02d2faa9f2e755ec1dfb69c3551b8f4ba"
 dependencies = [
  "futures-channel",
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.27",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "serde",
@@ -3899,7 +4090,7 @@ version = "0.11.0+8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
 dependencies = [
- "bindgen",
+ "bindgen 0.65.1",
  "bzip2-sys",
  "cc",
  "glob",
@@ -4718,7 +4909,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.39",
@@ -5841,9 +6032,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.11",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
  "ipnet",
  "js-sys",
  "log",
@@ -6719,7 +6910,7 @@ dependencies = [
  "fnv",
  "futures",
  "futures-timer",
- "hyper",
+ "hyper 0.14.27",
  "hyper-rustls",
  "libp2p",
  "log",
@@ -6805,7 +6996,7 @@ name = "sc-rpc-server"
 version = "4.0.0-dev"
 source = "git+https://github.com/serai-dex/substrate#49b7d20ef96b6ad42ea0266ea27f128e0ef3214d"
 dependencies = [
- "http",
+ "http 0.2.11",
  "jsonrpsee",
  "log",
  "serde_json",
@@ -7928,9 +8119,12 @@ name = "simple-request"
 version = "0.1.0"
 dependencies = [
  "base64ct",
- "hyper",
- "hyper-rustls",
+ "http-body-util",
+ "hyper 1.0.1",
+ "hyper-boring",
+ "hyper-util",
  "tokio",
+ "tower-service",
  "zeroize",
 ]
 
@@ -8025,7 +8219,7 @@ dependencies = [
  "base64 0.13.1",
  "bytes",
  "futures",
- "http",
+ "http 0.2.11",
  "httparse",
  "log",
  "rand",
@@ -8827,7 +9021,7 @@ name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
 source = "git+https://github.com/serai-dex/substrate#49b7d20ef96b6ad42ea0266ea27f128e0ef3214d"
 dependencies = [
- "hyper",
+ "hyper 0.14.27",
  "log",
  "prometheus",
  "thiserror",
@@ -9119,6 +9313,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-boring"
+version = "5.0.0"
+source = "git+https://github.com/cloudflare/boring?rev=423c260d87b69a926594ded0dd693b5cf1220452#423c260d87b69a926594ded0dd693b5cf1220452"
+dependencies = [
+ "boring",
+ "boring-sys",
+ "once_cell",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9226,6 +9431,11 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite 0.2.13",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9241,8 +9451,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.5",
  "http-range-header",
  "pin-project-lite 0.2.13",
  "tower-layer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,5 @@ lazy_static = { git = "https://github.com/rust-lang-nursery/lazy-static.rs", rev
 # subxt *can* pull these off crates.io yet there's no benefit to this
 sp-core-hashing = { git = "https://github.com/serai-dex/substrate" }
 sp-std = { git = "https://github.com/serai-dex/substrate" }
+
+hyper-boring = { git = "https://github.com/cloudflare/boring", rev = "423c260d87b69a926594ded0dd693b5cf1220452" }

--- a/coins/monero/src/rpc/mod.rs
+++ b/coins/monero/src/rpc/mod.rs
@@ -135,11 +135,7 @@ impl<R: RpcConnection> Rpc<R> {
       .0
       .post(
         route,
-        if let Some(params) = params {
-          serde_json::to_string(&params).unwrap().into_bytes()
-        } else {
-          vec![]
-        },
+        if let Some(params) = params { serde_json::to_vec(&params).unwrap() } else { vec![] },
       )
       .await?;
     let res_str = std_shims::str::from_utf8(&res)

--- a/common/request/Cargo.toml
+++ b/common/request/Cargo.toml
@@ -27,6 +27,6 @@ zeroize = { version = "1", optional = true }
 base64ct = { version = "1", features = ["alloc"], optional = true }
 
 [features]
-tls = ["hyper-boring"]
+tls = ["tower-service", "hyper-boring"]
 basic-auth = ["zeroize", "base64ct"]
 default = ["tls"]

--- a/common/request/Cargo.toml
+++ b/common/request/Cargo.toml
@@ -15,18 +15,18 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 hyper = { version = "1", default-features = false, features = ["http1", "client"] }
-hyper-util = { version = "0.1", default-features = false, features = ["http1", "client", "tokio"] }
+hyper-util = { version = "0.1", default-features = false, features = ["http1", "client-legacy", "tokio"] }
 http-body-util = { version = "0.1", default-features = false }
 
 tokio = { version = "1", default-features = false }
 
-tower-service = { version = "0.3", default-features = false, optional = true }
+tower-service = { version = "0.3", default-features = false }
 hyper-boring = { version = "5", default-features = false, optional = true }
 
 zeroize = { version = "1", optional = true }
 base64ct = { version = "1", features = ["alloc"], optional = true }
 
 [features]
-tls = ["tower-service", "hyper-boring"]
+tls = ["hyper-boring"]
 basic-auth = ["zeroize", "base64ct"]
 default = ["tls"]

--- a/common/request/Cargo.toml
+++ b/common/request/Cargo.toml
@@ -14,16 +14,19 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-# Deprecated here means to enable deprecated warnings, not to restore deprecated APIs
-hyper = { version = "0.14", default-features = false, features = ["http1", "tcp", "client", "runtime", "backports", "deprecated"] }
+hyper = { version = "1", default-features = false, features = ["http1", "client"] }
+hyper-util = { version = "0.1", default-features = false, features = ["http1", "client", "tokio"] }
+http-body-util = { version = "0.1", default-features = false }
+
 tokio = { version = "1", default-features = false }
 
-hyper-rustls = { version = "0.24", default-features = false, features = ["http1", "native-tokio"], optional = true }
+tower-service = { version = "0.3", default-features = false, optional = true }
+hyper-boring = { version = "5", default-features = false, optional = true }
 
 zeroize = { version = "1", optional = true }
 base64ct = { version = "1", features = ["alloc"], optional = true }
 
 [features]
-tls = ["hyper-rustls"]
+tls = ["hyper-boring"]
 basic-auth = ["zeroize", "base64ct"]
 default = ["tls"]

--- a/common/request/src/lib.rs
+++ b/common/request/src/lib.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
-#[cfg(feature = "tls")]
 use tower_service::Service as TowerService;
 #[cfg(feature = "tls")]
 use hyper_boring::HttpsConnector;

--- a/common/request/src/request.rs
+++ b/common/request/src/request.rs
@@ -1,5 +1,6 @@
+use hyper::body::Bytes;
 #[cfg(feature = "basic-auth")]
-use hyper::{body::Bytes, header::HeaderValue};
+use hyper::header::HeaderValue;
 pub use http_body_util::Full;
 
 #[cfg(feature = "basic-auth")]

--- a/common/request/src/request.rs
+++ b/common/request/src/request.rs
@@ -1,12 +1,12 @@
-use hyper::body::Body;
 #[cfg(feature = "basic-auth")]
-use hyper::header::HeaderValue;
+use hyper::{body::Bytes, header::HeaderValue};
+pub use http_body_util::Full;
 
 #[cfg(feature = "basic-auth")]
 use crate::Error;
 
 #[derive(Debug)]
-pub struct Request(pub(crate) hyper::Request<Body>);
+pub struct Request(pub(crate) hyper::Request<Full<Bytes>>);
 impl Request {
   #[cfg(feature = "basic-auth")]
   fn username_password_from_uri(&self) -> Result<(String, String), Error> {
@@ -59,8 +59,8 @@ impl Request {
     let _ = self.basic_auth_from_uri();
   }
 }
-impl From<hyper::Request<Body>> for Request {
-  fn from(request: hyper::Request<Body>) -> Request {
+impl From<hyper::Request<Full<Bytes>>> for Request {
+  fn from(request: hyper::Request<Full<Bytes>>) -> Request {
     Request(request)
   }
 }

--- a/orchestration/Dockerfile.parts/Dockerfile.serai.build
+++ b/orchestration/Dockerfile.parts/Dockerfile.serai.build
@@ -6,7 +6,7 @@ RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload
 RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
 
 # Add dev dependencies
-RUN apt install -y pkg-config clang
+RUN apt install -y pkg-config clang cmake git
 
 # Dependencies for the Serai node
 RUN apt install -y make protobuf-compiler

--- a/orchestration/coordinator/Dockerfile
+++ b/orchestration/coordinator/Dockerfile
@@ -16,7 +16,7 @@ RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload
 RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
 
 # Add dev dependencies
-RUN apt install -y pkg-config clang
+RUN apt install -y pkg-config clang cmake git
 
 # Dependencies for the Serai node
 RUN apt install -y make protobuf-compiler

--- a/orchestration/message-queue/Dockerfile
+++ b/orchestration/message-queue/Dockerfile
@@ -16,7 +16,7 @@ RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload
 RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
 
 # Add dev dependencies
-RUN apt install -y pkg-config clang
+RUN apt install -y pkg-config clang cmake git
 
 # Dependencies for the Serai node
 RUN apt install -y make protobuf-compiler

--- a/orchestration/processor/bitcoin/Dockerfile
+++ b/orchestration/processor/bitcoin/Dockerfile
@@ -16,7 +16,7 @@ RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload
 RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
 
 # Add dev dependencies
-RUN apt install -y pkg-config clang
+RUN apt install -y pkg-config clang cmake git
 
 # Dependencies for the Serai node
 RUN apt install -y make protobuf-compiler

--- a/orchestration/processor/monero/Dockerfile
+++ b/orchestration/processor/monero/Dockerfile
@@ -16,7 +16,7 @@ RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload
 RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
 
 # Add dev dependencies
-RUN apt install -y pkg-config clang
+RUN apt install -y pkg-config clang cmake git
 
 # Dependencies for the Serai node
 RUN apt install -y make protobuf-compiler

--- a/orchestration/serai/Dockerfile
+++ b/orchestration/serai/Dockerfile
@@ -16,7 +16,7 @@ RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload
 RUN apt update && apt upgrade -y && apt autoremove -y && apt clean
 
 # Add dev dependencies
-RUN apt install -y pkg-config clang
+RUN apt install -y pkg-config clang cmake git
 
 # Dependencies for the Serai node
 RUN apt install -y make protobuf-compiler

--- a/substrate/client/src/serai/mod.rs
+++ b/substrate/client/src/serai/mod.rs
@@ -150,7 +150,7 @@ impl Serai {
   }
 
   pub async fn new(url: String) -> Result<Self, SeraiError> {
-    let client = Client::with_connection_pool();
+    let client = Client::with_connection_pool().map_err(|_| SeraiError::ConnectionError)?;
     let mut res = Serai { url, client, genesis: [0xfe; 32] };
     res.genesis = res.block_hash(0).await?.ok_or_else(|| {
       SeraiError::InvalidNode("node didn't have the first block's hash".to_string())


### PR DESCRIPTION
This removes all re-attempts present in monero-serai's RPC and is an attempt to narrow down the sporadic failures.

Inspired by https://github.com/hyperium/hyper/issues/3427