### PR TITLE
Rust 1.80

### DIFF
--- a/common/std-shims/Cargo.toml
+++ b/common/std-shims/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-spin = { version = "0.9", default-features = false, features = ["use_ticket_mutex", "once"] }
+spin = { version = "0.9", default-features = false, features = ["use_ticket_mutex", "lazy"] }
 hashbrown = { version = "0.14", default-features = false, features = ["ahash", "inline-more"] }
 
 [features]

--- a/common/std-shims/src/sync.rs
+++ b/common/std-shims/src/sync.rs
@@ -26,27 +26,6 @@ mod mutex_shim {
 pub use mutex_shim::{ShimMutex as Mutex, MutexGuard};
 
 #[cfg(feature = "std")]
-pub use std::sync::OnceLock;
+pub use std::sync::LazyLock;
 #[cfg(not(feature = "std"))]
-mod oncelock_shim {
-  use spin::Once;
-
-  pub struct OnceLock<T>(Once<T>);
-  impl<T> OnceLock<T> {
-    pub const fn new() -> OnceLock<T> {
-      OnceLock(Once::new())
-    }
-    pub fn get(&self) -> Option<&T> {
-      self.0.poll()
-    }
-    pub fn get_mut(&mut self) -> Option<&mut T> {
-      self.0.get_mut()
-    }
-
-    pub fn get_or_init<F: FnOnce() -> T>(&self, f: F) -> &T {
-      self.0.call_once(f)
-    }
-  }
-}
-#[cfg(not(feature = "std"))]
-pub use oncelock_shim::*;
+pub use spin::Lazy as LazyLock;

--- a/networks/bitcoin/Cargo.toml
+++ b/networks/bitcoin/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/networks/bitcoin"
 authors = ["Luke Parker <lukeparker5132@gmail.com>", "Vrx <vrx00@proton.me>"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.80"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/networks/bitcoin/tests/runner.rs
+++ b/networks/bitcoin/tests/runner.rs
@@ -1,14 +1,11 @@
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 
 use bitcoin_serai::rpc::Rpc;
 
 use tokio::sync::Mutex;
 
-static SEQUENTIAL_CELL: OnceLock<Mutex<()>> = OnceLock::new();
-#[allow(non_snake_case)]
-pub fn SEQUENTIAL() -> &'static Mutex<()> {
-  SEQUENTIAL_CELL.get_or_init(|| Mutex::new(()))
-}
+#[allow(dead_code)]
+pub(crate) static SEQUENTIAL: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 #[allow(dead_code)]
 pub(crate) async fn rpc() -> Rpc {
@@ -34,7 +31,7 @@ macro_rules! async_sequential {
     $(
       #[tokio::test]
       async fn $name() {
-        let guard = runner::SEQUENTIAL().lock().await;
+        let guard = runner::SEQUENTIAL.lock().await;
         let local = tokio::task::LocalSet::new();
         local.run_until(async move {
           if let Err(err) = tokio::task::spawn_local(async move { $body }).await {

--- a/networks/monero/Cargo.toml
+++ b/networks/monero/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/networks/monero"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.80"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/networks/monero/io/Cargo.toml
+++ b/networks/monero/io/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/networks/monero/io"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
+rust-version = "1.80"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/networks/monero/primitives/Cargo.toml
+++ b/networks/monero/primitives/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/networks/monero/primitives"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.80"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/networks/monero/ringct/borromean/Cargo.toml
+++ b/networks/monero/ringct/borromean/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/networks/monero/ringct/borromean"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.80"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/networks/monero/ringct/bulletproofs/Cargo.toml
+++ b/networks/monero/ringct/bulletproofs/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/networks/monero/ringct/bulletproofs"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.80"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/networks/monero/ringct/bulletproofs/build.rs
+++ b/networks/monero/ringct/bulletproofs/build.rs
@@ -40,17 +40,14 @@ fn generators(prefix: &'static str, path: &str) {
     .write_all(
       format!(
         "
-          static GENERATORS_CELL: OnceLock<Generators> = OnceLock::new();
-          pub(crate) fn GENERATORS() -> &'static Generators {{
-            GENERATORS_CELL.get_or_init(|| Generators {{
-              G: std_shims::vec![
-                {G_str}
-              ],
-              H: std_shims::vec![
-                {H_str}
-              ],
-            }})
-          }}
+          pub(crate) static GENERATORS: LazyLock<Generators> = LazyLock::new(|| Generators {{
+            G: std_shims::vec![
+              {G_str}
+            ],
+            H: std_shims::vec![
+              {H_str}
+            ],
+          }});
         ",
       )
       .as_bytes(),
@@ -67,12 +64,9 @@ fn generators(prefix: &'static str, path: &str) {
     .write_all(
       format!(
         r#"
-        static GENERATORS_CELL: OnceLock<Generators> = OnceLock::new();
-        pub(crate) fn GENERATORS() -> &'static Generators {{
-          GENERATORS_CELL.get_or_init(|| {{
-            monero_generators::bulletproofs_generators(b"{prefix}")
-          }})
-        }}
+        pub(crate) static GENERATORS: LazyLock<Generators> = LazyLock::new(|| {{
+          monero_generators::bulletproofs_generators(b"{prefix}")
+        }});
       "#,
       )
       .as_bytes(),

--- a/networks/monero/ringct/bulletproofs/src/batch_verifier.rs
+++ b/networks/monero/ringct/bulletproofs/src/batch_verifier.rs
@@ -7,7 +7,7 @@ use curve25519_dalek::{
   edwards::EdwardsPoint,
 };
 
-use monero_generators::{H, Generators};
+use monero_generators::{H as MONERO_H, Generators};
 
 use crate::{original, plus};
 
@@ -57,7 +57,7 @@ pub(crate) struct BulletproofsBatchVerifier(pub(crate) InternalBatchVerifier);
 impl BulletproofsBatchVerifier {
   #[must_use]
   pub(crate) fn verify(self) -> bool {
-    self.0.verify(ED25519_BASEPOINT_POINT, H(), original::GENERATORS())
+    self.0.verify(ED25519_BASEPOINT_POINT, *MONERO_H, &original::GENERATORS)
   }
 }
 
@@ -68,7 +68,7 @@ impl BulletproofsPlusBatchVerifier {
   pub(crate) fn verify(self) -> bool {
     // Bulletproofs+ is written as per the paper, with G for the value and H for the mask
     // Monero uses H for the value and G for the mask
-    self.0.verify(H(), ED25519_BASEPOINT_POINT, plus::GENERATORS())
+    self.0.verify(*MONERO_H, ED25519_BASEPOINT_POINT, &plus::GENERATORS)
   }
 }
 

--- a/networks/monero/ringct/bulletproofs/src/original/inner_product.rs
+++ b/networks/monero/ringct/bulletproofs/src/original/inner_product.rs
@@ -96,13 +96,13 @@ impl IpStatement {
     mut transcript: Scalar,
     witness: IpWitness,
   ) -> Result<IpProof, IpError> {
-    let generators = crate::original::GENERATORS();
+    let generators = &crate::original::GENERATORS;
     let g_bold_slice = &generators.G[.. witness.a.len()];
     let h_bold_slice = &generators.H[.. witness.a.len()];
 
     let (mut g_bold, mut h_bold, u, mut a, mut b) = {
       let IpStatement { h_bold_weights, u } = self;
-      let u = H() * u;
+      let u = *H * u;
 
       // Ensure we have the exact amount of weights
       if h_bold_weights.len() != g_bold_slice.len() {
@@ -218,7 +218,7 @@ impl IpStatement {
     verifier_weight: Scalar,
     proof: IpProof,
   ) -> Result<(), IpError> {
-    let generators = crate::original::GENERATORS();
+    let generators = &crate::original::GENERATORS;
     let g_bold_slice = &generators.G[.. ip_rows];
     let h_bold_slice = &generators.H[.. ip_rows];
 

--- a/networks/monero/ringct/bulletproofs/src/original/mod.rs
+++ b/networks/monero/ringct/bulletproofs/src/original/mod.rs
@@ -1,4 +1,4 @@
-use std_shims::{sync::OnceLock, vec::Vec};
+use std_shims::{sync::LazyLock, vec::Vec};
 
 use rand_core::{RngCore, CryptoRng};
 
@@ -6,7 +6,7 @@ use zeroize::Zeroize;
 
 use curve25519_dalek::{constants::ED25519_BASEPOINT_POINT, Scalar, EdwardsPoint};
 
-use monero_generators::{H, Generators, MAX_COMMITMENTS, COMMITMENT_BITS};
+use monero_generators::{H as MONERO_H, Generators, MAX_COMMITMENTS, COMMITMENT_BITS};
 use monero_primitives::{Commitment, INV_EIGHT, keccak256_to_scalar};
 use crate::{core::multiexp, scalar_vector::ScalarVector, BulletproofsBatchVerifier};
 
@@ -107,7 +107,7 @@ impl<'a> AggregateRangeStatement<'a> {
       None?
     };
 
-    let generators = GENERATORS();
+    let generators = &GENERATORS;
 
     let (mut transcript, _) = self.initial_transcript();
 
@@ -186,7 +186,7 @@ impl<'a> AggregateRangeStatement<'a> {
 
     let tau_1 = Scalar::random(&mut *rng);
     let T1 = {
-      let mut T1_terms = [(t1, H()), (tau_1, ED25519_BASEPOINT_POINT)];
+      let mut T1_terms = [(t1, *MONERO_H), (tau_1, ED25519_BASEPOINT_POINT)];
       for term in &mut T1_terms {
         term.0 *= INV_EIGHT();
       }
@@ -196,7 +196,7 @@ impl<'a> AggregateRangeStatement<'a> {
     };
     let tau_2 = Scalar::random(&mut *rng);
     let T2 = {
-      let mut T2_terms = [(t2, H()), (tau_2, ED25519_BASEPOINT_POINT)];
+      let mut T2_terms = [(t2, *MONERO_H), (tau_2, ED25519_BASEPOINT_POINT)];
       for term in &mut T2_terms {
         term.0 *= INV_EIGHT();
       }

--- a/networks/monero/ringct/bulletproofs/src/plus/mod.rs
+++ b/networks/monero/ringct/bulletproofs/src/plus/mod.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 
-use std_shims::sync::OnceLock;
+use std_shims::sync::LazyLock;
 
 use curve25519_dalek::{constants::ED25519_BASEPOINT_POINT, scalar::Scalar, edwards::EdwardsPoint};
 
@@ -39,7 +39,7 @@ include!(concat!(env!("OUT_DIR"), "/generators_plus.rs"));
 impl BpPlusGenerators {
   #[allow(clippy::new_without_default)]
   pub(crate) fn new() -> Self {
-    let gens = GENERATORS();
+    let gens = &GENERATORS;
     BpPlusGenerators { g_bold: &gens.G, h_bold: &gens.H }
   }
 
@@ -48,7 +48,7 @@ impl BpPlusGenerators {
   }
 
   pub(crate) fn g() -> EdwardsPoint {
-    H()
+    *H
   }
 
   pub(crate) fn h() -> EdwardsPoint {

--- a/networks/monero/ringct/bulletproofs/src/plus/transcript.rs
+++ b/networks/monero/ringct/bulletproofs/src/plus/transcript.rs
@@ -1,4 +1,4 @@
-use std_shims::{sync::OnceLock, vec::Vec};
+use std_shims::{sync::LazyLock, vec::Vec};
 
 use curve25519_dalek::{scalar::Scalar, edwards::EdwardsPoint};
 
@@ -6,15 +6,12 @@ use monero_generators::hash_to_point;
 use monero_primitives::{keccak256, keccak256_to_scalar};
 
 // Monero starts BP+ transcripts with the following constant.
-static TRANSCRIPT_CELL: OnceLock<[u8; 32]> = OnceLock::new();
-pub(crate) fn TRANSCRIPT() -> [u8; 32] {
-  // Why this uses a hash_to_point is completely unknown.
-  *TRANSCRIPT_CELL
-    .get_or_init(|| hash_to_point(keccak256(b"bulletproof_plus_transcript")).compress().to_bytes())
-}
+// Why this uses a hash_to_point is completely unknown.
+pub(crate) static TRANSCRIPT: LazyLock<[u8; 32]> =
+  LazyLock::new(|| hash_to_point(keccak256(b"bulletproof_plus_transcript")).compress().to_bytes());
 
 pub(crate) fn initial_transcript(commitments: core::slice::Iter<'_, EdwardsPoint>) -> Scalar {
   let commitments_hash =
     keccak256_to_scalar(commitments.flat_map(|V| V.compress().to_bytes()).collect::<Vec<_>>());
-  keccak256_to_scalar([TRANSCRIPT().as_ref(), &commitments_hash.to_bytes()].concat())
+  keccak256_to_scalar([TRANSCRIPT.as_ref(), &commitments_hash.to_bytes()].concat())
 }

--- a/networks/monero/ringct/bulletproofs/src/tests/original/inner_product.rs
+++ b/networks/monero/ringct/bulletproofs/src/tests/original/inner_product.rs
@@ -35,12 +35,12 @@ fn test_zero_inner_product() {
 #[test]
 fn test_inner_product() {
   // P = sum(g_bold * a, h_bold * b, g * u * <a, b>)
-  let generators = GENERATORS();
+  let generators = &GENERATORS;
   let mut verifier = BulletproofsBatchVerifier::default();
   verifier.0.g_bold = vec![Scalar::ZERO; 32];
   verifier.0.h_bold = vec![Scalar::ZERO; 32];
   for i in [1, 2, 4, 8, 16, 32] {
-    let g = H();
+    let g = *H;
     let mut g_bold = vec![];
     let mut h_bold = vec![];
     for i in 0 .. i {

--- a/networks/monero/ringct/clsag/Cargo.toml
+++ b/networks/monero/ringct/clsag/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/networks/monero/ringct/clsag"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.80"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/networks/monero/ringct/mlsag/Cargo.toml
+++ b/networks/monero/ringct/mlsag/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/networks/monero/ringct/mlsag"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.80"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/networks/monero/ringct/mlsag/src/lib.rs
+++ b/networks/monero/ringct/mlsag/src/lib.rs
@@ -203,7 +203,7 @@ impl AggregateRingMatrixBuilder {
     AggregateRingMatrixBuilder {
       key_ring: vec![],
       amounts_ring: vec![],
-      sum_out: commitments.iter().sum::<EdwardsPoint>() + (H() * Scalar::from(fee)),
+      sum_out: commitments.iter().sum::<EdwardsPoint>() + (*H * Scalar::from(fee)),
     }
   }
 

--- a/networks/monero/rpc/Cargo.toml
+++ b/networks/monero/rpc/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/networks/monero/rpc"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.80"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/networks/monero/rpc/simple-request/Cargo.toml
+++ b/networks/monero/rpc/simple-request/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/networks/monero/rpc/simple-request"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.80"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/networks/monero/rpc/simple-request/tests/tests.rs
+++ b/networks/monero/rpc/simple-request/tests/tests.rs
@@ -1,4 +1,4 @@
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 use tokio::sync::Mutex;
 
 use monero_address::{Network, MoneroAddress};
@@ -8,7 +8,7 @@ use monero_address::{Network, MoneroAddress};
 // Accordingly, we test monero-rpc here (implicitly testing the simple-request transport)
 use monero_simple_request_rpc::*;
 
-static SEQUENTIAL: OnceLock<Mutex<()>> = OnceLock::new();
+static SEQUENTIAL: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 const ADDRESS: &str =
   "4B33mFPMq6mKi7Eiyd5XuyKRVMGVZz1Rqb9ZTyGApXW5d1aT7UBDZ89ewmnWFkzJ5wPd2SFbn313vCT8a4E2Qf4KQH4pNey";
@@ -17,7 +17,7 @@ const ADDRESS: &str =
 async fn test_rpc() {
   use monero_rpc::Rpc;
 
-  let guard = SEQUENTIAL.get_or_init(|| Mutex::new(())).lock().await;
+  let guard = SEQUENTIAL.lock().await;
 
   let rpc =
     SimpleRequestRpc::new("http://serai:seraidex@127.0.0.1:18081".to_string()).await.unwrap();
@@ -68,7 +68,7 @@ async fn test_rpc() {
 async fn test_decoy_rpc() {
   use monero_rpc::{Rpc, DecoyRpc};
 
-  let guard = SEQUENTIAL.get_or_init(|| Mutex::new(())).lock().await;
+  let guard = SEQUENTIAL.lock().await;
 
   let rpc =
     SimpleRequestRpc::new("http://serai:seraidex@127.0.0.1:18081".to_string()).await.unwrap();
@@ -122,7 +122,7 @@ async fn test_decoy_rpc() {
 async fn test_zero_out_tx_o_indexes() {
   use monero_rpc::Rpc;
 
-  let guard = SEQUENTIAL.get_or_init(|| Mutex::new(())).lock().await;
+  let guard = SEQUENTIAL.lock().await;
 
   let rpc = SimpleRequestRpc::new("https://node.sethforprivacy.com".to_string()).await.unwrap();
 

--- a/networks/monero/verify-chain/Cargo.toml
+++ b/networks/monero/verify-chain/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/networks/monero/verify-chain"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.80"
 publish = false
 
 [package.metadata.docs.rs]

--- a/networks/monero/wallet/Cargo.toml
+++ b/networks/monero/wallet/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/networks/monero/wallet"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.80"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/networks/monero/wallet/address/Cargo.toml
+++ b/networks/monero/wallet/address/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/networks/monero/wallet/address"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.80"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/networks/monero/wallet/polyseed/Cargo.toml
+++ b/networks/monero/wallet/polyseed/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/networks/monero/wallet/polyseed"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.80"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/networks/monero/wallet/seed/Cargo.toml
+++ b/networks/monero/wallet/seed/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/networks/monero/wallet/seed"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.80"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/networks/monero/wallet/seed/src/tests.rs
+++ b/networks/monero/wallet/seed/src/tests.rs
@@ -183,7 +183,7 @@ fn test_original_seed() {
   for vector in vectors {
     fn trim_by_lang(word: &str, lang: Language) -> String {
       if lang != Language::DeprecatedEnglish {
-        word.chars().take(LANGUAGES()[&lang].unique_prefix_length).collect()
+        word.chars().take(LANGUAGES[&lang].unique_prefix_length).collect()
       } else {
         word.to_string()
       }

--- a/networks/monero/wallet/util/Cargo.toml
+++ b/networks/monero/wallet/util/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/networks/monero/wallet/util"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.80"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/orchestration/runtime/Dockerfile
+++ b/orchestration/runtime/Dockerfile
@@ -1,5 +1,5 @@
-# rust:1.79.0-slim-bookworm as of June 14th, 2024 (GMT)
-FROM --platform=linux/amd64 rust@sha256:fa189cd885739dd17fc6bb4e132687fce43f2bf42983c0ac39b60e4943201e9c as deterministic
+# rust:1.80.0-slim-bookworm as of July 27th, 2024 (GMT)
+FROM --platform=linux/amd64 rust@sha256:37e6f90f98b3afd15c2526d7abb257a1f4cb7d49808fe3729d9d62020b07b544 as deterministic
 
 # Move to a Debian package snapshot
 RUN rm -rf /etc/apt/sources.list.d/debian.sources && \

--- a/orchestration/src/main.rs
+++ b/orchestration/src/main.rs
@@ -146,7 +146,7 @@ fn build_serai_service(prelude: &str, release: bool, features: &str, package: &s
 
   format!(
     r#"
-FROM rust:1.79-slim-bookworm as builder
+FROM rust:1.80-slim-bookworm as builder
 
 COPY --from=mimalloc-debian libmimalloc.so /usr/lib
 RUN echo "/usr/lib/libmimalloc.so" >> /etc/ld.so.preload

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.79"
+channel = "1.80"
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"
 components = ["rust-src", "rustfmt", "clippy"]


### PR DESCRIPTION
Preserves the fn accessors within the Monero crates so that we can use statics in some cfgs yet not all (in order to provide support for more low-memory devices) with the exception of `H` (which truly should be cached).