### PR TITLE
Remove offline participants from future DKG protocols so long as the threshold is met

### DIFF
--- a/coordinator/src/substrate/mod.rs
+++ b/coordinator/src/substrate/mod.rs
@@ -276,6 +276,9 @@ async fn handle_block<D: Db, Pro: Processors>(
           },
         )
         .await;
+
+      // TODO: If we were in the set, yet were removed, drop the tributary
+
       let mut txn = db.txn();
       SeraiDkgCompleted::set(&mut txn, set, &substrate_key);
       HandledEvent::handle_event(&mut txn, hash, event_id);

--- a/coordinator/src/tests/tributary/mod.rs
+++ b/coordinator/src/tests/tributary/mod.rs
@@ -2,6 +2,8 @@ use core::fmt::Debug;
 
 use rand_core::{RngCore, OsRng};
 
+use ciphersuite::{group::Group, Ciphersuite, Ristretto};
+
 use scale::{Encode, Decode};
 use serai_client::{
   primitives::{SeraiAddress, Signature},
@@ -141,11 +143,8 @@ fn serialize_sign_data() {
 #[test]
 fn serialize_transaction() {
   test_read_write(&Transaction::RemoveParticipantDueToDkg {
-    attempt: u32::try_from(OsRng.next_u64() >> 32).unwrap(),
-    participant: frost::Participant::new(
-      u16::try_from(OsRng.next_u64() >> 48).unwrap().saturating_add(1),
-    )
-    .unwrap(),
+    participant: <Ristretto as Ciphersuite>::G::random(&mut OsRng),
+    signed: random_signed_with_nonce(&mut OsRng, 0),
   });
 
   {

--- a/coordinator/src/tributary/mod.rs
+++ b/coordinator/src/tributary/mod.rs
@@ -32,18 +32,10 @@ pub fn removed_as_of_dkg_attempt(
   if attempt == 0 {
     Some(vec![])
   } else {
-    FatalSlashesAsOfDkgAttempt::get(getter, genesis, attempt).map(|keys| {
+    RemovedAsOfDkgAttempt::get(getter, genesis, attempt).map(|keys| {
       keys.iter().map(|key| <Ristretto as Ciphersuite>::G::from_bytes(key).unwrap()).collect()
     })
   }
-}
-
-pub fn latest_removed(getter: &impl Get, genesis: [u8; 32]) -> Vec<<Ristretto as Ciphersuite>::G> {
-  FatalSlashes::get(getter, genesis)
-    .unwrap_or(vec![])
-    .iter()
-    .map(|key| <Ristretto as Ciphersuite>::G::from_bytes(key).unwrap())
-    .collect()
 }
 
 pub fn removed_as_of_set_keys(

--- a/coordinator/src/tributary/signing_protocol.rs
+++ b/coordinator/src/tributary/signing_protocol.rs
@@ -215,14 +215,16 @@ fn threshold_i_map_to_keys_and_musig_i_map(
   mut map: HashMap<Participant, Vec<u8>>,
 ) -> (Vec<<Ristretto as Ciphersuite>::G>, HashMap<Participant, Vec<u8>>) {
   // Insert our own index so calculations aren't offset
-  let our_threshold_i =
-    spec.i(removed, <Ristretto as Ciphersuite>::generator() * our_key.deref()).unwrap().start;
+  let our_threshold_i = spec
+    .i(removed, <Ristretto as Ciphersuite>::generator() * our_key.deref())
+    .expect("MuSig t-of-n signing a for a protocol we were removed from")
+    .start;
   assert!(map.insert(our_threshold_i, vec![]).is_none());
 
   let spec_validators = spec.validators();
   let key_from_threshold_i = |threshold_i| {
     for (key, _) in &spec_validators {
-      if threshold_i == spec.i(removed, *key).unwrap().start {
+      if threshold_i == spec.i(removed, *key).expect("MuSig t-of-n participant was removed").start {
         return *key;
       }
     }

--- a/coordinator/src/tributary/spec.rs
+++ b/coordinator/src/tributary/spec.rs
@@ -137,6 +137,19 @@ impl TributarySpec {
     Some(result_i)
   }
 
+  pub fn reverse_lookup_i(
+    &self,
+    removed_validators: &[<Ristretto as Ciphersuite>::G],
+    i: Participant,
+  ) -> Option<<Ristretto as Ciphersuite>::G> {
+    for (validator, _) in &self.validators {
+      if self.i(removed_validators, *validator).map_or(false, |range| range.contains(&i)) {
+        return Some(*validator);
+      }
+    }
+    None
+  }
+
   pub fn validators(&self) -> Vec<(<Ristretto as Ciphersuite>::G, u64)> {
     self.validators.iter().map(|(validator, weight)| (*validator, u64::from(*weight))).collect()
   }


### PR DESCRIPTION
Makes RemoveParticipantDueToDkg a voted-on event instead of a Provided. This removes the requirement for offline parties to be able to fully validate blame, yet unfortunately lets an dishonest supermajority have an honest node label any arbitrary node as dishonest.

Corrects a variety of `.i(...)` calls which panicked when they shouldn't have.

Cleans up a couple no-longer-used storage values.