### PR TITLE
Monero: use only the first input ring length for RCT deserialization. 

### DIFF
--- a/coins/monero/src/ringct/mlsag.rs
+++ b/coins/monero/src/ringct/mlsag.rs
@@ -33,7 +33,10 @@ pub struct RingMatrix {
 
 impl RingMatrix {
   pub fn new(matrix: Vec<Vec<EdwardsPoint>>) -> Result<Self, MlsagError> {
-    if matrix.is_empty() {
+    // Monero requires that there is more than one ring member for MLSAG signatures:
+    // https://github.com/monero-project/monero/blob/ac02af92867590ca80b2779a7bbeafa99ff94dcb/
+    // src/ringct/rctSigs.cpp#L462
+    if matrix.len() < 2 {
       Err(MlsagError::InvalidRing)?;
     }
     for member in &matrix {

--- a/coins/monero/src/transaction.rs
+++ b/coins/monero/src/transaction.rs
@@ -331,14 +331,11 @@ impl Transaction {
       }
     } else if prefix.version == 2 {
       rct_signatures = RctSignatures::read(
-        &prefix
-          .inputs
-          .iter()
-          .map(|input| match input {
-            Input::Gen(_) => 0,
-            Input::ToKey { key_offsets, .. } => key_offsets.len(),
-          })
-          .collect::<Vec<_>>(),
+        prefix.inputs.first().map_or(0, |input| match input {
+          Input::Gen(_) => 0,
+          Input::ToKey { key_offsets, .. } => key_offsets.len(),
+        }),
+        prefix.inputs.len(),
         prefix.outputs.len(),
         r,
       )?;


### PR DESCRIPTION
This changes RCT deserialization to use the first inputs ring size for all inputs, which is how Monero does it [[1]](https://github.com/monero-project/monero/blob/ac02af92867590ca80b2779a7bbeafa99ff94dcb/src/ringct/rctTypes.h#L422C108-L422C108) [[2]](https://github.com/monero-project/monero/blob/master/src/cryptonote_basic/cryptonote_basic.h#L308-L309). By using the first inputs ring size for all inputs Monero restricts all RCT transactions to have the same number of ring members across all inputs, otherwise the signatures would be incorrect as they would have a different number of elements than required.

This isn't an issue for current txs as from [hf 12 Monero requires all inputs to have the same number of decoys anyway](https://github.com/monero-project/monero/blob/eac1b86bb2818ac552457380c9dd421fb8935e5b/src/cryptonote_core/blockchain.cpp#L3378), but for transactions before that we would accept RCT txs with inputs differing in ring size whereas Monero would reject them.

I could add a rule in Cuprate that all RCT txs must have a constant number of decoys but I think it would be better to fix this mismatch in deserialization.

This also adds a check I missed in #383, Monero checks that [MLSAG signatures have at least 2 ring members](https://github.com/monero-project/monero/blob/ac02af92867590ca80b2779a7bbeafa99ff94dcb/src/ringct/rctSigs.cpp#L462).