### PR TITLE
monero-serai: make it clear that not providing a change address is fingerprintable

### DIFF
--- a/coins/monero/src/wallet/send/builder.rs
+++ b/coins/monero/src/wallet/send/builder.rs
@@ -18,14 +18,14 @@ struct SignableTransactionBuilderInternal {
   r_seed: Option<Zeroizing<[u8; 32]>>,
   inputs: Vec<(SpendableOutput, Decoys)>,
   payments: Vec<(MoneroAddress, u64)>,
-  change_address: Option<Change>,
+  change_address: Change,
   data: Vec<Vec<u8>>,
 }
 
 impl SignableTransactionBuilderInternal {
   // Takes in the change address so users don't miss that they have to manually set one
   // If they don't, all leftover funds will become part of the fee
-  fn new(protocol: Protocol, fee_rate: Fee, change_address: Option<Change>) -> Self {
+  fn new(protocol: Protocol, fee_rate: Fee, change_address: Change) -> Self {
     Self {
       protocol,
       fee_rate,
@@ -90,7 +90,7 @@ impl SignableTransactionBuilder {
     Self(self.0.clone())
   }
 
-  pub fn new(protocol: Protocol, fee_rate: Fee, change_address: Option<Change>) -> Self {
+  pub fn new(protocol: Protocol, fee_rate: Fee, change_address: Change) -> Self {
     Self(Arc::new(RwLock::new(SignableTransactionBuilderInternal::new(
       protocol,
       fee_rate,

--- a/coins/monero/src/wallet/send/multisig.rs
+++ b/coins/monero/src/wallet/send/multisig.rs
@@ -125,9 +125,8 @@ impl SignableTransaction {
           transcript.append_message(b"payment_amount", payment.1.to_le_bytes());
         }
         InternalPayment::Change(change, amount) => {
-          transcript
-            .append_message(b"change_address", change.address.unwrap().to_string().as_bytes());
-          if let Some(view) = change.view.as_ref() {
+          transcript.append_message(b"change_address", change.0.to_string().as_bytes());
+          if let Some(view) = change.1.as_ref() {
             transcript.append_message(b"change_view_key", Zeroizing::new(view.to_bytes()));
           }
           transcript.append_message(b"change_amount", amount.to_le_bytes());

--- a/coins/monero/src/wallet/send/multisig.rs
+++ b/coins/monero/src/wallet/send/multisig.rs
@@ -125,7 +125,8 @@ impl SignableTransaction {
           transcript.append_message(b"payment_amount", payment.1.to_le_bytes());
         }
         InternalPayment::Change(change, amount) => {
-          transcript.append_message(b"change_address", change.address.to_string().as_bytes());
+          transcript
+            .append_message(b"change_address", change.address.unwrap().to_string().as_bytes());
           if let Some(view) = change.view.as_ref() {
             transcript.append_message(b"change_view_key", Zeroizing::new(view.to_bytes()));
           }

--- a/coins/monero/tests/runner.rs
+++ b/coins/monero/tests/runner.rs
@@ -213,13 +213,13 @@ macro_rules! test {
           let builder = SignableTransactionBuilder::new(
             protocol,
             rpc.get_fee(protocol, FeePriority::Low).await.unwrap(),
-            Some(Change::new(
+            Change::new(
               &ViewPair::new(
                 &random_scalar(&mut OsRng) * ED25519_BASEPOINT_TABLE,
                 Zeroizing::new(random_scalar(&mut OsRng))
               ),
               false
-            )),
+            ),
           );
 
           let sign = |tx: SignableTransaction| {
@@ -298,7 +298,10 @@ macro_rules! test {
             rpc.publish_transaction(&signed).await.unwrap();
             mine_until_unlocked(&rpc, &random_address().2.to_string(), signed.hash()).await;
             let tx = rpc.get_transaction(signed.hash()).await.unwrap();
-            check_weight_and_fee(&tx, fee_rate);
+            if stringify!($name) != "spend_one_input_to_two_outputs_no_change" {
+              // Skip weight and fee check for the above test
+              check_weight_and_fee(&tx, fee_rate);
+            }
             #[allow(unused_assignments)]
             {
               let scanner =

--- a/coins/monero/tests/runner.rs
+++ b/coins/monero/tests/runner.rs
@@ -299,7 +299,8 @@ macro_rules! test {
             mine_until_unlocked(&rpc, &random_address().2.to_string(), signed.hash()).await;
             let tx = rpc.get_transaction(signed.hash()).await.unwrap();
             if stringify!($name) != "spend_one_input_to_two_outputs_no_change" {
-              // Skip weight and fee check for the above test
+              // Skip weight and fee check for the above test because when there is no change,
+              // the change is added to the fee
               check_weight_and_fee(&tx, fee_rate);
             }
             #[allow(unused_assignments)]

--- a/processor/src/networks/monero.rs
+++ b/processor/src/networks/monero.rs
@@ -376,6 +376,12 @@ impl Monero {
       })
       .collect::<Vec<_>>();
 
+    let change = Change::fingerprintable(if change.is_some() {
+      Some(change.clone().unwrap().into())
+    } else {
+      None
+    });
+
     match MSignableTransaction::new(
       protocol,
       // Use the plan ID as the r_seed
@@ -384,7 +390,7 @@ impl Monero {
       Some(Zeroizing::new(*plan_id)),
       inputs.clone(),
       payments,
-      change.clone().map(|change| Change::fingerprintable(change.into())),
+      change,
       vec![],
       fee_rate,
     ) {
@@ -753,7 +759,7 @@ impl Network for Monero {
       None,
       inputs,
       vec![(address.into(), amount - fee)],
-      Some(Change::fingerprintable(Self::test_address().into())),
+      Change::fingerprintable(Some(Self::test_address().into())),
       vec![],
       self.rpc.get_fee(protocol, FeePriority::Low).await.unwrap(),
     )

--- a/processor/src/networks/monero.rs
+++ b/processor/src/networks/monero.rs
@@ -376,12 +376,6 @@ impl Monero {
       })
       .collect::<Vec<_>>();
 
-    let change = Change::fingerprintable(if change.is_some() {
-      Some(change.clone().unwrap().into())
-    } else {
-      None
-    });
-
     match MSignableTransaction::new(
       protocol,
       // Use the plan ID as the r_seed
@@ -390,7 +384,7 @@ impl Monero {
       Some(Zeroizing::new(*plan_id)),
       inputs.clone(),
       payments,
-      change,
+      Change::fingerprintable(change.as_ref().map(|change| change.clone().into())),
       vec![],
       fee_rate,
     ) {

--- a/tests/full-stack/src/tests/mint_and_burn.rs
+++ b/tests/full-stack/src/tests/mint_and_burn.rs
@@ -395,7 +395,7 @@ async fn mint_and_burn_test() {
             ),
             1_100_000_000_000,
           )],
-          Some(Change::new(&view_pair, false)),
+          Change::new(&view_pair, false),
           vec![Shorthand::transfer(None, serai_addr).encode()],
           rpc.get_fee(Protocol::v16, FeePriority::Low).await.unwrap(),
         )

--- a/tests/processor/src/networks.rs
+++ b/tests/processor/src/networks.rs
@@ -361,7 +361,7 @@ impl Wallet {
           None,
           these_inputs.drain(..).zip(decoys.drain(..)).collect(),
           vec![(to_addr, AMOUNT)],
-          Some(Change::new(view_pair, false)),
+          Change::new(view_pair, false),
           data,
           rpc.get_fee(Protocol::v16, FeePriority::Low).await.unwrap(),
         )


### PR DESCRIPTION
When a signable transaction is constructed without a change address specified, all change is added to the tx fee (this helps Serai avoid accumulating dust outputs that spam the chain). This PR makes it clearer to the caller that it is fingerprintable when the caller does not provide a change address, since the caller must explicitly initialize the change param with `Change::fingerprintable(None)` (as is done in the added test). A tx created this way is fingerprintable because the fee is distinguishable from a fee created with wallet2.