### PR TITLE
Have the CI check the lockfile isn't stale

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,14 @@ jobs:
       - name: Run Clippy
         run: cargo +${{ steps.nightly.outputs.version }} clippy --all-features --all-targets -- -D warnings -A clippy::items_after_test_module
 
+      # Also verify the lockfile isn't dirty
+      # This happens when someone edits a Cargo.toml yet doesn't do anything
+      # which causes the lockfile to be updated
+      # The above clippy run will cause it to be updated, so checking there's
+      # no differences present now performs the desired check
+      - name: Verify lockfile
+        run: git diff | wc -l | grep -x "0"
+
   deny:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Prevents a commit review from passing, yet then the next commit 'adding' 100 new dependencies.