### PR TITLE
monero: scan all tx pub keys (not additional) for every tx

### DIFF
--- a/coins/monero/src/wallet/extra.rs
+++ b/coins/monero/src/wallet/extra.rs
@@ -120,12 +120,12 @@ impl ExtraField {
 #[derive(Clone, PartialEq, Eq, Debug, Zeroize)]
 pub struct Extra(Vec<ExtraField>);
 impl Extra {
-  pub fn keys(&self) -> Option<(EdwardsPoint, Option<Vec<EdwardsPoint>>)> {
-    let mut key = None;
+  pub fn keys(&self) -> Option<(Vec<EdwardsPoint>, Option<Vec<EdwardsPoint>>)> {
+    let mut keys = vec![];
     let mut additional = None;
     for field in &self.0 {
       match field.clone() {
-        ExtraField::PublicKey(this_key) => key = key.or(Some(this_key)),
+        ExtraField::PublicKey(this_key) => keys.push(this_key),
         ExtraField::PublicKeys(these_additional) => {
           additional = additional.or(Some(these_additional))
         }
@@ -133,7 +133,11 @@ impl Extra {
       }
     }
     // Don't return any keys if this was non-standard and didn't include the primary key
-    key.map(|key| (key, additional))
+    if keys.is_empty() {
+      None
+    } else {
+      Some((keys, additional))
+    }
   }
 
   pub fn payment_id(&self) -> Option<PaymentId> {

--- a/coins/monero/src/wallet/scan.rs
+++ b/coins/monero/src/wallet/scan.rs
@@ -334,7 +334,7 @@ impl Scanner {
       return Timelocked(tx.prefix.timelock, vec![]);
     };
 
-    let Some((tx_key, additional)) = extra.keys() else {
+    let Some((tx_keys, additional)) = extra.keys() else {
       return Timelocked(tx.prefix.timelock, vec![]);
     };
 
@@ -355,7 +355,9 @@ impl Scanner {
       }
       let output_key = output_key.unwrap();
 
-      for key in [Some(Some(&tx_key)), additional.as_ref().map(|additional| additional.get(o))] {
+      let additional = additional.as_ref().map(|additional| additional.get(o));
+
+      for key in tx_keys.iter().map(|key| Some(Some(key))).chain(core::iter::once(additional)) {
         let key = match key {
           Some(Some(key)) => key,
           Some(None) => {


### PR DESCRIPTION
This ensures receives in non-standard txs would be identified, same as wallet2.

wallet2's behavior is explained more fully here: https://github.com/UkoeHB/monero/issues/27