### PR TITLE
Add bootnode code prior used in testnet-internal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7613,6 +7613,7 @@ dependencies = [
  "futures-util",
  "hex",
  "jsonrpsee",
+ "libp2p",
  "pallet-transaction-payment-rpc",
  "rand_core",
  "sc-authority-discovery",

--- a/substrate/node/Cargo.toml
+++ b/substrate/node/Cargo.toml
@@ -26,6 +26,8 @@ hex = "0.4"
 rand_core = "0.6"
 schnorrkel = "0.11"
 
+libp2p = "0.52"
+
 sp-core = { git = "https://github.com/serai-dex/substrate" }
 sp-keystore = { git = "https://github.com/serai-dex/substrate" }
 sp-timestamp = { git = "https://github.com/serai-dex/substrate" }

--- a/substrate/node/src/chain_spec.rs
+++ b/substrate/node/src/chain_spec.rs
@@ -209,7 +209,10 @@ pub fn testnet_config() -> ChainSpec {
     // ID
     "testnet-2",
     ChainType::Live,
-    move || { let _ = testnet_genesis(&wasm_binary, vec![]); todo!() },
+    move || {
+      let _ = testnet_genesis(&wasm_binary, vec![]);
+      todo!()
+    },
     // Bootnodes
     vec![],
     // Telemetry

--- a/substrate/node/src/chain_spec.rs
+++ b/substrate/node/src/chain_spec.rs
@@ -209,10 +209,7 @@ pub fn testnet_config() -> ChainSpec {
     // ID
     "testnet-2",
     ChainType::Live,
-    move || {
-      let _ = testnet_genesis(&wasm_binary, vec![]);
-      todo!()
-    },
+    move || { let _ = testnet_genesis(&wasm_binary, vec![]); todo!() },
     // Bootnodes
     vec![],
     // Telemetry
@@ -230,8 +227,8 @@ pub fn testnet_config() -> ChainSpec {
 
 pub fn bootnode_multiaddrs(id: &str) -> Vec<libp2p::Multiaddr> {
   match id {
-    "serai-devnet" | "serai-local" => vec![],
-    "serai-testnet-2" => todo!(),
+    "devnet" | "local" => vec![],
+    "testnet-2" => todo!(),
     _ => panic!("unrecognized network ID"),
   }
 }

--- a/substrate/node/src/command.rs
+++ b/substrate/node/src/command.rs
@@ -40,7 +40,8 @@ impl SubstrateCli for Cli {
   fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
     match id {
       "dev" | "devnet" => Ok(Box::new(chain_spec::development_config())),
-      "local" => Ok(Box::new(chain_spec::testnet_config())),
+      "local" => Ok(Box::new(chain_spec::local_config())),
+      "testnet" => Ok(Box::new(chain_spec::testnet_config())),
       _ => panic!("Unknown network ID"),
     }
   }


### PR DESCRIPTION
Also performs the devnet/testnet differentation done since the testnet branch.

Placed on a PR to ensure it doesn't bork CI.