### PR TITLE
monero: investigated TODO and can remove it

### DIFF
--- a/coins/monero/src/wallet/scan.rs
+++ b/coins/monero/src/wallet/scan.rs
@@ -363,7 +363,6 @@ impl Scanner {
             // https://github.com/monero-project/monero/
             //   blob/04a1e2875d6e35e27bb21497988a6c822d319c28/
             //   src/cryptonote_basic/cryptonote_format_utils.cpp#L1062
-            // TODO: Should this return? Where does Monero set the trap handler for this exception?
             continue;
           }
           None => {


### PR DESCRIPTION
The behavior appears to match monero core. monero core isn't throwing an exception in the linked code, it's returning `boost::none` (and logging an error) which is the same functional behavior as finding that the output does not belong to the user.

[The linked code](https://github.com/monero-project/monero/blob/04a1e2875d6e35e27bb21497988a6c822d319c28/src/cryptonote_basic/cryptonote_format_utils.cpp#L1062)

[`CHECK_AND_ASSERT_MES`](https://github.com/monero-project/monero/blob/ac02af92867590ca80b2779a7bbeafa99ff94dcb/contrib/epee/include/misc_log_ex.h#L183)