### PR TITLE
Use TX IDs for Bitcoin Eventualities

### DIFF
--- a/coins/bitcoin/src/rpc.rs
+++ b/coins/bitcoin/src/rpc.rs
@@ -149,11 +149,11 @@ impl Rpc {
 
   /// Get the hash of a block by the block's number.
   pub async fn get_block_hash(&self, number: usize) -> Result<[u8; 32], RpcError> {
-    let mut hash = *self
+    let mut hash = self
       .rpc_call::<BlockHash>("getblockhash", json!([number]))
       .await?
       .as_raw_hash()
-      .as_byte_array();
+      .to_byte_array();
     // bitcoin stores the inner bytes in reverse order.
     hash.reverse();
     Ok(hash)

--- a/coins/bitcoin/src/wallet/send.rs
+++ b/coins/bitcoin/src/wallet/send.rs
@@ -13,6 +13,7 @@ use k256::{elliptic_curve::sec1::ToEncodedPoint, Scalar};
 use frost::{curve::Secp256k1, Participant, ThresholdKeys, FrostError, sign::*};
 
 use bitcoin::{
+  hashes::Hash,
   sighash::{TapSighashType, SighashCache, Prevouts},
   absolute::LockTime,
   script::{PushBytesBuf, ScriptBuf},
@@ -243,6 +244,13 @@ impl SignableTransaction {
       prevouts: inputs.drain(..).map(|input| input.output).collect(),
       needed_fee,
     })
+  }
+
+  /// Returns the TX ID of the transaction this will create.
+  pub fn txid(&self) -> [u8; 32] {
+    let mut res = self.tx.txid().to_byte_array();
+    res.reverse();
+    res
   }
 
   /// Returns the outputs this transaction will create.

--- a/coins/bitcoin/tests/wallet.rs
+++ b/coins/bitcoin/tests/wallet.rs
@@ -279,6 +279,7 @@ async_sequential! {
       FEE
     ).unwrap();
     let needed_fee = tx.needed_fee();
+    let expected_id = tx.txid();
     let tx = sign(&keys, tx);
 
     assert_eq!(tx.output.len(), 3);
@@ -322,6 +323,7 @@ async_sequential! {
     let mut hash = *tx.txid().as_raw_hash().as_byte_array();
     hash.reverse();
     assert_eq!(tx, rpc.get_transaction(&hash).await.unwrap());
+    assert_eq!(expected_id, hash);
   }
 
   async fn test_data() {

--- a/tests/full-stack/src/tests/mint_and_burn.rs
+++ b/tests/full-stack/src/tests/mint_and_burn.rs
@@ -35,7 +35,7 @@ async fn mint_and_burn_test() {
 
       // Helper to mine a block on each network
       async fn mine_blocks(
-        handles: &Vec<Handles>,
+        handles: &[Handles],
         ops: &DockerOperations,
         producer: &mut usize,
         count: usize,


### PR DESCRIPTION
They're a bit more binding, smaller, provided by the Rust bitcoin library, sane, and we don't have to worry about malleability since all of our inputs are SegWit.