### PR TITLE
monero: only mask user features on new polyseed, not on decode

### DIFF
--- a/coins/monero/src/tests/seed.rs
+++ b/coins/monero/src/tests/seed.rs
@@ -7,7 +7,7 @@ use curve25519_dalek::scalar::Scalar;
 use crate::{
   hash,
   wallet::seed::{
-    Seed, SeedType,
+    Seed, SeedType, SeedError,
     classic::{self, trim_by_lang},
     polyseed,
   },
@@ -404,4 +404,13 @@ fn test_polyseed() {
       );
     }
   }
+}
+
+#[test]
+fn test_invalid_polyseed() {
+  let seed = "include domain claim resemble urban hire lunch bird \
+    crucial fire best wife ring warm ignore model"
+    .into();
+  let res = Seed::from_string(Zeroizing::new(seed));
+  assert_eq!(res, Err(SeedError::UnsupportedFeatures));
 }

--- a/coins/monero/src/tests/seed.rs
+++ b/coins/monero/src/tests/seed.rs
@@ -408,6 +408,7 @@ fn test_polyseed() {
 
 #[test]
 fn test_invalid_polyseed() {
+  // This seed includes unsupported features bits and should error on decode
   let seed = "include domain claim resemble urban hire lunch bird \
     crucial fire best wife ring warm ignore model"
     .into();

--- a/coins/monero/src/wallet/seed/polyseed.rs
+++ b/coins/monero/src/wallet/seed/polyseed.rs
@@ -178,32 +178,6 @@ fn valid_entropy(entropy: &Zeroizing<[u8; 32]>) -> bool {
   }
   res.into()
 }
-
-fn from_internal(
-  language: Language,
-  masked_features: u8,
-  encoded_birthday: u16,
-  entropy: Zeroizing<[u8; 32]>,
-) -> Result<Polyseed, SeedError> {
-  if !polyseed_features_supported(masked_features) {
-    Err(SeedError::UnsupportedFeatures)?;
-  }
-
-  if !valid_entropy(&entropy) {
-    Err(SeedError::InvalidEntropy)?;
-  }
-
-  let mut res = Polyseed {
-    language,
-    birthday: encoded_birthday,
-    features: masked_features,
-    entropy,
-    checksum: 0,
-  };
-  res.checksum = poly_eval(&res.to_poly());
-  Ok(res)
-}
-
 impl Polyseed {
   // TODO: Clean this
   fn to_poly(&self) -> Poly {
@@ -242,6 +216,31 @@ impl Polyseed {
     poly
   }
 
+  fn from_internal(
+    language: Language,
+    masked_features: u8,
+    encoded_birthday: u16,
+    entropy: Zeroizing<[u8; 32]>,
+  ) -> Result<Polyseed, SeedError> {
+    if !polyseed_features_supported(masked_features) {
+      Err(SeedError::UnsupportedFeatures)?;
+    }
+
+    if !valid_entropy(&entropy) {
+      Err(SeedError::InvalidEntropy)?;
+    }
+
+    let mut res = Polyseed {
+      language,
+      birthday: encoded_birthday,
+      features: masked_features,
+      entropy,
+      checksum: 0,
+    };
+    res.checksum = poly_eval(&res.to_poly());
+    Ok(res)
+  }
+
   /// Create a new `Polyseed` with specific internals.
   ///
   /// `birthday` is defined in seconds since the Unix epoch.
@@ -251,7 +250,7 @@ impl Polyseed {
     birthday: u64,
     entropy: Zeroizing<[u8; 32]>,
   ) -> Result<Polyseed, SeedError> {
-    from_internal(language, user_features(features), birthday_encode(birthday), entropy)
+    Self::from_internal(language, user_features(features), birthday_encode(birthday), entropy)
   }
 
   /// Create a new `Polyseed`.
@@ -387,7 +386,7 @@ impl Polyseed {
     let features =
       u8::try_from(extra >> DATE_BITS).expect("couldn't convert extra >> DATE_BITS to u8");
 
-    let res = from_internal(lang, features, birthday, entropy);
+    let res = Self::from_internal(lang, features, birthday, entropy);
     if let Ok(res) = res.as_ref() {
       debug_assert_eq!(res.checksum, checksum);
     }

--- a/coins/monero/src/wallet/seed/polyseed.rs
+++ b/coins/monero/src/wallet/seed/polyseed.rs
@@ -389,10 +389,7 @@ impl Polyseed {
 
     let res = from_internal(lang, features, birthday, entropy);
     if let Ok(res) = res.as_ref() {
-      if res.checksum != checksum {
-        // This should never trigger
-        Err(SeedError::InvalidSeed)?;
-      }
+      debug_assert_eq!(res.checksum, checksum);
     }
     res
   }

--- a/coins/monero/src/wallet/seed/polyseed.rs
+++ b/coins/monero/src/wallet/seed/polyseed.rs
@@ -178,6 +178,7 @@ fn valid_entropy(entropy: &Zeroizing<[u8; 32]>) -> bool {
   }
   res.into()
 }
+
 impl Polyseed {
   // TODO: Clean this
   fn to_poly(&self) -> Poly {


### PR DESCRIPTION
- This commit ensures a polyseed string that has unsupported features correctly errors on decode (without this PR, the test in this PR would trigger a debug assert, and if instead triggered in a non-debug build then `Polyseed::from_string` could return an incorrect successful response)
- Also avoids panicking in debug builds when checksum calculation is unexpectedly wrong

Polyseed reference impl for feature masking:
- polyseed_create: https://github.com/tevador/polyseed/blob/b7c35bb3c6b91e481ecb04fc235eaff69c507fa1/src/polyseed.c#L61
- polyseed_decode: https://github.com/tevador/polyseed/blob/b7c35bb3c6b91e481ecb04fc235eaff69c507fa1/src/polyseed.c#L212