### PR TITLE
monero: added tx extra variants padding and mysterious minergate

### DIFF
--- a/coins/monero/src/tests/extra.rs
+++ b/coins/monero/src/tests/extra.rs
@@ -20,9 +20,9 @@ fn pub_key() -> EdwardsPoint {
     .unwrap()
 }
 
-fn test_write_buf(extra: Extra, buf: Vec<u8>) {
+fn test_write_buf(extra: &Extra, buf: &[u8]) {
   let mut w: Vec<u8> = vec![];
-  Extra::write(&extra, &mut w).unwrap();
+  Extra::write(extra, &mut w).unwrap();
   assert_eq!(buf, w);
 }
 
@@ -31,7 +31,7 @@ fn empty_extra() {
   let buf: Vec<u8> = vec![];
   let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
   assert!(extra.0.is_empty());
-  test_write_buf(extra, buf);
+  test_write_buf(&extra, &buf);
 }
 
 #[test]
@@ -39,7 +39,7 @@ fn padding_only_size_1() {
   let buf: Vec<u8> = vec![0];
   let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::Padding(1)]);
-  test_write_buf(extra, buf);
+  test_write_buf(&extra, &buf);
 }
 
 #[test]
@@ -47,7 +47,7 @@ fn padding_only_size_2() {
   let buf: Vec<u8> = vec![0, 0];
   let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::Padding(2)]);
-  test_write_buf(extra, buf);
+  test_write_buf(&extra, &buf);
 }
 
 #[test]
@@ -55,7 +55,7 @@ fn padding_only_max_size() {
   let buf: Vec<u8> = vec![0; MAX_TX_EXTRA_PADDING_COUNT];
   let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::Padding(MAX_TX_EXTRA_PADDING_COUNT)]);
-  test_write_buf(extra, buf);
+  test_write_buf(&extra, &buf);
 }
 
 #[test]
@@ -77,7 +77,7 @@ fn pub_key_only() {
   let buf: Vec<u8> = PUB_KEY_BYTES.to_vec();
   let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::PublicKey(pub_key())]);
-  test_write_buf(extra, buf);
+  test_write_buf(&extra, &buf);
 }
 
 #[test]
@@ -85,7 +85,7 @@ fn extra_nonce_only() {
   let buf: Vec<u8> = vec![2, 1, 42];
   let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::Nonce(vec![42])]);
-  test_write_buf(extra, buf);
+  test_write_buf(&extra, &buf);
 }
 
 #[test]
@@ -107,7 +107,7 @@ fn pub_key_and_padding() {
   ]);
   let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::PublicKey(pub_key()), ExtraField::Padding(76)]);
-  test_write_buf(extra, buf);
+  test_write_buf(&extra, &buf);
 }
 
 #[test]
@@ -123,7 +123,7 @@ fn extra_mysterious_minergate_only() {
   let buf: Vec<u8> = vec![222, 1, 42];
   let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::MysteriousMinergate(vec![42])]);
-  test_write_buf(extra, buf);
+  test_write_buf(&extra, &buf);
 }
 
 #[test]
@@ -133,7 +133,7 @@ fn extra_mysterious_minergate_only_large() {
   buf.extend_from_slice(&vec![0; 512]);
   let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::MysteriousMinergate(vec![0; 512])]);
-  test_write_buf(extra, buf);
+  test_write_buf(&extra, &buf);
 }
 
 #[test]

--- a/coins/monero/src/tests/extra.rs
+++ b/coins/monero/src/tests/extra.rs
@@ -1,16 +1,28 @@
 use crate::{
   wallet::{ExtraField, Extra, extra::MAX_TX_EXTRA_PADDING_COUNT},
+  serialize::write_varint,
 };
 
-use curve25519_dalek::edwards::CompressedEdwardsY;
+use curve25519_dalek::edwards::{EdwardsPoint, CompressedEdwardsY};
 
 // Borrowed tests from
 // https://github.com/monero-project/monero/blob/ac02af92867590ca80b2779a7bbeafa99ff94dcb/
 //   tests/unit_tests/test_tx_utils.cpp
 
+const PUB_KEY_BYTES: [u8; 33] = [
+  1, 30, 208, 98, 162, 133, 64, 85, 83, 112, 91, 188, 89, 211, 24, 131, 39, 154, 22, 228, 80, 63,
+  198, 141, 173, 111, 244, 183, 4, 149, 186, 140, 230,
+];
+
+fn pub_key() -> EdwardsPoint {
+  CompressedEdwardsY(PUB_KEY_BYTES[1 .. PUB_KEY_BYTES.len()].try_into().expect("invalid pub key"))
+    .decompress()
+    .unwrap()
+}
+
 fn test_write_buf(extra: Extra, buf: Vec<u8>) {
   let mut w: Vec<u8> = vec![];
-  let _ = Extra::write(&extra, &mut w);
+  Extra::write(&extra, &mut w).unwrap();
   assert_eq!(buf, w);
 }
 
@@ -24,7 +36,7 @@ fn empty_extra() {
 
 #[test]
 fn padding_only_size_1() {
-  let buf: Vec<u8> = Vec::from([0]);
+  let buf: Vec<u8> = vec![0];
   let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::Padding(1)]);
   test_write_buf(extra, buf);
@@ -32,7 +44,7 @@ fn padding_only_size_1() {
 
 #[test]
 fn padding_only_size_2() {
-  let buf: Vec<u8> = Vec::from([0, 0]);
+  let buf: Vec<u8> = vec![0, 0];
   let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::Padding(2)]);
   test_write_buf(extra, buf);
@@ -40,7 +52,7 @@ fn padding_only_size_2() {
 
 #[test]
 fn padding_only_max_size() {
-  let buf: Vec<u8> = Vec::from([0; MAX_TX_EXTRA_PADDING_COUNT]);
+  let buf: Vec<u8> = vec![0; MAX_TX_EXTRA_PADDING_COUNT];
   let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::Padding(MAX_TX_EXTRA_PADDING_COUNT)]);
   test_write_buf(extra, buf);
@@ -48,36 +60,29 @@ fn padding_only_max_size() {
 
 #[test]
 fn padding_only_exceed_max_size() {
-  let buf: Vec<u8> = Vec::from([0; MAX_TX_EXTRA_PADDING_COUNT + 1]);
+  let buf: Vec<u8> = vec![0; MAX_TX_EXTRA_PADDING_COUNT + 1];
   let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
   assert!(extra.0.is_empty());
 }
 
 #[test]
 fn invalid_padding_only() {
-  let buf: Vec<u8> = Vec::from([0, 42]);
+  let buf: Vec<u8> = vec![0, 42];
   let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
   assert!(extra.0.is_empty());
 }
 
 #[test]
 fn pub_key_only() {
-  let buf: Vec<u8> = Vec::from([
-    1, 30, 208, 98, 162, 133, 64, 85, 83, 112, 91, 188, 89, 211, 24, 131, 39, 154, 22, 228, 80, 63,
-    198, 141, 173, 111, 244, 183, 4, 149, 186, 140, 230,
-  ]);
-  let expected_pub_key =
-    CompressedEdwardsY(buf.clone()[1 .. buf.len()].try_into().expect("invalid pub key"))
-      .decompress()
-      .unwrap();
+  let buf: Vec<u8> = PUB_KEY_BYTES.to_vec();
   let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
-  assert_eq!(extra.0, vec![ExtraField::PublicKey(expected_pub_key)]);
+  assert_eq!(extra.0, vec![ExtraField::PublicKey(pub_key())]);
   test_write_buf(extra, buf);
 }
 
 #[test]
 fn extra_nonce_only() {
-  let buf: Vec<u8> = Vec::from([2, 1, 42]);
+  let buf: Vec<u8> = vec![2, 1, 42];
   let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::Nonce(vec![42])]);
   test_write_buf(extra, buf);
@@ -85,7 +90,7 @@ fn extra_nonce_only() {
 
 #[test]
 fn extra_nonce_only_wrong_size() {
-  let mut buf: Vec<u8> = Vec::from([0; 20]);
+  let mut buf: Vec<u8> = vec![0; 20];
   buf[0] = 2;
   buf[1] = 255;
   let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
@@ -94,17 +99,48 @@ fn extra_nonce_only_wrong_size() {
 
 #[test]
 fn pub_key_and_padding() {
-  let buf: Vec<u8> = Vec::from([
-    1, 30, 208, 98, 162, 133, 64, 85, 83, 112, 91, 188, 89, 211, 24, 131, 39, 154, 22, 228, 80, 63,
-    198, 141, 173, 111, 244, 183, 4, 149, 186, 140, 230, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  let mut buf: Vec<u8> = PUB_KEY_BYTES.to_vec();
+  buf.extend([
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   ]);
-  let expected_pub_key =
-    CompressedEdwardsY(buf.clone()[1 .. 33].try_into().expect("invalid pub key"))
-      .decompress()
-      .unwrap();
   let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
-  assert_eq!(extra.0, vec![ExtraField::PublicKey(expected_pub_key), ExtraField::Padding(76)]);
+  assert_eq!(extra.0, vec![ExtraField::PublicKey(pub_key()), ExtraField::Padding(76)]);
   test_write_buf(extra, buf);
+}
+
+#[test]
+fn pub_key_and_invalid_padding() {
+  let mut buf: Vec<u8> = PUB_KEY_BYTES.to_vec();
+  buf.extend([0, 1]);
+  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  assert_eq!(extra.0, vec![ExtraField::PublicKey(pub_key())]);
+}
+
+#[test]
+fn extra_mysterious_minergate_only() {
+  let buf: Vec<u8> = vec![222, 1, 42];
+  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  assert_eq!(extra.0, vec![ExtraField::MysteriousMinergate(vec![42])]);
+  test_write_buf(extra, buf);
+}
+
+#[test]
+fn extra_mysterious_minergate_only_large() {
+  let mut buf: Vec<u8> = vec![222];
+  write_varint(&512u64, &mut buf).unwrap();
+  buf.extend_from_slice(&vec![0; 512]);
+  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  assert_eq!(extra.0, vec![ExtraField::MysteriousMinergate(vec![0; 512])]);
+  test_write_buf(extra, buf);
+}
+
+#[test]
+fn extra_mysterious_minergate_only_wrong_size() {
+  let mut buf: Vec<u8> = vec![0; 20];
+  buf[0] = 222;
+  buf[1] = 255;
+  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  assert!(extra.0.is_empty());
 }

--- a/coins/monero/src/tests/extra.rs
+++ b/coins/monero/src/tests/extra.rs
@@ -144,3 +144,15 @@ fn extra_mysterious_minergate_only_wrong_size() {
   let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
   assert!(extra.0.is_empty());
 }
+
+#[test]
+fn extra_mysterious_minergate_and_pub_key() {
+  let mut buf: Vec<u8> = vec![222, 1, 42];
+  buf.extend(PUB_KEY_BYTES.to_vec());
+  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  assert_eq!(
+    extra.0,
+    vec![ExtraField::MysteriousMinergate(vec![42]), ExtraField::PublicKey(pub_key())]
+  );
+  test_write_buf(&extra, &buf);
+}

--- a/coins/monero/src/tests/extra.rs
+++ b/coins/monero/src/tests/extra.rs
@@ -1,0 +1,110 @@
+use crate::{
+  wallet::{ExtraField, Extra, extra::MAX_TX_EXTRA_PADDING_COUNT},
+};
+
+use curve25519_dalek::edwards::CompressedEdwardsY;
+
+// Borrowed tests from
+// https://github.com/monero-project/monero/blob/ac02af92867590ca80b2779a7bbeafa99ff94dcb/
+//   tests/unit_tests/test_tx_utils.cpp
+
+fn test_write_buf(extra: Extra, buf: Vec<u8>) {
+  let mut w: Vec<u8> = vec![];
+  let _ = Extra::write(&extra, &mut w);
+  assert_eq!(buf, w);
+}
+
+#[test]
+fn empty_extra() {
+  let buf: Vec<u8> = vec![];
+  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  assert!(extra.0.is_empty());
+  test_write_buf(extra, buf);
+}
+
+#[test]
+fn padding_only_size_1() {
+  let buf: Vec<u8> = Vec::from([0]);
+  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  assert_eq!(extra.0, vec![ExtraField::Padding(1)]);
+  test_write_buf(extra, buf);
+}
+
+#[test]
+fn padding_only_size_2() {
+  let buf: Vec<u8> = Vec::from([0, 0]);
+  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  assert_eq!(extra.0, vec![ExtraField::Padding(2)]);
+  test_write_buf(extra, buf);
+}
+
+#[test]
+fn padding_only_max_size() {
+  let buf: Vec<u8> = Vec::from([0; MAX_TX_EXTRA_PADDING_COUNT]);
+  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  assert_eq!(extra.0, vec![ExtraField::Padding(MAX_TX_EXTRA_PADDING_COUNT)]);
+  test_write_buf(extra, buf);
+}
+
+#[test]
+fn padding_only_exceed_max_size() {
+  let buf: Vec<u8> = Vec::from([0; MAX_TX_EXTRA_PADDING_COUNT + 1]);
+  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  assert!(extra.0.is_empty());
+}
+
+#[test]
+fn invalid_padding_only() {
+  let buf: Vec<u8> = Vec::from([0, 42]);
+  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  assert!(extra.0.is_empty());
+}
+
+#[test]
+fn pub_key_only() {
+  let buf: Vec<u8> = Vec::from([
+    1, 30, 208, 98, 162, 133, 64, 85, 83, 112, 91, 188, 89, 211, 24, 131, 39, 154, 22, 228, 80, 63,
+    198, 141, 173, 111, 244, 183, 4, 149, 186, 140, 230,
+  ]);
+  let expected_pub_key =
+    CompressedEdwardsY(buf.clone()[1 .. buf.len()].try_into().expect("invalid pub key"))
+      .decompress()
+      .unwrap();
+  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  assert_eq!(extra.0, vec![ExtraField::PublicKey(expected_pub_key)]);
+  test_write_buf(extra, buf);
+}
+
+#[test]
+fn extra_nonce_only() {
+  let buf: Vec<u8> = Vec::from([2, 1, 42]);
+  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  assert_eq!(extra.0, vec![ExtraField::Nonce(vec![42])]);
+  test_write_buf(extra, buf);
+}
+
+#[test]
+fn extra_nonce_only_wrong_size() {
+  let mut buf: Vec<u8> = Vec::from([0; 20]);
+  buf[0] = 2;
+  buf[1] = 255;
+  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  assert!(extra.0.is_empty());
+}
+
+#[test]
+fn pub_key_and_padding() {
+  let buf: Vec<u8> = Vec::from([
+    1, 30, 208, 98, 162, 133, 64, 85, 83, 112, 91, 188, 89, 211, 24, 131, 39, 154, 22, 228, 80, 63,
+    198, 141, 173, 111, 244, 183, 4, 149, 186, 140, 230, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  ]);
+  let expected_pub_key =
+    CompressedEdwardsY(buf.clone()[1 .. 33].try_into().expect("invalid pub key"))
+      .decompress()
+      .unwrap();
+  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  assert_eq!(extra.0, vec![ExtraField::PublicKey(expected_pub_key), ExtraField::Padding(76)]);
+  test_write_buf(extra, buf);
+}

--- a/coins/monero/src/tests/mod.rs
+++ b/coins/monero/src/tests/mod.rs
@@ -3,3 +3,4 @@ mod clsag;
 mod bulletproofs;
 mod address;
 mod seed;
+mod extra;

--- a/coins/monero/src/wallet/extra.rs
+++ b/coins/monero/src/wallet/extra.rs
@@ -79,6 +79,7 @@ pub enum ExtraField {
   Nonce(Vec<u8>),
   MergeMining(usize, [u8; 32]),
   PublicKeys(Vec<EdwardsPoint>),
+  MysteriousMinergate(Vec<u8>),
 }
 
 impl ExtraField {
@@ -106,6 +107,10 @@ impl ExtraField {
       ExtraField::PublicKeys(keys) => {
         w.write_all(&[4])?;
         write_vec(write_point, keys, w)?;
+      }
+      ExtraField::MysteriousMinergate(data) => {
+        w.write_all(&[0xDE])?;
+        write_vec(write_byte, data, w)?;
       }
     }
     Ok(())
@@ -146,6 +151,7 @@ impl ExtraField {
       }),
       3 => ExtraField::MergeMining(read_varint(r)?, read_bytes(r)?),
       4 => ExtraField::PublicKeys(read_vec(read_point, r)?),
+      0xDE => ExtraField::MysteriousMinergate(read_vec(read_byte, r)?),
       _ => Err(io::Error::other("unknown extra field"))?,
     })
   }

--- a/coins/monero/src/wallet/extra.rs
+++ b/coins/monero/src/wallet/extra.rs
@@ -124,7 +124,7 @@ impl ExtraField {
         loop {
           let buf = r.fill_buf()?;
           let mut n_consume = 0;
-          for v in buf.as_ref() {
+          for v in buf {
             if *v != 0u8 {
               Err(io::Error::other("non-zero value after padding"))?
             }

--- a/coins/monero/src/wallet/extra.rs
+++ b/coins/monero/src/wallet/extra.rs
@@ -1,11 +1,8 @@
 use core::ops::BitXor;
 use std_shims::{
   vec::Vec,
-  io::{self, Read, Write},
+  io::{self, Read, BufRead, Write},
 };
-
-// TODO: implement std_shim::io::BufRead
-use std::io::BufRead;
 
 use zeroize::Zeroize;
 

--- a/common/std-shims/src/io.rs
+++ b/common/std-shims/src/io.rs
@@ -64,6 +64,20 @@ mod shims {
     }
   }
 
+  pub trait BufRead: Read {
+    fn fill_buf(&mut self) -> Result<&[u8]>;
+    fn consume(&mut self, amt: usize);
+  }
+
+  impl BufRead for &[u8] {
+    fn fill_buf(&mut self) -> Result<&[u8]> {
+      Ok(*self)
+    }
+    fn consume(&mut self, amt: usize) {
+      *self = &self[amt ..];
+    }
+  }
+
   pub trait Write {
     fn write(&mut self, buf: &[u8]) -> Result<usize>;
     fn write_all(&mut self, buf: &[u8]) -> Result<()> {


### PR DESCRIPTION
Handling the mysterious minergate variant ensures that when scanning a tx, the tx extra parser will not error early and short-circuit if it encounters the mysterious minergate tag prior to other values wallet2 would use (and monero-serai should use) to scan the tx

I left a TODO for `std_shim::io::BufRead`