### PR TITLE
monero: Use fee priority enums from monero repo CLI/RPC wallets

### DIFF
--- a/coins/monero/src/wallet/send/mod.rs
+++ b/coins/monero/src/wallet/send/mod.rs
@@ -270,7 +270,6 @@ impl Fee {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[allow(non_camel_case_types)]
 pub enum FeePriority {
-  Default,
   Unimportant,
   Normal,
   Elevated,
@@ -283,7 +282,6 @@ pub enum FeePriority {
 impl FeePriority {
   pub(crate) fn fee_priority(&self) -> u32 {
     match self {
-      FeePriority::Default => 0,
       FeePriority::Unimportant => 1,
       FeePriority::Normal => 2,
       FeePriority::Elevated => 3,

--- a/coins/monero/src/wallet/send/mod.rs
+++ b/coins/monero/src/wallet/send/mod.rs
@@ -270,20 +270,24 @@ impl Fee {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[allow(non_camel_case_types)]
 pub enum FeePriority {
-  Lowest,
-  Low,
-  Medium,
-  High,
+  Default,
+  Unimportant,
+  Normal,
+  Elevated,
+  Priority,
   Custom { priority: u32 },
 }
 
+/// https://github.com/monero-project/monero/blob/ac02af92867590ca80b2779a7bbeafa99ff94dcb/
+///   src/simplewallet/simplewallet.cpp#L161
 impl FeePriority {
   pub(crate) fn fee_priority(&self) -> u32 {
     match self {
-      FeePriority::Lowest => 0,
-      FeePriority::Low => 1,
-      FeePriority::Medium => 2,
-      FeePriority::High => 3,
+      FeePriority::Default => 0,
+      FeePriority::Unimportant => 1,
+      FeePriority::Normal => 2,
+      FeePriority::Elevated => 3,
+      FeePriority::Priority => 4,
       FeePriority::Custom { priority, .. } => *priority,
     }
   }

--- a/coins/monero/tests/runner.rs
+++ b/coins/monero/tests/runner.rs
@@ -212,7 +212,7 @@ macro_rules! test {
 
           let builder = SignableTransactionBuilder::new(
             protocol,
-            rpc.get_fee(protocol, FeePriority::Low).await.unwrap(),
+            rpc.get_fee(protocol, FeePriority::Unimportant).await.unwrap(),
             Change::new(
               &ViewPair::new(
                 &random_scalar(&mut OsRng) * ED25519_BASEPOINT_TABLE,

--- a/coins/monero/tests/send.rs
+++ b/coins/monero/tests/send.rs
@@ -110,7 +110,7 @@ test!(
 
       let mut builder = SignableTransactionBuilder::new(
         protocol,
-        rpc.get_fee(protocol, FeePriority::Low).await.unwrap(),
+        rpc.get_fee(protocol, FeePriority::Unimportant).await.unwrap(),
         Change::new(&change_view, false),
       );
       add_inputs(protocol, &rpc, vec![outputs.first().unwrap().clone()], &mut builder).await;
@@ -294,7 +294,7 @@ test!(
 
       let mut builder = SignableTransactionBuilder::new(
         protocol,
-        rpc.get_fee(protocol, FeePriority::Low).await.unwrap(),
+        rpc.get_fee(protocol, FeePriority::Unimportant).await.unwrap(),
         Change::fingerprintable(None),
       );
       add_inputs(protocol, &rpc, vec![outputs.first().unwrap().clone()], &mut builder).await;

--- a/coins/monero/tests/wallet2_compatibility.rs
+++ b/coins/monero/tests/wallet2_compatibility.rs
@@ -90,8 +90,6 @@ async fn from_wallet_rpc_to_self(spec: AddressSpec) {
 
   // TODO: Needs https://github.com/monero-project/monero/pull/8882
   // let fee_rate = daemon_rpc
-  //   // Uses `FeePriority::Unimportant` instead of `FeePriority::Default` because wallet RPC
-  //   // adjusts `monero_rpc::TransferPriority::Default` up by 1
   //   .get_fee(daemon_rpc.get_protocol().await.unwrap(), FeePriority::Unimportant)
   //   .await
   //   .unwrap();

--- a/coins/monero/tests/wallet2_compatibility.rs
+++ b/coins/monero/tests/wallet2_compatibility.rs
@@ -90,9 +90,9 @@ async fn from_wallet_rpc_to_self(spec: AddressSpec) {
 
   // TODO: Needs https://github.com/monero-project/monero/pull/8882
   // let fee_rate = daemon_rpc
-  //   // Uses `FeePriority::Low` instead of `FeePriority::Lowest` because wallet RPC
+  //   // Uses `FeePriority::Unimportant` instead of `FeePriority::Default` because wallet RPC
   //   // adjusts `monero_rpc::TransferPriority::Default` up by 1
-  //   .get_fee(daemon_rpc.get_protocol().await.unwrap(), FeePriority::Low)
+  //   .get_fee(daemon_rpc.get_protocol().await.unwrap(), FeePriority::Unimportant)
   //   .await
   //   .unwrap();
 

--- a/processor/src/networks/monero.rs
+++ b/processor/src/networks/monero.rs
@@ -756,7 +756,7 @@ impl Network for Monero {
       vec![(address.into(), amount - fee)],
       &Change::fingerprintable(Some(Self::test_address().into())),
       vec![],
-      self.rpc.get_fee(protocol, FeePriority::Low).await.unwrap(),
+      self.rpc.get_fee(protocol, FeePriority::Unimportant).await.unwrap(),
     )
     .unwrap()
     .sign(&mut OsRng, &Zeroizing::new(Scalar::ONE.0))

--- a/tests/full-stack/src/tests/mint_and_burn.rs
+++ b/tests/full-stack/src/tests/mint_and_burn.rs
@@ -392,7 +392,7 @@ async fn mint_and_burn_test() {
         )],
         &Change::new(&view_pair, false),
         vec![Shorthand::transfer(None, serai_addr).encode()],
-        rpc.get_fee(Protocol::v16, FeePriority::Low).await.unwrap(),
+        rpc.get_fee(Protocol::v16, FeePriority::Unimportant).await.unwrap(),
       )
       .unwrap()
       .sign(&mut OsRng, &Zeroizing::new(Scalar::ONE))

--- a/tests/processor/src/networks.rs
+++ b/tests/processor/src/networks.rs
@@ -363,7 +363,7 @@ impl Wallet {
           vec![(to_addr, AMOUNT)],
           &Change::new(view_pair, false),
           data,
-          rpc.get_fee(Protocol::v16, FeePriority::Low).await.unwrap(),
+          rpc.get_fee(Protocol::v16, FeePriority::Unimportant).await.unwrap(),
         )
         .unwrap()
         .sign(&mut OsRng, spend_key)


### PR DESCRIPTION
While testing fee calculation on mainnet, I noticed I was missing the highest priority level and that the CLI (and [RPC](https://www.getmonero.org/resources/developer-guides/wallet-rpc.html)) used different enums. Copied the enums from the CLI/RPC wallets.

For lack of a better place to include this... I also ran a manual test to make sure monero-serai has fee parity with wallet2 using the following script:

```rust
use rand_core::OsRng;

use monero_serai::wallet::{
  ViewPair, Scanner, SpendableOutput, Decoys,
  address::SubaddressIndex,
  SignableTransactionBuilder, Change, FeePriority,
  address::{Network, AddressSpec},
};

use zeroize::Zeroizing;

use std_shims::collections::HashSet;

use curve25519_dalek::{Scalar, edwards::CompressedEdwardsY};

mod runner;

fn offset(ring: &[u64]) -> Vec<u64> {
  let mut res = vec![ring[0]];
  res.resize(ring.len(), 0);
  for m in (1 .. ring.len()).rev() {
    res[m] = ring[m] - ring[m - 1];
  }
  res
}

async_sequential!(
  async fn mainnet_fees() {
    // CONSTANTS
    let tx_hash_bytes =
      hex::decode("TEST")
        .unwrap()
        .try_into()
        .unwrap();
    let spend_pub_bytes =
      hex::decode("TEST")
        .unwrap()
        .try_into()
        .unwrap();
    let view_priv_bytes =
      hex::decode("TEST")
        .unwrap()
        .try_into()
        .unwrap();

    let num_inputs = 1;
    
    // First use the CLI or RPC wallet to try to transfer a single output, but don't submit.
    // Take note of the fee and of the global output indexes in the ring in the constructed tx and manually include them in 
    // the candidates vec below. Obviously this can be automated but I just wanted a quick sanity check
    // against mainnet.
    // let candidates: Vec<u64> = Vec::from([]);
    // let spendable_global_index = 0;
    // END CONSTANTS

    let spend_pub = CompressedEdwardsY(spend_pub_bytes).decompress().unwrap();
    let view_priv = Zeroizing::new(Scalar::from_canonical_bytes(view_priv_bytes).unwrap());
    let view = ViewPair::new(spend_pub, view_priv);

    let mut scanner = Scanner::from_view(view.clone(), Some(HashSet::new()));

    let rpc = runner::rpc().await;

    let tx = rpc.get_transaction(tx_hash_bytes).await.unwrap();
    let output = scanner.scan_transaction(&tx).not_locked().swap_remove(0);
    let spendable_output = SpendableOutput::from(&rpc, output).await.unwrap();
    assert_eq!(spendable_global_index, spendable_output.global_index);

    let protocol = rpc.get_protocol().await.unwrap();
    let height = rpc.get_height().await.unwrap();

    // SET UP DECOYS
    let mut unlocked_decoys = Vec::with_capacity(protocol.ring_len());
    for (i, output) in
      rpc.get_unlocked_outputs(&candidates, height, false).await.unwrap().iter_mut().enumerate()
    {
      assert!(output.is_some());

      // Don't put the real in
      if candidates[i] == spendable_output.global_index {
        continue;
      }

      if let Some(output) = output.take() {
        unlocked_decoys.push((candidates[i], output));
      }
    }

    let o = (
      spendable_output.global_index,
      [spendable_output.key(), spendable_output.commitment().calculate()],
    );
    let mut decoys: Vec<Decoys> = Vec::with_capacity(num_inputs);
    let mut ring = unlocked_decoys
      .drain((unlocked_decoys.len() - (protocol.ring_len() - 1)) ..)
      .collect::<Vec<_>>();
    ring.push(o);
    ring.sort_by(|a, b| a.0.cmp(&b.0));
    decoys.push(Decoys {
      // Binary searches for the real spend since we don't know where it sorted to
      i: u8::try_from(ring.partition_point(|x| x.0 < o.0)).unwrap(),
      offsets: offset(&ring.iter().map(|output| output.0).collect::<Vec<_>>()),
      ring: ring.iter().map(|output| output.1).collect(),
    });
    // DONE setting up decoys

    for priority in [
      FeePriority::Default,
      FeePriority::Unimportant,
      FeePriority::Normal,
      FeePriority::Elevated,
      FeePriority::Priority,
    ] {
      let mut builder = SignableTransactionBuilder::new(
        protocol,
        rpc.get_fee(protocol, priority).await.unwrap(),
        Some(Change::new(&view, false)),
      );

      builder.add_input((spendable_output.clone(), decoys[0].clone()));

      let addr = view.address(Network::Mainnet, AddressSpec::Standard);
      let amount = spendable_output.commitment().amount * 9 / 10;
      builder.add_payment(addr, amount);

      let tx = builder.build().unwrap();
      dbg!(priority, tx.fee()); // make sure this matches up with the CLI's constructed txs
    }
  }
);
```