### PR TITLE
Some improvements on economic security

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7397,6 +7397,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serai-coins-primitives",
+ "serai-in-instructions-primitives",
  "serai-primitives",
  "sp-core",
  "sp-runtime",

--- a/substrate/client/tests/dex.rs
+++ b/substrate/client/tests/dex.rs
@@ -11,7 +11,7 @@ use serai_client::{
     SeraiAddress, PublicKey,
   },
   in_instructions::primitives::{
-    InInstruction, InInstructionWithBalance, Batch, IN_INSTRUCTION_EXECUTOR, OutAddress,
+    InInstruction, InInstructionWithBalance, Batch, ADD_LIQUIDITY_ACCOUNT, SWAP_ACCOUNT, OutAddress,
   },
   dex::DexEvent,
   Serai,
@@ -270,7 +270,7 @@ serai_test!(
     assert_eq!(
       events,
       vec![DexEvent::LiquidityAdded {
-        who: IN_INSTRUCTION_EXECUTOR,
+        who: ADD_LIQUIDITY_ACCOUNT,
         mint_to: pair.public().into(),
         pool_id: Coin::Bitcoin,
         coin_amount: 10_000_000_000_000, // half of sent amount
@@ -357,8 +357,8 @@ serai_test!(
       assert_eq!(
         events,
         vec![DexEvent::SwapExecuted {
-          who: IN_INSTRUCTION_EXECUTOR,
-          send_to: IN_INSTRUCTION_EXECUTOR,
+          who: SWAP_ACCOUNT,
+          send_to: SWAP_ACCOUNT,
           path,
           amount_in: 20_000_000_000_000,
           amount_out: 11066655622377
@@ -396,7 +396,7 @@ serai_test!(
       assert_eq!(
         events,
         vec![DexEvent::SwapExecuted {
-          who: IN_INSTRUCTION_EXECUTOR,
+          who: SWAP_ACCOUNT,
           send_to: out_address.as_native().unwrap(),
           path,
           amount_in: 20_000_000_000_000,
@@ -434,7 +434,7 @@ serai_test!(
       assert_eq!(
         events,
         vec![DexEvent::SwapExecuted {
-          who: IN_INSTRUCTION_EXECUTOR,
+          who: SWAP_ACCOUNT,
           send_to: out_address.as_native().unwrap(),
           path,
           amount_in: 10_000_000_000_000,

--- a/substrate/coins/pallet/Cargo.toml
+++ b/substrate/coins/pallet/Cargo.toml
@@ -33,6 +33,7 @@ pallet-transaction-payment = { git = "https://github.com/serai-dex/substrate", d
 
 serai-primitives = { path = "../../primitives", default-features = false, features = ["serde"] }
 coins-primitives = { package = "serai-coins-primitives", path = "../primitives", default-features = false }
+in-ins-primitives = { package = "serai-in-instructions-primitives", path = "../../in-instructions/primitives", default-features = false }
 
 [features]
 std = [
@@ -47,6 +48,7 @@ std = [
 
   "serai-primitives/std",
   "coins-primitives/std",
+  "in-ins-primitives/std",
 ]
 
 runtime-benchmarks = [

--- a/substrate/coins/pallet/src/lib.rs
+++ b/substrate/coins/pallet/src/lib.rs
@@ -3,11 +3,11 @@
 use serai_primitives::{Coin, SubstrateAmount, Balance};
 
 pub trait AllowMint {
-  fn is_allowed(balance: &Balance) -> bool;
+  fn is_allowed(balance: &Balance, for_swap: bool) -> bool;
 }
 
 impl AllowMint for () {
-  fn is_allowed(_: &Balance) -> bool {
+  fn is_allowed(_: &Balance, _: bool) -> bool {
     true
   }
 }
@@ -32,6 +32,8 @@ pub mod pallet {
   use serai_primitives::*;
   pub use coins_primitives as primitives;
   use primitives::*;
+
+  use in_ins_primitives::SWAP_ACCOUNT;
 
   type LiquidityTokensInstance = crate::Instance1;
 
@@ -159,7 +161,7 @@ pub mod pallet {
     ///
     /// Errors if any amount overflows.
     pub fn mint(to: Public, balance: Balance) -> Result<(), Error<T, I>> {
-      if !T::AllowMint::is_allowed(&balance) {
+      if !T::AllowMint::is_allowed(&balance, to == SWAP_ACCOUNT.into()) {
         Err(Error::<T, I>::MintNotAllowed)?;
       }
 

--- a/substrate/dex/pallet/src/lib.rs
+++ b/substrate/dex/pallet/src/lib.rs
@@ -151,6 +151,7 @@ pub mod pallet {
   /// Map from `PoolId` to `()`. This establishes whether a pool has been officially
   /// created rather than people sending tokens directly to a pool's public account.
   #[pallet::storage]
+  #[pallet::getter(fn pools)]
   pub type Pools<T: Config> = StorageMap<_, Blake2_128Concat, PoolId, (), OptionQuery>;
 
   #[pallet::storage]

--- a/substrate/in-instructions/primitives/src/lib.rs
+++ b/substrate/in-instructions/primitives/src/lib.rs
@@ -27,8 +27,11 @@ pub use shorthand::*;
 
 pub const MAX_BATCH_SIZE: usize = 25_000; // ~25kb
 
-// This is the account which will be the origin for any dispatched `InInstruction`s.
-pub const IN_INSTRUCTION_EXECUTOR: SeraiAddress = system_address(b"InInstructions-executor");
+// This is the account which will be the origin for add liquidity instructions.
+pub const ADD_LIQUIDITY_ACCOUNT: SeraiAddress = system_address(b"add-liquidty-account");
+
+// This is the account which will be the origin for swap intructions.
+pub const SWAP_ACCOUNT: SeraiAddress = system_address(b"swap-account");
 
 #[derive(Clone, PartialEq, Eq, Debug, Encode, Decode, MaxEncodedLen, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Zeroize))]

--- a/substrate/validator-sets/pallet/src/lib.rs
+++ b/substrate/validator-sets/pallet/src/lib.rs
@@ -1031,14 +1031,20 @@ pub mod pallet {
   }
 
   impl<T: Config> AllowMint for Pallet<T> {
-    fn is_allowed(balance: &Balance) -> bool {
+    fn is_allowed(balance: &Balance, for_swap: bool) -> bool {
       // get the required stake
       let current_required = Self::required_stake_for_network(balance.coin.network());
       let new_required = current_required + Self::required_stake(balance);
 
       // get the total stake for the network & compare.
-      let staked = Self::total_allocated_stake(balance.coin.network()).unwrap_or(Amount(0));
-      staked.0 >= new_required
+      let mut staked = Self::total_allocated_stake(balance.coin.network()).unwrap_or(Amount(0)).0;
+
+      // we leave 5% buffer on our stake for swap mints.
+      if !for_swap {
+        staked -= staked / 20; // TODO: this should be a const but where?
+      }
+
+      staked >= new_required
     }
   }
 


### PR DESCRIPTION
- Puts a 5% buffer between the required stake for minted coins and the current stake if the mint is not for a swap. This is to reduce the rejection of mints for swap transactions.  Buffer size can be further optimized.
- Restricts the out-of-pool coins that are on serai chain to 20% of in-pool coins if a pool with a certain liquidity exists for the coin. That is to prevent a DoS where a user mints all the allowed sriXYZ for a given stake and in doing so prevents other users to add liquidity or doing swaps since those operations are also mint coins.

For now, the enforcement of the second restriction only applies to direct mints, a situation where a user directly mints sriXYZ  by sending coins to its multisig address. But same out-of-pool but in system sriXYZ situation can be also achieved by on-chain swapping to it or removing liquidity from the pool without burning the received sriXYZ. 

This pr doesn't apply the same restriction to those situations for now to not prevent someone from just doing a swap or removing liquidity from a pool since those are critical system functions. Also there are extra steps and hence inherent risks to those ways of achieving more sriXYZ in out-of-pool than allowed. Though those disincentives might solely be enough, it still requires further discussion and maybe thinking of other methods such as charging fees for the out-of-pool sriXYZ.