### PR TITLE
monero: documentation

### DIFF
--- a/coins/monero/README.md
+++ b/coins/monero/README.md
@@ -47,3 +47,15 @@ It also won't act as a wallet, just as a transaction library. wallet2 has
 several *non-transaction-level* policies, such as always attempting to use two
 inputs to create transactions. These are considered out of scope to
 monero-serai.
+
+### Feature flags
+monero-serai has certain functionality behind feature flags:
+
+- `std:` Enables usage of Rust's `std` and several other functionality. See `Cargo.toml` for the full list.
+- `http-rpc`: Enables an HTTP(S) transport type within the `rpc` module
+- `multisig`: Enables multi-signature features within the `wallet` module
+- `binaries`: TODO
+
+The features enabled by default are:
+- `std`
+- `http-rpc`

--- a/coins/monero/src/block.rs
+++ b/coins/monero/src/block.rs
@@ -47,7 +47,7 @@ impl BlockHeader {
   ///
   /// let mut writer = vec![];
   /// block_header.write(&mut writer)?;
-  /// # }
+  /// # Ok(()) }
   /// ```
   ///
   /// # Errors
@@ -79,7 +79,7 @@ impl BlockHeader {
   ///
   /// let serialized = block_header.serialize();
   /// assert_eq!(serialized, writer);
-  /// # }
+  /// # Ok(()) }
   /// ```
   pub fn serialize(&self) -> Vec<u8> {
     let mut serialized = vec![];
@@ -104,9 +104,9 @@ impl BlockHeader {
   /// let mut vec = vec![];
   /// block_header.write(&mut vec)?;
   ///
-  /// let read = BlockHeader::read(& vec)?;
+  /// let read = BlockHeader::read(&mut vec.as_slice())?;
   /// assert_eq!(read, block_header);
-  /// # }
+  /// # Ok(()) }
   /// ```
   ///
   /// # Errors

--- a/coins/monero/src/block.rs
+++ b/coins/monero/src/block.rs
@@ -15,8 +15,8 @@ const CORRECT_BLOCK_HASH_202612: [u8; 32] =
 const EXISTING_BLOCK_HASH_202612: [u8; 32] =
   hex_literal::hex!("bbd604d2ba11ba27935e006ed39c9bfdd99b76bf4a50654bc1e1e61217962698");
 
-#[derive(Clone, PartialEq, Eq, Debug)]
 /// The header of a [`Block`].
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct BlockHeader {
   /// This represents the hardfork number of the block.
   pub major_version: u8,
@@ -60,9 +60,7 @@ impl BlockHeader {
     w.write_all(&self.nonce.to_le_bytes())
   }
 
-  /// Serialize [`Self`].
-  ///
-  /// This allocates and returns a new buffer containing the serialized bytes.
+  /// Serialize [`Self`] into a new byte buffer.
   ///
   /// # Example
   /// ```rust
@@ -125,8 +123,8 @@ impl BlockHeader {
   }
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
 /// Block on the Monero blockchain.
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Block {
   /// The header of this block.
   pub header: BlockHeader,
@@ -197,9 +195,7 @@ impl Block {
     hash
   }
 
-  /// Serialize [`Self`].
-  ///
-  /// This allocates and returns a new buffer containing the serialized bytes.
+  /// Serialize [`Self`] into a new byte buffer.
   pub fn serialize(&self) -> Vec<u8> {
     let mut serialized = vec![];
     self.write(&mut serialized).unwrap();

--- a/coins/monero/src/lib.rs
+++ b/coins/monero/src/lib.rs
@@ -93,19 +93,34 @@ pub(crate) fn BASEPOINT_PRECOMP() -> &'static VartimeEdwardsPrecomputation {
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Zeroize)]
 #[allow(non_camel_case_types)]
 pub enum Protocol {
+  /// Version 14.
   v14,
+  /// Version 16.
   v16,
+  /// A custom version with customized properties.
   Custom {
+    /// See [`Self::ring_len`].
     ring_len: usize,
+    /// See [`Self::bp_plus`].
     bp_plus: bool,
+    /// See [`Self::optimal_rct_type`].
     optimal_rct_type: RctType,
+    /// See [`Self::view_tags`].
     view_tags: bool,
+    /// See [`Self::v16_fee`].
     v16_fee: bool,
   },
 }
 
 impl Protocol {
   /// Amount of ring members under this protocol version.
+  ///
+  /// # Example
+  /// ```rust
+  /// # use monero_serai::*;
+  /// assert_eq!(Protocol::v14.ring_len(), 11);
+  /// assert_eq!(Protocol::v16.ring_len(), 16);
+  /// ```
   pub fn ring_len(&self) -> usize {
     match self {
       Protocol::v14 => 11,
@@ -117,6 +132,13 @@ impl Protocol {
   /// Whether or not the specified version uses Bulletproofs or Bulletproofs+.
   ///
   /// This method will likely be reworked when versions not using Bulletproofs at all are added.
+  ///
+  /// # Example
+  /// ```rust
+  /// # use monero_serai::*;
+  /// assert_eq!(Protocol::v14.bp_plus(), false);
+  /// assert_eq!(Protocol::v16.bp_plus(), true);
+  /// ```
   pub fn bp_plus(&self) -> bool {
     match self {
       Protocol::v14 => false,
@@ -125,6 +147,14 @@ impl Protocol {
     }
   }
 
+  /// The optimal RingCT type for this version.
+  ///
+  /// # Example
+  /// ```rust
+  /// # use monero_serai::{*, ringct::*};
+  /// assert_eq!(Protocol::v14.optimal_rct_type(), RctType::Clsag);
+  /// assert_eq!(Protocol::v16.optimal_rct_type(), RctType::BulletproofsPlus);
+  /// ```
   // TODO: Make this an Option when we support pre-RCT protocols
   pub fn optimal_rct_type(&self) -> RctType {
     match self {
@@ -135,6 +165,13 @@ impl Protocol {
   }
 
   /// Whether or not the specified version uses view tags.
+  ///
+  /// # Example
+  /// ```rust
+  /// # use monero_serai::{*, ringct::*};
+  /// assert_eq!(Protocol::v14.view_tags(), false);
+  /// assert_eq!(Protocol::v16.view_tags(), true);
+  /// ```
   pub fn view_tags(&self) -> bool {
     match self {
       Protocol::v14 => false,
@@ -145,6 +182,13 @@ impl Protocol {
 
   /// Whether or not the specified version uses the fee algorithm from Monero
   /// hard fork version 16 (released in v18 binaries).
+  ///
+  /// # Example
+  /// ```rust
+  /// # use monero_serai::{*, ringct::*};
+  /// assert_eq!(Protocol::v14.v16_fee(), false);
+  /// assert_eq!(Protocol::v16.v16_fee(), true);
+  /// ```
   pub fn v16_fee(&self) -> bool {
     match self {
       Protocol::v14 => false,
@@ -206,11 +250,15 @@ impl Protocol {
   }
 }
 
-/// Transparent structure representing a Pedersen commitment's contents.
+/// Transparent structure representing a [https://web.getmonero.org/resources/moneropedia/pedersen-commitment.html]()'s contents.
 #[allow(non_snake_case)]
 #[derive(Clone, PartialEq, Eq, Zeroize, ZeroizeOnDrop)]
 pub struct Commitment {
+  /// The value used to mask the `amount`.
   pub mask: Scalar,
+  /// The value being masked.
+  ///
+  /// In Monero's case, this is the amount of XMR in atomic units.
   pub amount: u64,
 }
 
@@ -226,6 +274,7 @@ impl Commitment {
     Commitment { mask: Scalar::ONE, amount: 0 }
   }
 
+  /// Create a new [`Self`].
   pub fn new(mask: Scalar, amount: u64) -> Commitment {
     Commitment { mask, amount }
   }

--- a/coins/monero/src/lib.rs
+++ b/coins/monero/src/lib.rs
@@ -51,8 +51,26 @@ pub mod wallet;
 #[cfg(test)]
 mod tests;
 
+/// Default block lock time for transactions.
+///
+/// This is the amount of new blocks that must
+/// pass before a new transaction can be spent.
+///
+/// Equivalent to Monero's [`CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE`](https://github.com/monero-project/monero/blob/c8214782fb2a769c57382a999eaf099691c836e7/src/cryptonote_config.h#L49).
 pub const DEFAULT_LOCK_WINDOW: usize = 10;
+/// Block lock time for coinbase transactions.
+///
+/// This is the amount of new blocks that must
+/// pass before a coinbase/miner transaction can be spent.
+///
+/// Equivalent to Monero's [`CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW`](https://github.com/monero-project/monero/blob/c8214782fb2a769c57382a999eaf099691c836e7/src/cryptonote_config.h#L44).
 pub const COINBASE_LOCK_WINDOW: usize = 60;
+/// Average amount of seconds it takes for a block to be mined.
+///
+/// This is target amount of seconds mining difficulty will adjust to,
+/// i.e. a block will be mined every `BLOCK_TIME` seconds on average.
+///
+/// Equivalent to Monero's [`DIFFICULTY_TARGET_V2`](https://github.com/monero-project/monero/blob/c8214782fb2a769c57382a999eaf099691c836e7/src/cryptonote_config.h#L44).
 pub const BLOCK_TIME: usize = 120;
 
 static INV_EIGHT_CELL: OnceLock<Scalar> = OnceLock::new();

--- a/coins/monero/src/lib.rs
+++ b/coins/monero/src/lib.rs
@@ -250,7 +250,7 @@ impl Protocol {
   }
 }
 
-/// Transparent structure representing a [https://web.getmonero.org/resources/moneropedia/pedersen-commitment.html]()'s contents.
+/// Transparent structure representing a [Pedersen commitment](https://web.getmonero.org/resources/moneropedia/pedersen-commitment.html)'s contents.
 #[allow(non_snake_case)]
 #[derive(Clone, PartialEq, Eq, Zeroize, ZeroizeOnDrop)]
 pub struct Commitment {

--- a/coins/monero/src/ring_signatures.rs
+++ b/coins/monero/src/ring_signatures.rs
@@ -11,6 +11,7 @@ use monero_generators::hash_to_point;
 
 use crate::{serialize::*, hash_to_scalar};
 
+/// A signature within a [`RingSignature`].
 #[derive(Clone, PartialEq, Eq, Debug, Zeroize)]
 pub struct Signature {
   c: Scalar,
@@ -18,23 +19,37 @@ pub struct Signature {
 }
 
 impl Signature {
+  /// Serialize [`Self`] into the writer `w`.
+  ///
+  /// # Errors
+  /// This function returns any errors from the writer itself.
   pub fn write<W: Write>(&self, w: &mut W) -> io::Result<()> {
     write_scalar(&self.c, w)?;
     write_scalar(&self.r, w)?;
     Ok(())
   }
 
+  /// Create [`Self`] from the reader `r`.
+  ///
+  /// # Errors
+  /// This function returns an error if either the reader failed,
+  /// or if the data could not be deserialized into a [`Self`].
   pub fn read<R: Read>(r: &mut R) -> io::Result<Signature> {
     Ok(Signature { c: read_scalar(r)?, r: read_scalar(r)? })
   }
 }
 
+/// A [ring signature](https://en.wikipedia.org/wiki/Ring_signature).
 #[derive(Clone, PartialEq, Eq, Debug, Zeroize)]
 pub struct RingSignature {
   sigs: Vec<Signature>,
 }
 
 impl RingSignature {
+  /// Serialize [`Self`] into the writer `w`.
+  ///
+  /// # Errors
+  /// This function returns any errors from the writer itself.
   pub fn write<W: Write>(&self, w: &mut W) -> io::Result<()> {
     for sig in &self.sigs {
       sig.write(w)?;
@@ -42,6 +57,11 @@ impl RingSignature {
     Ok(())
   }
 
+  /// Create [`Self`] from the reader `r`.
+  ///
+  /// # Errors
+  /// This function returns an error if either the reader failed,
+  /// or if the data could not be deserialized into a [`Self`].
   pub fn read<R: Read>(members: usize, r: &mut R) -> io::Result<RingSignature> {
     Ok(RingSignature { sigs: read_raw_vec(Signature::read, members, r)? })
   }

--- a/coins/monero/src/ringct/clsag/multisig.rs
+++ b/coins/monero/src/ringct/clsag/multisig.rs
@@ -249,7 +249,7 @@ impl Algorithm<Ed25519> for ClsagMultisig {
     let interim = self.interim.as_ref().unwrap();
     let mut clsag = interim.clsag.clone();
     // We produced shares as `r - p x`, yet the signature is `r - p x - c x`
-    // Substract `c x` (saved as `c`) now
+    // Subtract `c x` (saved as `c`) now
     clsag.s[usize::from(self.input().decoys.i)] = sum.0 - interim.c;
     if clsag
       .verify(

--- a/coins/monero/src/ringct/mod.rs
+++ b/coins/monero/src/ringct/mod.rs
@@ -85,13 +85,13 @@ impl RctType {
   ///
   /// ```rust
   /// # use monero_serai::ringct::*;
-  /// assert_eq!(RctType::Null.to_bytes(), 0);
-  /// assert_eq!(RctType::MlsagAggregate.to_bytes(), 1);
-  /// assert_eq!(RctType::MlsagIndividual.to_bytes(), 2);
-  /// assert_eq!(RctType::Bulletproofs.to_bytes(), 3);
-  /// assert_eq!(RctType::BulletproofsCompactAmount.to_bytes(), 4);
-  /// assert_eq!(RctType::Clsag.to_bytes(), 5);
-  /// assert_eq!(RctType::BulletproofsPlus.to_bytes(), 6);
+  /// assert_eq!(RctType::Null.to_byte(), 0);
+  /// assert_eq!(RctType::MlsagAggregate.to_byte(), 1);
+  /// assert_eq!(RctType::MlsagIndividual.to_byte(), 2);
+  /// assert_eq!(RctType::Bulletproofs.to_byte(), 3);
+  /// assert_eq!(RctType::BulletproofsCompactAmount.to_byte(), 4);
+  /// assert_eq!(RctType::Clsag.to_byte(), 5);
+  /// assert_eq!(RctType::BulletproofsPlus.to_byte(), 6);
   /// ```
   pub fn to_byte(self) -> u8 {
     match self {
@@ -109,20 +109,20 @@ impl RctType {
   ///
   /// ```rust
   /// # use monero_serai::ringct::*;
-  /// assert_eq!(RctType::from_bytes(0).unwrap(), RctType::Null);
-  /// assert_eq!(RctType::from_bytes(1).unwrap(), RctType::MlsagAggregate);
-  /// assert_eq!(RctType::from_bytes(2).unwrap(), RctType::MlsagIndividual);
-  /// assert_eq!(RctType::from_bytes(3).unwrap(), RctType::Bulletproofs);
-  /// assert_eq!(RctType::from_bytes(4).unwrap(), RctType::BulletproofsCompactAmount);
-  /// assert_eq!(RctType::from_bytes(5).unwrap(), RctType::Clsag);
-  /// assert_eq!(RctType::from_bytes(6).unwrap(), RctType::BulletproofsPlus);
+  /// assert_eq!(RctType::from_byte(0).unwrap(), RctType::Null);
+  /// assert_eq!(RctType::from_byte(1).unwrap(), RctType::MlsagAggregate);
+  /// assert_eq!(RctType::from_byte(2).unwrap(), RctType::MlsagIndividual);
+  /// assert_eq!(RctType::from_byte(3).unwrap(), RctType::Bulletproofs);
+  /// assert_eq!(RctType::from_byte(4).unwrap(), RctType::BulletproofsCompactAmount);
+  /// assert_eq!(RctType::from_byte(5).unwrap(), RctType::Clsag);
+  /// assert_eq!(RctType::from_byte(6).unwrap(), RctType::BulletproofsPlus);
   /// ```
   ///
   /// # Errors
   /// This function returns [`None`] if the byte representation is invalid.
   /// ```rust
   /// # use monero_serai::ringct::*;
-  /// assert_eq!(RctType::from_bytes(7), None);
+  /// assert_eq!(RctType::from_byte(7), None);
   /// ```
   pub fn from_byte(byte: u8) -> Option<Self> {
     Some(match byte {


### PR DESCRIPTION
Adds more crate documentation to `monero-serai`.

This PR is forked from and is being merged into `monero-tidy`.