### PR TITLE
add specific network/coin/balance types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8393,6 +8393,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-std",
  "zeroize",
 ]
 

--- a/coordinator/src/cosign_evaluator.rs
+++ b/coordinator/src/cosign_evaluator.rs
@@ -204,14 +204,12 @@ impl<D: Db> CosignEvaluator<D> {
 
       let mut total_stake = 0;
       let mut total_on_distinct_chain = 0;
-      // TODO: `network` isn't being used in the following loop. is this a bug?
-      // why are we going through the networks here?
-      for _network in EXTERNAL_NETWORKS {
+      for network in EXTERNAL_NETWORKS {
         // Get the current set for this network
         let set_with_keys = {
           let mut res;
           while {
-            res = set_with_keys_fn(&serai, cosign.network).await;
+            res = set_with_keys_fn(&serai, network).await;
             res.is_err()
           } {
             log::error!(

--- a/coordinator/src/cosign_evaluator.rs
+++ b/coordinator/src/cosign_evaluator.rs
@@ -12,9 +12,9 @@ use tokio::{
 use borsh::BorshSerialize;
 use sp_application_crypto::RuntimePublic;
 use serai_client::{
-  primitives::{NETWORKS, NetworkId, Signature},
-  validator_sets::primitives::{Session, ValidatorSet},
-  SeraiError, TemporalSerai, Serai,
+  primitives::{ExternalNetworkId, NetworkId, Signature, EXTERNAL_NETWORKS, NETWORKS},
+  validator_sets::primitives::{ExternalValidatorSet, Session},
+  Serai, SeraiError, TemporalSerai,
 };
 
 use serai_db::{Get, DbTxn, Db, create_db};
@@ -28,17 +28,17 @@ use crate::{
 
 create_db! {
   CosignDb {
-    ReceivedCosign: (set: ValidatorSet, block: [u8; 32]) -> CosignedBlock,
-    LatestCosign: (network: NetworkId) -> CosignedBlock,
-    DistinctChain: (set: ValidatorSet) -> (),
+    ReceivedCosign: (set: ExternalValidatorSet, block: [u8; 32]) -> CosignedBlock,
+    LatestCosign: (network: ExternalNetworkId) -> CosignedBlock,
+    DistinctChain: (set: ExternalValidatorSet) -> (),
   }
 }
 
 pub struct CosignEvaluator<D: Db> {
   db: Mutex<D>,
   serai: Arc<Serai>,
-  stakes: RwLock<Option<HashMap<NetworkId, u64>>>,
-  latest_cosigns: RwLock<HashMap<NetworkId, CosignedBlock>>,
+  stakes: RwLock<Option<HashMap<ExternalNetworkId, u64>>>,
+  latest_cosigns: RwLock<HashMap<ExternalNetworkId, CosignedBlock>>,
 }
 
 impl<D: Db> CosignEvaluator<D> {
@@ -79,7 +79,7 @@ impl<D: Db> CosignEvaluator<D> {
     let serai = self.serai.as_of_latest_finalized_block().await?;
 
     let mut stakes = HashMap::new();
-    for network in NETWORKS {
+    for network in EXTERNAL_NETWORKS {
       // Use if this network has published a Batch for a short-circuit of if they've ever set a key
       let set_key = serai.in_instructions().last_batch_for_network(network).await?.is_some();
       if set_key {
@@ -87,7 +87,7 @@ impl<D: Db> CosignEvaluator<D> {
           network,
           serai
             .validator_sets()
-            .total_allocated_stake(network)
+            .total_allocated_stake(network.into())
             .await?
             .expect("network which published a batch didn't have a stake set")
             .0,
@@ -126,9 +126,9 @@ impl<D: Db> CosignEvaluator<D> {
 
     async fn set_with_keys_fn(
       serai: &TemporalSerai<'_>,
-      network: NetworkId,
-    ) -> Result<Option<ValidatorSet>, SeraiError> {
-      let Some(latest_session) = serai.validator_sets().session(network).await? else {
+      network: ExternalNetworkId,
+    ) -> Result<Option<ExternalValidatorSet>, SeraiError> {
+      let Some(latest_session) = serai.validator_sets().session(network.into()).await? else {
         log::warn!("received cosign from {:?}, which doesn't yet have a session", network);
         return Ok(None);
       };
@@ -136,13 +136,13 @@ impl<D: Db> CosignEvaluator<D> {
       Ok(Some(
         if serai
           .validator_sets()
-          .keys(ValidatorSet { network, session: prior_session })
+          .keys(ExternalValidatorSet { network, session: prior_session })
           .await?
           .is_some()
         {
-          ValidatorSet { network, session: prior_session }
+          ExternalValidatorSet { network, session: prior_session }
         } else {
-          ValidatorSet { network, session: latest_session }
+          ExternalValidatorSet { network, session: latest_session }
         },
       ))
     }
@@ -231,7 +231,8 @@ impl<D: Db> CosignEvaluator<D> {
           let stake = {
             let mut res;
             while {
-              res = serai.validator_sets().total_allocated_stake(set_with_keys.network).await;
+              res =
+                serai.validator_sets().total_allocated_stake(set_with_keys.network.into()).await;
               res.is_err()
             } {
               log::error!(
@@ -271,7 +272,7 @@ impl<D: Db> CosignEvaluator<D> {
   #[allow(clippy::new_ret_no_self)]
   pub fn new<P: P2p>(db: D, p2p: P, serai: Arc<Serai>) -> mpsc::UnboundedSender<CosignedBlock> {
     let mut latest_cosigns = HashMap::new();
-    for network in NETWORKS {
+    for network in EXTERNAL_NETWORKS {
       if let Some(cosign) = LatestCosign::get(&db, network) {
         latest_cosigns.insert(network, cosign);
       }

--- a/coordinator/src/cosign_evaluator.rs
+++ b/coordinator/src/cosign_evaluator.rs
@@ -12,7 +12,7 @@ use tokio::{
 use borsh::BorshSerialize;
 use sp_application_crypto::RuntimePublic;
 use serai_client::{
-  primitives::{ExternalNetworkId, NetworkId, Signature, EXTERNAL_NETWORKS, NETWORKS},
+  primitives::{ExternalNetworkId, Signature, EXTERNAL_NETWORKS},
   validator_sets::primitives::{ExternalValidatorSet, Session},
   Serai, SeraiError, TemporalSerai,
 };
@@ -204,11 +204,9 @@ impl<D: Db> CosignEvaluator<D> {
 
       let mut total_stake = 0;
       let mut total_on_distinct_chain = 0;
-      for network in NETWORKS {
-        if network == NetworkId::Serai {
-          continue;
-        }
-
+      // TODO: `network` isn't being used in the following loop. is this a bug?
+      // why are we going through the networks here?
+      for _network in EXTERNAL_NETWORKS {
         // Get the current set for this network
         let set_with_keys = {
           let mut res;

--- a/coordinator/src/processors.rs
+++ b/coordinator/src/processors.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use serai_client::primitives::NetworkId;
+use serai_client::primitives::ExternalNetworkId;
 use processor_messages::{ProcessorMessage, CoordinatorMessage};
 
 use message_queue::{Service, Metadata, client::MessageQueue};
@@ -8,27 +8,27 @@ use message_queue::{Service, Metadata, client::MessageQueue};
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Message {
   pub id: u64,
-  pub network: NetworkId,
+  pub network: ExternalNetworkId,
   pub msg: ProcessorMessage,
 }
 
 #[async_trait::async_trait]
 pub trait Processors: 'static + Send + Sync + Clone {
-  async fn send(&self, network: NetworkId, msg: impl Send + Into<CoordinatorMessage>);
-  async fn recv(&self, network: NetworkId) -> Message;
+  async fn send(&self, network: ExternalNetworkId, msg: impl Send + Into<CoordinatorMessage>);
+  async fn recv(&self, network: ExternalNetworkId) -> Message;
   async fn ack(&self, msg: Message);
 }
 
 #[async_trait::async_trait]
 impl Processors for Arc<MessageQueue> {
-  async fn send(&self, network: NetworkId, msg: impl Send + Into<CoordinatorMessage>) {
+  async fn send(&self, network: ExternalNetworkId, msg: impl Send + Into<CoordinatorMessage>) {
     let msg: CoordinatorMessage = msg.into();
     let metadata =
       Metadata { from: self.service, to: Service::Processor(network), intent: msg.intent() };
     let msg = borsh::to_vec(&msg).unwrap();
     self.queue(metadata, msg).await;
   }
-  async fn recv(&self, network: NetworkId) -> Message {
+  async fn recv(&self, network: ExternalNetworkId) -> Message {
     let msg = self.next(Service::Processor(network)).await;
     assert_eq!(msg.from, Service::Processor(network));
 

--- a/coordinator/src/substrate/db.rs
+++ b/coordinator/src/substrate/db.rs
@@ -1,4 +1,4 @@
-use serai_client::primitives::NetworkId;
+use serai_client::primitives::ExternalNetworkId;
 
 pub use serai_db::*;
 
@@ -9,7 +9,7 @@ mod inner_db {
     SubstrateDb {
       NextBlock: () -> u64,
       HandledEvent: (block: [u8; 32]) -> u32,
-      BatchInstructionsHashDb: (network: NetworkId, id: u32) -> [u8; 32]
+      BatchInstructionsHashDb: (network: ExternalNetworkId, id: u32) -> [u8; 32]
     }
   );
 }

--- a/coordinator/src/tests/mod.rs
+++ b/coordinator/src/tests/mod.rs
@@ -4,7 +4,7 @@ use std::{
   collections::{VecDeque, HashSet, HashMap},
 };
 
-use serai_client::{primitives::NetworkId, validator_sets::primitives::ValidatorSet};
+use serai_client::{primitives::ExternalNetworkId, validator_sets::primitives::ExternalValidatorSet};
 
 use processor_messages::CoordinatorMessage;
 
@@ -20,7 +20,7 @@ use crate::{
 pub mod tributary;
 
 #[derive(Clone)]
-pub struct MemProcessors(pub Arc<RwLock<HashMap<NetworkId, VecDeque<CoordinatorMessage>>>>);
+pub struct MemProcessors(pub Arc<RwLock<HashMap<ExternalNetworkId, VecDeque<CoordinatorMessage>>>>);
 impl MemProcessors {
   #[allow(clippy::new_without_default)]
   pub fn new() -> MemProcessors {
@@ -30,12 +30,12 @@ impl MemProcessors {
 
 #[async_trait::async_trait]
 impl Processors for MemProcessors {
-  async fn send(&self, network: NetworkId, msg: impl Send + Into<CoordinatorMessage>) {
+  async fn send(&self, network: ExternalNetworkId, msg: impl Send + Into<CoordinatorMessage>) {
     let mut processors = self.0.write().await;
     let processor = processors.entry(network).or_insert_with(VecDeque::new);
     processor.push_back(msg.into());
   }
-  async fn recv(&self, _: NetworkId) -> Message {
+  async fn recv(&self, _: ExternalNetworkId) -> Message {
     todo!()
   }
   async fn ack(&self, _: Message) {
@@ -65,8 +65,8 @@ impl LocalP2p {
 impl P2p for LocalP2p {
   type Id = usize;
 
-  async fn subscribe(&self, _set: ValidatorSet, _genesis: [u8; 32]) {}
-  async fn unsubscribe(&self, _set: ValidatorSet, _genesis: [u8; 32]) {}
+  async fn subscribe(&self, _set: ExternalValidatorSet, _genesis: [u8; 32]) {}
+  async fn unsubscribe(&self, _set: ExternalValidatorSet, _genesis: [u8; 32]) {}
 
   async fn send_raw(&self, to: Self::Id, msg: Vec<u8>) {
     let mut msg_ref = msg.as_slice();

--- a/coordinator/src/tests/tributary/chain.rs
+++ b/coordinator/src/tests/tributary/chain.rs
@@ -15,8 +15,8 @@ use ciphersuite::{
 use sp_application_crypto::sr25519;
 use borsh::BorshDeserialize;
 use serai_client::{
-  primitives::NetworkId,
-  validator_sets::primitives::{Session, ValidatorSet},
+  primitives::ExternalNetworkId,
+  validator_sets::primitives::{ExternalValidatorSet, Session},
 };
 
 use tokio::time::sleep;
@@ -50,7 +50,7 @@ pub fn new_spec<R: RngCore + CryptoRng>(
 
   let start_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs();
 
-  let set = ValidatorSet { session: Session(0), network: NetworkId::Bitcoin };
+  let set = ExternalValidatorSet { session: Session(0), network: ExternalNetworkId::Bitcoin };
 
   let set_participants = keys
     .iter()

--- a/coordinator/src/tests/tributary/dkg.rs
+++ b/coordinator/src/tests/tributary/dkg.rs
@@ -10,7 +10,7 @@ use frost::Participant;
 use sp_runtime::traits::Verify;
 use serai_client::{
   primitives::{SeraiAddress, Signature},
-  validator_sets::primitives::{ValidatorSet, KeyPair},
+  validator_sets::primitives::{ExternalValidatorSet, KeyPair},
 };
 
 use tokio::time::sleep;
@@ -350,7 +350,7 @@ async fn dkg_test() {
     async fn publish_set_keys(
       &self,
       _db: &(impl Sync + Get),
-      set: ValidatorSet,
+      set: ExternalValidatorSet,
       removed: Vec<SeraiAddress>,
       key_pair: KeyPair,
       signature: Signature,
@@ -362,7 +362,7 @@ async fn dkg_test() {
         &*serai_client::validator_sets::primitives::set_keys_message(&set, &[], &key_pair),
         &serai_client::Public(
           frost::dkg::musig::musig_key::<Ristretto>(
-            &serai_client::validator_sets::primitives::musig_context(set),
+            &serai_client::validator_sets::primitives::musig_context(set.into()),
             &self.spec.validators().into_iter().map(|(validator, _)| validator).collect::<Vec<_>>()
           )
           .unwrap()

--- a/coordinator/src/tests/tributary/mod.rs
+++ b/coordinator/src/tests/tributary/mod.rs
@@ -7,7 +7,7 @@ use ciphersuite::{group::Group, Ciphersuite, Ristretto};
 use scale::{Encode, Decode};
 use serai_client::{
   primitives::{SeraiAddress, Signature},
-  validator_sets::primitives::{MAX_KEY_SHARES_PER_SET, ValidatorSet, KeyPair},
+  validator_sets::primitives::{ExternalValidatorSet, KeyPair, MAX_KEY_SHARES_PER_SET},
 };
 use processor_messages::coordinator::SubstrateSignableId;
 
@@ -31,7 +31,7 @@ impl PublishSeraiTransaction for () {
   async fn publish_set_keys(
     &self,
     _db: &(impl Sync + serai_db::Get),
-    _set: ValidatorSet,
+    _set: ExternalValidatorSet,
     _removed: Vec<SeraiAddress>,
     _key_pair: KeyPair,
     _signature: Signature,

--- a/coordinator/src/tributary/db.rs
+++ b/coordinator/src/tributary/db.rs
@@ -6,7 +6,7 @@ use borsh::{BorshSerialize, BorshDeserialize};
 use ciphersuite::{group::GroupEncoding, Ciphersuite, Ristretto};
 use frost::Participant;
 
-use serai_client::validator_sets::primitives::{KeyPair, ValidatorSet};
+use serai_client::validator_sets::primitives::{KeyPair, ExternalValidatorSet};
 
 use processor_messages::coordinator::SubstrateSignableId;
 
@@ -46,7 +46,7 @@ pub enum Accumulation {
 create_db!(
   Tributary {
     SeraiBlockNumber: (hash: [u8; 32]) -> u64,
-    SeraiDkgCompleted: (spec: ValidatorSet) -> [u8; 32],
+    SeraiDkgCompleted: (spec: ExternalValidatorSet) -> [u8; 32],
 
     TributaryBlockNumber: (block: [u8; 32]) -> u32,
     LastHandledBlock: (genesis: [u8; 32]) -> [u8; 32],
@@ -80,7 +80,7 @@ create_db!(
     SlashReports: (genesis: [u8; 32], signer: [u8; 32]) -> Vec<u32>,
     SlashReported: (genesis: [u8; 32]) -> u16,
     SlashReportCutOff: (genesis: [u8; 32]) -> u64,
-    SlashReport: (set: ValidatorSet) -> Vec<([u8; 32], u32)>,
+    SlashReport: (set: ExternalValidatorSet) -> Vec<([u8; 32], u32)>,
   }
 );
 

--- a/coordinator/src/tributary/mod.rs
+++ b/coordinator/src/tributary/mod.rs
@@ -1,6 +1,6 @@
 use ciphersuite::{group::GroupEncoding, Ciphersuite, Ristretto};
 
-use serai_client::validator_sets::primitives::ValidatorSet;
+use serai_client::validator_sets::primitives::ExternalValidatorSet;
 
 use tributary::{
   ReadWrite,
@@ -40,7 +40,7 @@ pub fn removed_as_of_dkg_attempt(
 
 pub fn removed_as_of_set_keys(
   getter: &impl Get,
-  set: ValidatorSet,
+  set: ExternalValidatorSet,
   genesis: [u8; 32],
 ) -> Option<Vec<<Ristretto as Ciphersuite>::G>> {
   // SeraiDkgCompleted has the key placed on-chain.

--- a/coordinator/src/tributary/scanner.rs
+++ b/coordinator/src/tributary/scanner.rs
@@ -10,7 +10,7 @@ use tokio::sync::broadcast;
 use scale::{Encode, Decode};
 use serai_client::{
   primitives::{SeraiAddress, Signature},
-  validator_sets::primitives::{KeyPair, ValidatorSet},
+  validator_sets::primitives::{ExternalValidatorSet, KeyPair},
   Serai,
 };
 
@@ -38,7 +38,7 @@ pub enum RecognizedIdType {
 pub trait RIDTrait {
   async fn recognized_id(
     &self,
-    set: ValidatorSet,
+    set: ExternalValidatorSet,
     genesis: [u8; 32],
     kind: RecognizedIdType,
     id: Vec<u8>,
@@ -47,12 +47,12 @@ pub trait RIDTrait {
 #[async_trait::async_trait]
 impl<
     FRid: Send + Future<Output = ()>,
-    F: Sync + Fn(ValidatorSet, [u8; 32], RecognizedIdType, Vec<u8>) -> FRid,
+    F: Sync + Fn(ExternalValidatorSet, [u8; 32], RecognizedIdType, Vec<u8>) -> FRid,
   > RIDTrait for F
 {
   async fn recognized_id(
     &self,
-    set: ValidatorSet,
+    set: ExternalValidatorSet,
     genesis: [u8; 32],
     kind: RecognizedIdType,
     id: Vec<u8>,
@@ -66,7 +66,7 @@ pub trait PublishSeraiTransaction {
   async fn publish_set_keys(
     &self,
     db: &(impl Sync + Get),
-    set: ValidatorSet,
+    set: ExternalValidatorSet,
     removed: Vec<SeraiAddress>,
     key_pair: KeyPair,
     signature: Signature,
@@ -86,7 +86,7 @@ mod impl_pst_for_serai {
       async fn publish(
         serai: &Serai,
         db: &impl Get,
-        set: ValidatorSet,
+        set: ExternalValidatorSet,
         tx: serai_client::Transaction,
         meta: $Meta,
       ) -> bool {
@@ -128,7 +128,7 @@ mod impl_pst_for_serai {
     async fn publish_set_keys(
       &self,
       db: &(impl Sync + Get),
-      set: ValidatorSet,
+      set: ExternalValidatorSet,
       removed: Vec<SeraiAddress>,
       key_pair: KeyPair,
       signature: Signature,
@@ -140,7 +140,7 @@ mod impl_pst_for_serai {
         key_pair,
         signature,
       );
-      async fn check(serai: SeraiValidatorSets<'_>, set: ValidatorSet, (): ()) -> bool {
+      async fn check(serai: SeraiValidatorSets<'_>, set: ExternalValidatorSet, (): ()) -> bool {
         if matches!(serai.keys(set).await, Ok(Some(_))) {
           log::info!("another coordinator set key pair for {:?}", set);
           return true;

--- a/coordinator/src/tributary/signing_protocol.rs
+++ b/coordinator/src/tributary/signing_protocol.rs
@@ -119,7 +119,7 @@ impl<T: DbTxn, C: Encode> SigningProtocol<'_, T, C> {
 
     let algorithm = Schnorrkel::new(b"substrate");
     let keys: ThresholdKeys<Ristretto> =
-      musig(&musig_context(self.spec.set()), self.key, participants)
+      musig(&musig_context(self.spec.set().into()), self.key, participants)
         .expect("signing for a set we aren't in/validator present multiple times")
         .into();
 

--- a/coordinator/src/tributary/spec.rs
+++ b/coordinator/src/tributary/spec.rs
@@ -9,7 +9,7 @@ use frost::Participant;
 use scale::Encode;
 use borsh::{BorshSerialize, BorshDeserialize};
 
-use serai_client::{primitives::PublicKey, validator_sets::primitives::ValidatorSet};
+use serai_client::{primitives::PublicKey, validator_sets::primitives::ExternalValidatorSet};
 
 fn borsh_serialize_validators<W: io::Write>(
   validators: &Vec<(<Ristretto as Ciphersuite>::G, u16)>,
@@ -43,7 +43,7 @@ fn borsh_deserialize_validators<R: io::Read>(
 pub struct TributarySpec {
   serai_block: [u8; 32],
   start_time: u64,
-  set: ValidatorSet,
+  set: ExternalValidatorSet,
   #[borsh(
     serialize_with = "borsh_serialize_validators",
     deserialize_with = "borsh_deserialize_validators"
@@ -55,7 +55,7 @@ impl TributarySpec {
   pub fn new(
     serai_block: [u8; 32],
     start_time: u64,
-    set: ValidatorSet,
+    set: ExternalValidatorSet,
     set_participants: Vec<(PublicKey, u16)>,
   ) -> TributarySpec {
     let mut validators = vec![];
@@ -68,7 +68,7 @@ impl TributarySpec {
     Self { serai_block, start_time, set, validators }
   }
 
-  pub fn set(&self) -> ValidatorSet {
+  pub fn set(&self) -> ExternalValidatorSet {
     self.set
   }
 

--- a/message-queue/src/main.rs
+++ b/message-queue/src/main.rs
@@ -6,7 +6,7 @@ pub(crate) use std::{
 pub(crate) use ciphersuite::{group::GroupEncoding, Ciphersuite, Ristretto};
 pub(crate) use schnorr_signatures::SchnorrSignature;
 
-pub(crate) use serai_primitives::NetworkId;
+pub(crate) use serai_primitives::ExternalNetworkId;
 
 pub(crate) use tokio::{
   io::{AsyncReadExt, AsyncWriteExt},
@@ -193,10 +193,7 @@ async fn main() {
     KEYS.write().unwrap().insert(service, key);
     let mut queues = QUEUES.write().unwrap();
     if service == Service::Coordinator {
-      for network in serai_primitives::NETWORKS {
-        if network == NetworkId::Serai {
-          continue;
-        }
+      for network in serai_primitives::EXTERNAL_NETWORKS {
         queues.insert(
           (service, Service::Processor(network)),
           RwLock::new(Queue(db.clone(), service, Service::Processor(network))),
@@ -210,17 +207,13 @@ async fn main() {
     }
   };
 
-  // Make queues for each NetworkId, other than Serai
-  for network in serai_primitives::NETWORKS {
-    if network == NetworkId::Serai {
-      continue;
-    }
+  // Make queues for each ExternalNetworkId
+  for network in serai_primitives::EXTERNAL_NETWORKS {
     // Use a match so we error if the list of NetworkIds changes
     let Some(key) = read_key(match network {
-      NetworkId::Serai => unreachable!(),
-      NetworkId::Bitcoin => "BITCOIN_KEY",
-      NetworkId::Ethereum => "ETHEREUM_KEY",
-      NetworkId::Monero => "MONERO_KEY",
+      ExternalNetworkId::Bitcoin => "BITCOIN_KEY",
+      ExternalNetworkId::Ethereum => "ETHEREUM_KEY",
+      ExternalNetworkId::Monero => "MONERO_KEY",
     }) else {
       continue;
     };

--- a/message-queue/src/messages.rs
+++ b/message-queue/src/messages.rs
@@ -3,11 +3,11 @@ use ciphersuite::{group::GroupEncoding, Ciphersuite, Ristretto};
 
 use borsh::{BorshSerialize, BorshDeserialize};
 
-use serai_primitives::NetworkId;
+use serai_primitives::ExternalNetworkId;
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, BorshSerialize, BorshDeserialize)]
 pub enum Service {
-  Processor(NetworkId),
+  Processor(ExternalNetworkId),
   Coordinator,
 }
 

--- a/processor/src/batch_signer.rs
+++ b/processor/src/batch_signer.rs
@@ -17,7 +17,7 @@ use frost_schnorrkel::Schnorrkel;
 use log::{info, debug, warn};
 
 use serai_client::{
-  primitives::{NetworkId, BlockHash},
+  primitives::{ExternalNetworkId, BlockHash},
   in_instructions::primitives::{Batch, SignedBatch, batch_message},
   validator_sets::primitives::Session,
 };
@@ -41,7 +41,7 @@ type SignatureShare = <AlgorithmSignMachine<Ristretto, Schnorrkel> as SignMachin
 pub struct BatchSigner<D: Db> {
   db: PhantomData<D>,
 
-  network: NetworkId,
+  network: ExternalNetworkId,
   session: Session,
   keys: Vec<ThresholdKeys<Ristretto>>,
 
@@ -65,7 +65,7 @@ impl<D: Db> fmt::Debug for BatchSigner<D> {
 
 impl<D: Db> BatchSigner<D> {
   pub fn new(
-    network: NetworkId,
+    network: ExternalNetworkId,
     session: Session,
     keys: Vec<ThresholdKeys<Ristretto>>,
   ) -> BatchSigner<D> {

--- a/processor/src/main.rs
+++ b/processor/src/main.rs
@@ -744,6 +744,10 @@ async fn main() {
 
   let coordinator = MessageQueue::from_env(Service::Processor(network_id));
 
+  // This allow is necessary since each configuration deletes the other networks from the following
+  // match arms. So we match all cases but since all cases already there according to the compiler
+  // we put this to allow clippy to get pass this.
+  #[allow(unreachable_patterns)]
   match network_id {
     #[cfg(feature = "bitcoin")]
     ExternalNetworkId::Bitcoin => run(db, Bitcoin::new(url).await, coordinator).await,
@@ -759,5 +763,6 @@ async fn main() {
     }
     #[cfg(feature = "monero")]
     ExternalNetworkId::Monero => run(db, Monero::new(url).await, coordinator).await,
+    _ => panic!("spawning a processor for an unsupported network"),
   }
 }

--- a/processor/src/main.rs
+++ b/processor/src/main.rs
@@ -9,7 +9,7 @@ use log::{info, warn};
 use tokio::time::sleep;
 
 use serai_client::{
-  primitives::{BlockHash, NetworkId},
+  primitives::{BlockHash, ExternalNetworkId},
   validator_sets::primitives::{Session, KeyPair},
 };
 
@@ -736,9 +736,9 @@ async fn main() {
     "http://".to_string() + &login + "@" + &hostname + ":" + &port
   };
   let network_id = match env::var("NETWORK").expect("network wasn't specified").as_str() {
-    "bitcoin" => NetworkId::Bitcoin,
-    "ethereum" => NetworkId::Ethereum,
-    "monero" => NetworkId::Monero,
+    "bitcoin" => ExternalNetworkId::Bitcoin,
+    "ethereum" => ExternalNetworkId::Ethereum,
+    "monero" => ExternalNetworkId::Monero,
     _ => panic!("unrecognized network"),
   };
 
@@ -746,9 +746,9 @@ async fn main() {
 
   match network_id {
     #[cfg(feature = "bitcoin")]
-    NetworkId::Bitcoin => run(db, Bitcoin::new(url).await, coordinator).await,
+    ExternalNetworkId::Bitcoin => run(db, Bitcoin::new(url).await, coordinator).await,
     #[cfg(feature = "ethereum")]
-    NetworkId::Ethereum => {
+    ExternalNetworkId::Ethereum => {
       let relayer_hostname = env::var("ETHEREUM_RELAYER_HOSTNAME")
         .expect("ethereum relayer hostname wasn't specified")
         .to_string();
@@ -758,7 +758,6 @@ async fn main() {
       run(db.clone(), Ethereum::new(db, url, relayer_url).await, coordinator).await
     }
     #[cfg(feature = "monero")]
-    NetworkId::Monero => run(db, Monero::new(url).await, coordinator).await,
-    _ => panic!("spawning a processor for an unsupported network"),
+    ExternalNetworkId::Monero => run(db, Monero::new(url).await, coordinator).await,
   }
 }

--- a/processor/src/multisigs/db.rs
+++ b/processor/src/multisigs/db.rs
@@ -4,7 +4,11 @@ use ciphersuite::Ciphersuite;
 pub use serai_db::*;
 
 use scale::{Encode, Decode};
-use serai_client::{primitives::Balance, in_instructions::primitives::InInstructionWithBalance};
+#[rustfmt::skip]
+use serai_client::{
+  in_instructions::primitives::InInstructionWithBalance,
+  primitives::ExternalBalance
+};
 
 use crate::{
   Get, Plan,
@@ -69,7 +73,7 @@ create_db!(
     OperatingCostsDb: () -> u64,
     ResolvedDb: (tx: &[u8]) -> [u8; 32],
     SigningDb: (key: &[u8]) -> Vec<u8>,
-    ForwardedOutputDb: (balance: Balance) -> Vec<u8>,
+    ForwardedOutputDb: (balance: ExternalBalance) -> Vec<u8>,
     DelayedOutputDb: () -> Vec<u8>
   }
 );
@@ -224,7 +228,7 @@ impl ForwardedOutputDb {
 
   pub fn take_forwarded_output(
     txn: &mut impl DbTxn,
-    balance: Balance,
+    balance: ExternalBalance,
   ) -> Option<InInstructionWithBalance> {
     let outputs = Self::get(txn, balance)?;
     let mut outputs_ref = outputs.as_slice();

--- a/processor/src/multisigs/scheduler/mod.rs
+++ b/processor/src/multisigs/scheduler/mod.rs
@@ -3,7 +3,7 @@ use std::io;
 
 use ciphersuite::Ciphersuite;
 
-use serai_client::primitives::{NetworkId, Balance};
+use serai_client::primitives::{ExternalBalance, ExternalNetworkId};
 
 use crate::{networks::Network, Db, Payment, Plan};
 
@@ -34,18 +34,18 @@ pub trait Scheduler<N: Network>: Sized + Clone + PartialEq + Debug {
   fn new<D: Db>(
     txn: &mut D::Transaction<'_>,
     key: <N::Curve as Ciphersuite>::G,
-    network: NetworkId,
+    network: ExternalNetworkId,
   ) -> Self;
 
   /// Load a Scheduler from the DB.
   fn from_db<D: Db>(
     db: &D,
     key: <N::Curve as Ciphersuite>::G,
-    network: NetworkId,
+    network: ExternalNetworkId,
   ) -> io::Result<Self>;
 
   /// Check if a branch is usable.
-  fn can_use_branch(&self, balance: Balance) -> bool;
+  fn can_use_branch(&self, balance: ExternalBalance) -> bool;
 
   /// Schedule a series of outputs/payments.
   fn schedule<D: Db>(

--- a/processor/src/multisigs/scheduler/smart_contract.rs
+++ b/processor/src/multisigs/scheduler/smart_contract.rs
@@ -2,7 +2,7 @@ use std::{io, collections::HashSet};
 
 use ciphersuite::{group::GroupEncoding, Ciphersuite};
 
-use serai_client::primitives::{NetworkId, Coin, Balance};
+use serai_client::primitives::{ExternalBalance, ExternalCoin, ExternalNetworkId};
 
 use crate::{
   Get, DbTxn, Db, Payment, Plan, create_db,
@@ -13,7 +13,7 @@ use crate::{
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Scheduler<N: Network> {
   key: <N::Curve as Ciphersuite>::G,
-  coins: HashSet<Coin>,
+  coins: HashSet<ExternalCoin>,
   rotated: bool,
 }
 
@@ -78,7 +78,7 @@ impl<N: Network<Scheduler = Self>> SchedulerTrait<N> for Scheduler<N> {
   fn new<D: Db>(
     _txn: &mut D::Transaction<'_>,
     key: <N::Curve as Ciphersuite>::G,
-    network: NetworkId,
+    network: ExternalNetworkId,
   ) -> Self {
     assert!(N::branch_address(key).is_none());
     assert!(N::change_address(key).is_none());
@@ -91,7 +91,7 @@ impl<N: Network<Scheduler = Self>> SchedulerTrait<N> for Scheduler<N> {
   fn from_db<D: Db>(
     db: &D,
     key: <N::Curve as Ciphersuite>::G,
-    network: NetworkId,
+    network: ExternalNetworkId,
   ) -> io::Result<Self> {
     Ok(Scheduler {
       key,
@@ -100,7 +100,7 @@ impl<N: Network<Scheduler = Self>> SchedulerTrait<N> for Scheduler<N> {
     })
   }
 
-  fn can_use_branch(&self, _balance: Balance) -> bool {
+  fn can_use_branch(&self, _balance: ExternalBalance) -> bool {
     false
   }
 

--- a/processor/src/networks/bitcoin.rs
+++ b/processor/src/networks/bitcoin.rs
@@ -42,7 +42,7 @@ use bitcoin_serai::bitcoin::{
 };
 
 use serai_client::{
-  primitives::{MAX_DATA_LEN, Coin, NetworkId, Amount, Balance},
+  primitives::{MAX_DATA_LEN, ExternalCoin, ExternalNetworkId, Amount, ExternalBalance},
   networks::bitcoin::Address,
 };
 
@@ -125,8 +125,8 @@ impl OutputTrait<Bitcoin> for Output {
     self.presumed_origin.clone()
   }
 
-  fn balance(&self) -> Balance {
-    Balance { coin: Coin::Bitcoin, amount: Amount(self.output.value()) }
+  fn balance(&self) -> ExternalBalance {
+    ExternalBalance { coin: ExternalCoin::Bitcoin, amount: Amount(self.output.value()) }
   }
 
   fn data(&self) -> &[u8] {
@@ -423,7 +423,7 @@ impl Bitcoin {
     calculating_fee: bool,
   ) -> Result<Option<BSignableTransaction>, NetworkError> {
     for payment in payments {
-      assert_eq!(payment.balance.coin, Coin::Bitcoin);
+      assert_eq!(payment.balance.coin, ExternalCoin::Bitcoin);
     }
 
     // TODO2: Use an fee representative of several blocks, cached inside Self
@@ -598,7 +598,7 @@ impl Network for Bitcoin {
 
   type Address = Address;
 
-  const NETWORK: NetworkId = NetworkId::Bitcoin;
+  const NETWORK: ExternalNetworkId = ExternalNetworkId::Bitcoin;
   const ID: &'static str = "Bitcoin";
   const ESTIMATED_BLOCK_TIME_IN_SECONDS: usize = 600;
   const CONFIRMATIONS: usize = 6;

--- a/processor/src/networks/ethereum.rs
+++ b/processor/src/networks/ethereum.rs
@@ -38,7 +38,7 @@ use tokio::{
 };
 
 use serai_client::{
-  primitives::{Coin, Amount, Balance, NetworkId},
+  primitives::{ExternalCoin, Amount, ExternalBalance, ExternalNetworkId},
   validator_sets::primitives::Session,
 };
 
@@ -68,20 +68,20 @@ const DAI: [u8; 20] =
     Err(_) => panic!("invalid test DAI hex address"),
   };
 
-fn coin_to_serai_coin(coin: &EthereumCoin) -> Option<Coin> {
+fn coin_to_serai_coin(coin: &EthereumCoin) -> Option<ExternalCoin> {
   match coin {
-    EthereumCoin::Ether => Some(Coin::Ether),
+    EthereumCoin::Ether => Some(ExternalCoin::Ether),
     EthereumCoin::Erc20(token) => {
       if *token == DAI {
-        return Some(Coin::Dai);
+        return Some(ExternalCoin::Dai);
       }
       None
     }
   }
 }
 
-fn amount_to_serai_amount(coin: Coin, amount: U256) -> Amount {
-  assert_eq!(coin.network(), NetworkId::Ethereum);
+fn amount_to_serai_amount(coin: ExternalCoin, amount: U256) -> Amount {
+  assert_eq!(coin.network(), ExternalNetworkId::Ethereum);
   assert_eq!(coin.decimals(), 8);
   // Remove 10 decimals so we go from 18 decimals to 8 decimals
   let divisor = U256::from(10_000_000_000u64);
@@ -89,8 +89,8 @@ fn amount_to_serai_amount(coin: Coin, amount: U256) -> Amount {
   Amount(u64::try_from(amount / divisor).unwrap())
 }
 
-fn balance_to_ethereum_amount(balance: Balance) -> U256 {
-  assert_eq!(balance.coin.network(), NetworkId::Ethereum);
+fn balance_to_ethereum_amount(balance: ExternalBalance) -> U256 {
+  assert_eq!(balance.coin.network(), ExternalNetworkId::Ethereum);
   assert_eq!(balance.coin.decimals(), 8);
   // Restore 10 decimals so we go from 8 decimals to 18 decimals
   let factor = U256::from(10_000_000_000u64);
@@ -201,14 +201,14 @@ impl<D: Db> Output<Ethereum<D>> for EthereumInInstruction {
     Some(Address(self.from))
   }
 
-  fn balance(&self) -> Balance {
+  fn balance(&self) -> ExternalBalance {
     let coin = coin_to_serai_coin(&self.coin).unwrap_or_else(|| {
       panic!(
         "requesting coin for an EthereumInInstruction with a coin {}",
         "we don't handle. this never should have been yielded"
       )
     });
-    Balance { coin, amount: amount_to_serai_amount(coin, self.amount) }
+    ExternalBalance { coin, amount: amount_to_serai_amount(coin, self.amount) }
   }
   fn data(&self) -> &[u8] {
     &self.data
@@ -394,7 +394,7 @@ impl<D: Db> Network for Ethereum<D> {
 
   type Address = Address;
 
-  const NETWORK: NetworkId = NetworkId::Ethereum;
+  const NETWORK: ExternalNetworkId = ExternalNetworkId::Ethereum;
   const ID: &'static str = "Ethereum";
   const ESTIMATED_BLOCK_TIME_IN_SECONDS: usize = 32 * 12;
   const CONFIRMATIONS: usize = 1;
@@ -681,7 +681,7 @@ impl<D: Db> Network for Ethereum<D> {
                 OutInstructionTarget::Direct(payment.address.0)
               },
               value: {
-                assert_eq!(payment.balance.coin, Coin::Ether); // TODO
+                assert_eq!(payment.balance.coin, ExternalCoin::Ether); // TODO
                 balance_to_ethereum_amount(payment.balance)
               },
             })

--- a/processor/src/networks/mod.rs
+++ b/processor/src/networks/mod.rs
@@ -10,7 +10,7 @@ use frost::{
   sign::PreprocessMachine,
 };
 
-use serai_client::primitives::{NetworkId, Balance};
+use serai_client::primitives::{ExternalBalance, ExternalNetworkId};
 
 use log::error;
 
@@ -115,7 +115,7 @@ pub trait Output<N: Network>: Send + Sync + Sized + Clone + PartialEq + Eq + Deb
 
   fn presumed_origin(&self) -> Option<N::Address>;
 
-  fn balance(&self) -> Balance;
+  fn balance(&self) -> ExternalBalance;
   fn data(&self) -> &[u8];
 
   fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()>;
@@ -126,13 +126,13 @@ pub trait Output<N: Network>: Send + Sync + Sized + Clone + PartialEq + Eq + Deb
 pub trait Transaction<N: Network>: Send + Sync + Sized + Clone + PartialEq + Debug {
   type Id: 'static + Id;
   fn id(&self) -> Self::Id;
-  // TODO: Move to Balance
+  // TODO: Move to ExternalBalance
   #[cfg(test)]
   async fn fee(&self, network: &N) -> u64;
 }
 
 pub trait SignableTransaction: Send + Sync + Clone + Debug {
-  // TODO: Move to Balance
+  // TODO: Move to ExternalBalance
   fn fee(&self) -> u64;
 }
 
@@ -280,7 +280,7 @@ pub trait Network: 'static + Send + Sync + Clone + PartialEq + Debug {
     + TryFrom<Vec<u8>>;
 
   /// Network ID for this network.
-  const NETWORK: NetworkId;
+  const NETWORK: ExternalNetworkId;
   /// String ID for this network.
   const ID: &'static str;
   /// The estimated amount of time a block will take.
@@ -297,7 +297,7 @@ pub trait Network: 'static + Send + Sync + Clone + PartialEq + Debug {
   /// For any received output, there's the cost to spend the output. This value MUST exceed the
   /// cost to spend said output, and should by a notable margin (not just 2x, yet an order of
   /// magnitude).
-  // TODO: Dust needs to be diversified per Coin
+  // TODO: Dust needs to be diversified per ExternalCoin
   const DUST: u64;
 
   /// The cost to perform input aggregation with a 2-input 1-output TX.

--- a/processor/src/networks/monero.rs
+++ b/processor/src/networks/monero.rs
@@ -31,7 +31,7 @@ use monero_wallet::Scanner;
 use tokio::time::sleep;
 
 pub use serai_client::{
-  primitives::{MAX_DATA_LEN, Coin, NetworkId, Amount, Balance},
+  primitives::{MAX_DATA_LEN, ExternalCoin, ExternalNetworkId, Amount, ExternalBalance},
   networks::monero::Address,
 };
 
@@ -85,8 +85,8 @@ impl OutputTrait<Monero> for Output {
     None
   }
 
-  fn balance(&self) -> Balance {
-    Balance { coin: Coin::Monero, amount: Amount(self.0.commitment().amount) }
+  fn balance(&self) -> ExternalBalance {
+    ExternalBalance { coin: ExternalCoin::Monero, amount: Amount(self.0.commitment().amount) }
   }
 
   fn data(&self) -> &[u8] {
@@ -308,7 +308,7 @@ impl Monero {
     calculating_fee: bool,
   ) -> Result<Option<MakeSignableTransactionResult>, NetworkError> {
     for payment in payments {
-      assert_eq!(payment.balance.coin, Coin::Monero);
+      assert_eq!(payment.balance.coin, ExternalCoin::Monero);
     }
 
     // TODO2: Use an fee representative of several blocks, cached inside Self
@@ -363,7 +363,7 @@ impl Monero {
             .legacy_address(MoneroNetwork::Mainnet),
         )
         .unwrap(),
-        balance: Balance { coin: Coin::Monero, amount: Amount(0) },
+        balance: ExternalBalance { coin: ExternalCoin::Monero, amount: Amount(0) },
         data: None,
       });
     }
@@ -470,7 +470,7 @@ impl Network for Monero {
 
   type Address = Address;
 
-  const NETWORK: NetworkId = NetworkId::Monero;
+  const NETWORK: ExternalNetworkId = ExternalNetworkId::Monero;
   const ID: &'static str = "Monero";
   const ESTIMATED_BLOCK_TIME_IN_SECONDS: usize = 120;
   const CONFIRMATIONS: usize = 10;

--- a/processor/src/plan.rs
+++ b/processor/src/plan.rs
@@ -6,7 +6,7 @@ use transcript::{Transcript, RecommendedTranscript};
 use ciphersuite::group::GroupEncoding;
 use frost::curve::Ciphersuite;
 
-use serai_client::primitives::Balance;
+use serai_client::primitives::ExternalBalance;
 
 use crate::{
   networks::{Output, Network},
@@ -17,7 +17,7 @@ use crate::{
 pub struct Payment<N: Network> {
   pub address: N::Address,
   pub data: Option<Vec<u8>>,
-  pub balance: Balance,
+  pub balance: ExternalBalance,
 }
 
 impl<N: Network> Payment<N> {
@@ -69,7 +69,7 @@ impl<N: Network> Payment<N> {
       None
     };
 
-    let balance = Balance::decode(&mut scale::IoReader(reader))
+    let balance = ExternalBalance::decode(&mut scale::IoReader(reader))
       .map_err(|_| io::Error::other("invalid balance"))?;
 
     Ok(Payment { address, data, balance })

--- a/processor/src/slash_report_signer.rs
+++ b/processor/src/slash_report_signer.rs
@@ -17,9 +17,9 @@ use frost_schnorrkel::Schnorrkel;
 use log::{info, warn};
 
 use serai_client::{
+  primitives::ExternalNetworkId,
+  validator_sets::primitives::{report_slashes_message, ExternalValidatorSet, Session},
   Public,
-  primitives::NetworkId,
-  validator_sets::primitives::{Session, ValidatorSet, report_slashes_message},
 };
 
 use messages::coordinator::*;
@@ -38,7 +38,7 @@ type SignatureShare = <AlgorithmSignMachine<Ristretto, Schnorrkel> as SignMachin
 >>::SignatureShare;
 
 pub struct SlashReportSigner {
-  network: NetworkId,
+  network: ExternalNetworkId,
   session: Session,
   keys: Vec<ThresholdKeys<Ristretto>>,
   report: Vec<([u8; 32], u32)>,
@@ -66,7 +66,7 @@ impl fmt::Debug for SlashReportSigner {
 impl SlashReportSigner {
   pub fn new(
     txn: &mut impl DbTxn,
-    network: NetworkId,
+    network: ExternalNetworkId,
     session: Session,
     keys: Vec<ThresholdKeys<Ristretto>>,
     report: Vec<([u8; 32], u32)>,
@@ -178,7 +178,7 @@ impl SlashReportSigner {
           let (machine, share) = match machine.sign(
             preprocesses,
             &report_slashes_message(
-              &ValidatorSet { network: self.network, session: self.session },
+              &ExternalValidatorSet { network: self.network, session: self.session },
               &self
                 .report
                 .clone()

--- a/processor/src/tests/batch_signer.rs
+++ b/processor/src/tests/batch_signer.rs
@@ -33,17 +33,17 @@ fn test_batch_signer() {
   let block = BlockHash([0xaa; 32]);
 
   let batch = Batch {
-    network: NetworkId::Monero,
+    network: ExternalNetworkId::Monero,
     id,
     block,
     instructions: vec![
       InInstructionWithBalance {
         instruction: InInstruction::Transfer(SeraiAddress([0xbb; 32])),
-        balance: Balance { coin: Coin::Bitcoin, amount: Amount(1000) },
+        balance: ExternalBalance { coin: ExternalCoin::Bitcoin, amount: Amount(1000) },
       },
       InInstructionWithBalance {
         instruction: InInstruction::Dex(DexCall::SwapAndAddLiquidity(SeraiAddress([0xbb; 32]))),
-        balance: Balance { coin: Coin::Monero, amount: Amount(9999999999999999) },
+        balance: ExternalBalance { coin: ExternalCoin::Monero, amount: Amount(9999999999999999) },
       },
     ],
   };
@@ -70,7 +70,7 @@ fn test_batch_signer() {
     let i = Participant::new(u16::try_from(i).unwrap()).unwrap();
     let keys = keys.get(&i).unwrap().clone();
 
-    let mut signer = BatchSigner::<MemDb>::new(NetworkId::Monero, Session(0), vec![keys]);
+    let mut signer = BatchSigner::<MemDb>::new(ExternalNetworkId::Monero, Session(0), vec![keys]);
     let mut db = MemDb::new();
 
     let mut txn = db.txn();

--- a/processor/src/tests/signer.rs
+++ b/processor/src/tests/signer.rs
@@ -12,7 +12,7 @@ use frost::{
 use serai_db::{DbTxn, Db, MemDb};
 
 use serai_client::{
-  primitives::{NetworkId, Coin, Amount, Balance},
+  primitives::{ExternalNetworkId, ExternalCoin, Amount, ExternalBalance},
   validator_sets::primitives::Session,
 };
 
@@ -185,12 +185,11 @@ pub async fn test_signer<N: Network>(
     let payments = vec![Payment {
       address: N::external_address(&network, key).await,
       data: None,
-      balance: Balance {
+      balance: ExternalBalance {
         coin: match N::NETWORK {
-          NetworkId::Serai => panic!("test_signer called with Serai"),
-          NetworkId::Bitcoin => Coin::Bitcoin,
-          NetworkId::Ethereum => Coin::Ether,
-          NetworkId::Monero => Coin::Monero,
+          ExternalNetworkId::Bitcoin => ExternalCoin::Bitcoin,
+          ExternalNetworkId::Ethereum => ExternalCoin::Ether,
+          ExternalNetworkId::Monero => ExternalCoin::Monero,
         },
         amount: Amount(amount),
       },
@@ -224,7 +223,7 @@ pub async fn test_signer<N: Network>(
     .await;
   // Don't run if Ethereum as the received output will revert by the contract
   // (and therefore not actually exist)
-  if N::NETWORK != NetworkId::Ethereum {
+  if N::NETWORK != ExternalNetworkId::Ethereum {
     assert_eq!(outputs.len(), 1 + usize::from(u8::from(plan.change.is_some())));
     // Adjust the amount for the fees
     let amount = amount - tx.fee(&network).await;

--- a/processor/src/tests/wallet.rs
+++ b/processor/src/tests/wallet.rs
@@ -11,7 +11,7 @@ use tokio::time::timeout;
 use serai_db::{DbTxn, Db, MemDb};
 
 use serai_client::{
-  primitives::{NetworkId, Coin, Amount, Balance},
+  primitives::{ExternalNetworkId, ExternalCoin, Amount, ExternalBalance},
   validator_sets::primitives::Session,
 };
 
@@ -89,12 +89,11 @@ pub async fn test_wallet<N: Network>(
     vec![Payment {
       address: N::external_address(&network, key).await,
       data: None,
-      balance: Balance {
+      balance: ExternalBalance {
         coin: match N::NETWORK {
-          NetworkId::Serai => panic!("test_wallet called with Serai"),
-          NetworkId::Bitcoin => Coin::Bitcoin,
-          NetworkId::Ethereum => Coin::Ether,
-          NetworkId::Monero => Coin::Monero,
+          ExternalNetworkId::Bitcoin => ExternalCoin::Bitcoin,
+          ExternalNetworkId::Ethereum => ExternalCoin::Ether,
+          ExternalNetworkId::Monero => ExternalCoin::Monero,
         },
         amount: Amount(amount),
       },
@@ -117,12 +116,11 @@ pub async fn test_wallet<N: Network>(
     vec![Payment {
       address: N::external_address(&network, key).await,
       data: None,
-      balance: Balance {
+      balance: ExternalBalance {
         coin: match N::NETWORK {
-          NetworkId::Serai => panic!("test_wallet called with Serai"),
-          NetworkId::Bitcoin => Coin::Bitcoin,
-          NetworkId::Ethereum => Coin::Ether,
-          NetworkId::Monero => Coin::Monero,
+          ExternalNetworkId::Bitcoin => ExternalCoin::Bitcoin,
+          ExternalNetworkId::Ethereum => ExternalCoin::Ether,
+          ExternalNetworkId::Monero => ExternalCoin::Monero,
         },
         amount: Amount(amount),
       }
@@ -160,7 +158,7 @@ pub async fn test_wallet<N: Network>(
 
   // Don't run if Ethereum as the received output will revert by the contract
   // (and therefore not actually exist)
-  if N::NETWORK != NetworkId::Ethereum {
+  if N::NETWORK != ExternalNetworkId::Ethereum {
     assert_eq!(outputs.len(), 1 + usize::from(u8::from(plans[0].change.is_some())));
     // Adjust the amount for the fees
     let amount = amount - tx.fee(&network).await;
@@ -183,7 +181,7 @@ pub async fn test_wallet<N: Network>(
     network.mine_block().await;
   }
 
-  if N::NETWORK != NetworkId::Ethereum {
+  if N::NETWORK != ExternalNetworkId::Ethereum {
     match timeout(Duration::from_secs(30), scanner.events.recv()).await.unwrap().unwrap() {
       ScannerEvent::Block { is_retirement_block, block: block_id, outputs: these_outputs } => {
         scanner.multisig_completed.send(false).unwrap();

--- a/substrate/abi/src/dex.rs
+++ b/substrate/abi/src/dex.rs
@@ -2,7 +2,7 @@ use sp_runtime::BoundedVec;
 
 use serai_primitives::*;
 
-type PoolId = Coin;
+type PoolId = ExternalCoin;
 type MaxSwapPathLength = sp_core::ConstU32<3>;
 
 #[derive(Clone, PartialEq, Eq, Debug, scale::Encode, scale::Decode, scale_info::TypeInfo)]
@@ -10,7 +10,7 @@ type MaxSwapPathLength = sp_core::ConstU32<3>;
 #[cfg_attr(all(feature = "std", feature = "serde"), derive(serde::Deserialize))]
 pub enum Call {
   add_liquidity {
-    coin: Coin,
+    coin: ExternalCoin,
     coin_desired: SubstrateAmount,
     sri_desired: SubstrateAmount,
     coin_min: SubstrateAmount,
@@ -18,7 +18,7 @@ pub enum Call {
     mint_to: SeraiAddress,
   },
   remove_liquidity {
-    coin: Coin,
+    coin: ExternalCoin,
     lp_token_burn: SubstrateAmount,
     coin_min_receive: SubstrateAmount,
     sri_min_receive: SubstrateAmount,

--- a/substrate/abi/src/economic_security.rs
+++ b/substrate/abi/src/economic_security.rs
@@ -1,8 +1,8 @@
-use serai_primitives::NetworkId;
+use serai_primitives::ExternalNetworkId;
 
 #[derive(Clone, PartialEq, Eq, Debug, scale::Encode, scale::Decode, scale_info::TypeInfo)]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Event {
-  EconomicSecurityReached { network: NetworkId },
+  EconomicSecurityReached { network: ExternalNetworkId },
 }

--- a/substrate/abi/src/genesis_liquidity.rs
+++ b/substrate/abi/src/genesis_liquidity.rs
@@ -17,5 +17,4 @@ pub enum Event {
   GenesisLiquidityAdded { by: SeraiAddress, balance: ExternalBalance },
   GenesisLiquidityRemoved { by: SeraiAddress, balance: ExternalBalance },
   GenesisLiquidityAddedToPool { coin: ExternalBalance, sri: Amount },
-  EconomicSecurityReached { network: NetworkId },
 }

--- a/substrate/abi/src/genesis_liquidity.rs
+++ b/substrate/abi/src/genesis_liquidity.rs
@@ -6,7 +6,7 @@ use primitives::*;
 #[derive(Clone, PartialEq, Eq, Debug, scale::Encode, scale::Decode, scale_info::TypeInfo)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Call {
-  remove_coin_liquidity { balance: Balance },
+  remove_coin_liquidity { balance: ExternalBalance },
   oraclize_values { values: Values, signature: Signature },
 }
 
@@ -14,8 +14,8 @@ pub enum Call {
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Event {
-  GenesisLiquidityAdded { by: SeraiAddress, balance: Balance },
-  GenesisLiquidityRemoved { by: SeraiAddress, balance: Balance },
-  GenesisLiquidityAddedToPool { coin1: Balance, coin2: Balance },
+  GenesisLiquidityAdded { by: SeraiAddress, balance: ExternalBalance },
+  GenesisLiquidityRemoved { by: SeraiAddress, balance: ExternalBalance },
+  GenesisLiquidityAddedToPool { coin: ExternalBalance, sri: Amount },
   EconomicSecurityReached { network: NetworkId },
 }

--- a/substrate/abi/src/in_instructions.rs
+++ b/substrate/abi/src/in_instructions.rs
@@ -18,5 +18,5 @@ pub enum Call {
 pub enum Event {
   Batch { network: ExternalNetworkId, id: u32, block: BlockHash, instructions_hash: [u8; 32] },
   InstructionFailure { network: ExternalNetworkId, id: u32, index: u32 },
-  Halt { network: NetworkId },
+  Halt { network: ExternalNetworkId },
 }

--- a/substrate/abi/src/in_instructions.rs
+++ b/substrate/abi/src/in_instructions.rs
@@ -16,7 +16,7 @@ pub enum Call {
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(all(feature = "std", feature = "serde"), derive(serde::Deserialize))]
 pub enum Event {
-  Batch { network: NetworkId, id: u32, block: BlockHash, instructions_hash: [u8; 32] },
-  InstructionFailure { network: NetworkId, id: u32, index: u32 },
+  Batch { network: ExternalNetworkId, id: u32, block: BlockHash, instructions_hash: [u8; 32] },
+  InstructionFailure { network: ExternalNetworkId, id: u32, index: u32 },
   Halt { network: NetworkId },
 }

--- a/substrate/abi/src/validator_sets.rs
+++ b/substrate/abi/src/validator_sets.rs
@@ -10,13 +10,13 @@ use serai_validator_sets_primitives::*;
 #[cfg_attr(all(feature = "std", feature = "serde"), derive(serde::Deserialize))]
 pub enum Call {
   set_keys {
-    network: NetworkId,
+    network: ExternalNetworkId,
     removed_participants: BoundedVec<SeraiAddress, ConstU32<{ MAX_KEY_SHARES_PER_SET / 3 }>>,
     key_pair: KeyPair,
     signature: Signature,
   },
   report_slashes {
-    network: NetworkId,
+    network: ExternalNetworkId,
     slashes: BoundedVec<(SeraiAddress, u32), ConstU32<{ MAX_KEY_SHARES_PER_SET / 3 }>>,
     signature: Signature,
   },
@@ -47,7 +47,7 @@ pub enum Event {
     removed: SeraiAddress,
   },
   KeyGen {
-    set: ValidatorSet,
+    set: ExternalValidatorSet,
     key_pair: KeyPair,
   },
   AcceptedHandover {

--- a/substrate/client/src/serai/dex.rs
+++ b/substrate/client/src/serai/dex.rs
@@ -1,5 +1,5 @@
 use sp_core::bounded_vec::BoundedVec;
-use serai_abi::primitives::{SeraiAddress, Amount, Coin};
+use serai_abi::primitives::{Amount, Coin, ExternalCoin, SeraiAddress};
 
 use crate::{SeraiError, TemporalSerai};
 
@@ -20,7 +20,7 @@ impl<'a> SeraiDex<'a> {
   }
 
   pub fn add_liquidity(
-    coin: Coin,
+    coin: ExternalCoin,
     coin_amount: Amount,
     sri_amount: Amount,
     min_coin_amount: Amount,
@@ -61,11 +61,14 @@ impl<'a> SeraiDex<'a> {
   }
 
   /// Returns the reserves of `coin:SRI` pool.
-  pub async fn get_reserves(&self, coin: Coin) -> Result<Option<(Amount, Amount)>, SeraiError> {
-    self.0.runtime_api("DexApi_get_reserves", (coin, Coin::Serai)).await
+  pub async fn get_reserves(
+    &self,
+    coin: ExternalCoin,
+  ) -> Result<Option<(Amount, Amount)>, SeraiError> {
+    self.0.runtime_api("DexApi_get_reserves", (Coin::from(coin), Coin::Serai)).await
   }
 
-  pub async fn oracle_value(&self, coin: Coin) -> Result<Option<Amount>, SeraiError> {
+  pub async fn oracle_value(&self, coin: ExternalCoin) -> Result<Option<Amount>, SeraiError> {
     self.0.storage(PALLET, "SecurityOracleValue", coin).await
   }
 }

--- a/substrate/client/src/serai/genesis_liquidity.rs
+++ b/substrate/client/src/serai/genesis_liquidity.rs
@@ -35,7 +35,7 @@ impl<'a> SeraiGenesisLiquidity<'a> {
     ))
   }
 
-  pub fn remove_coin_liquidity(balance: Balance) -> serai_abi::Call {
+  pub fn remove_coin_liquidity(balance: ExternalBalance) -> serai_abi::Call {
     serai_abi::Call::GenesisLiquidity(serai_abi::genesis_liquidity::Call::remove_coin_liquidity {
       balance,
     })
@@ -44,7 +44,7 @@ impl<'a> SeraiGenesisLiquidity<'a> {
   pub async fn liquidity(
     &self,
     address: &SeraiAddress,
-    coin: Coin,
+    coin: ExternalCoin,
   ) -> Result<LiquidityAmount, SeraiError> {
     Ok(
       self
@@ -59,7 +59,7 @@ impl<'a> SeraiGenesisLiquidity<'a> {
     )
   }
 
-  pub async fn supply(&self, coin: Coin) -> Result<LiquidityAmount, SeraiError> {
+  pub async fn supply(&self, coin: ExternalCoin) -> Result<LiquidityAmount, SeraiError> {
     Ok(self.0.storage(PALLET, "Supply", coin).await?.unwrap_or(LiquidityAmount::zero()))
   }
 

--- a/substrate/client/src/serai/in_instructions.rs
+++ b/substrate/client/src/serai/in_instructions.rs
@@ -2,7 +2,7 @@ pub use serai_abi::in_instructions::primitives;
 use primitives::SignedBatch;
 
 use crate::{
-  primitives::{BlockHash, NetworkId},
+  primitives::{BlockHash, ExternalNetworkId},
   Transaction, SeraiError, Serai, TemporalSerai,
 };
 
@@ -15,14 +15,14 @@ pub struct SeraiInInstructions<'a>(pub(crate) &'a TemporalSerai<'a>);
 impl<'a> SeraiInInstructions<'a> {
   pub async fn latest_block_for_network(
     &self,
-    network: NetworkId,
+    network: ExternalNetworkId,
   ) -> Result<Option<BlockHash>, SeraiError> {
     self.0.storage(PALLET, "LatestNetworkBlock", network).await
   }
 
   pub async fn last_batch_for_network(
     &self,
-    network: NetworkId,
+    network: ExternalNetworkId,
   ) -> Result<Option<u32>, SeraiError> {
     self.0.storage(PALLET, "LastBatch", network).await
   }

--- a/substrate/client/src/serai/liquidity_tokens.rs
+++ b/substrate/client/src/serai/liquidity_tokens.rs
@@ -1,6 +1,6 @@
 use scale::Encode;
 
-use serai_abi::primitives::{SeraiAddress, Amount, Coin, Balance};
+use serai_abi::primitives::{Amount, ExternalBalance, ExternalCoin, SeraiAddress};
 
 use crate::{TemporalSerai, SeraiError};
 
@@ -9,13 +9,13 @@ const PALLET: &str = "LiquidityTokens";
 #[derive(Clone, Copy)]
 pub struct SeraiLiquidityTokens<'a>(pub(crate) &'a TemporalSerai<'a>);
 impl<'a> SeraiLiquidityTokens<'a> {
-  pub async fn token_supply(&self, coin: Coin) -> Result<Amount, SeraiError> {
+  pub async fn token_supply(&self, coin: ExternalCoin) -> Result<Amount, SeraiError> {
     Ok(self.0.storage(PALLET, "Supply", coin).await?.unwrap_or(Amount(0)))
   }
 
   pub async fn token_balance(
     &self,
-    coin: Coin,
+    coin: ExternalCoin,
     address: SeraiAddress,
   ) -> Result<Amount, SeraiError> {
     Ok(
@@ -31,11 +31,16 @@ impl<'a> SeraiLiquidityTokens<'a> {
     )
   }
 
-  pub fn transfer(to: SeraiAddress, balance: Balance) -> serai_abi::Call {
-    serai_abi::Call::LiquidityTokens(serai_abi::liquidity_tokens::Call::transfer { to, balance })
+  pub fn transfer(to: SeraiAddress, balance: ExternalBalance) -> serai_abi::Call {
+    serai_abi::Call::LiquidityTokens(serai_abi::liquidity_tokens::Call::transfer {
+      to,
+      balance: balance.into(),
+    })
   }
 
-  pub fn burn(balance: Balance) -> serai_abi::Call {
-    serai_abi::Call::LiquidityTokens(serai_abi::liquidity_tokens::Call::burn { balance })
+  pub fn burn(balance: ExternalBalance) -> serai_abi::Call {
+    serai_abi::Call::LiquidityTokens(serai_abi::liquidity_tokens::Call::burn {
+      balance: balance.into(),
+    })
   }
 }

--- a/substrate/client/src/serai/validator_sets.rs
+++ b/substrate/client/src/serai/validator_sets.rs
@@ -2,12 +2,12 @@ use scale::Encode;
 
 use sp_core::sr25519::{Public, Signature};
 
-use serai_abi::primitives::Amount;
+use serai_abi::{primitives::Amount, validator_sets::primitives::ExternalValidatorSet};
 pub use serai_abi::validator_sets::primitives;
-use primitives::{Session, ValidatorSet, KeyPair};
+use primitives::{Session, KeyPair};
 
 use crate::{
-  primitives::{NetworkId, SeraiAddress},
+  primitives::{NetworkId, ExternalNetworkId, SeraiAddress},
   Transaction, Serai, TemporalSerai, SeraiError,
 };
 
@@ -167,13 +167,13 @@ impl<'a> SeraiValidatorSets<'a> {
   }
 
   // TODO: Store these separately since we almost never need both at once?
-  pub async fn keys(&self, set: ValidatorSet) -> Result<Option<KeyPair>, SeraiError> {
+  pub async fn keys(&self, set: ExternalValidatorSet) -> Result<Option<KeyPair>, SeraiError> {
     self.0.storage(PALLET, "Keys", (sp_core::hashing::twox_64(&set.encode()), set)).await
   }
 
   pub async fn key_pending_slash_report(
     &self,
-    network: NetworkId,
+    network: ExternalNetworkId,
   ) -> Result<Option<Public>, SeraiError> {
     self.0.storage(PALLET, "PendingSlashReport", network).await
   }
@@ -187,7 +187,7 @@ impl<'a> SeraiValidatorSets<'a> {
   }
 
   pub fn set_keys(
-    network: NetworkId,
+    network: ExternalNetworkId,
     removed_participants: sp_runtime::BoundedVec<
       SeraiAddress,
       sp_core::ConstU32<{ primitives::MAX_KEY_SHARES_PER_SET / 3 }>,
@@ -212,7 +212,7 @@ impl<'a> SeraiValidatorSets<'a> {
   }
 
   pub fn report_slashes(
-    network: NetworkId,
+    network: ExternalNetworkId,
     slashes: sp_runtime::BoundedVec<
       (SeraiAddress, u32),
       sp_core::ConstU32<{ primitives::MAX_KEY_SHARES_PER_SET / 3 }>,

--- a/substrate/client/tests/common/dex.rs
+++ b/substrate/client/tests/common/dex.rs
@@ -1,4 +1,4 @@
-use serai_abi::primitives::{Coin, Amount};
+use serai_abi::primitives::{Amount, Coin, ExternalCoin};
 
 use serai_client::{Serai, SeraiDex};
 use sp_core::{sr25519::Pair, Pair as PairTrait};
@@ -8,7 +8,7 @@ use crate::common::tx::publish_tx;
 #[allow(dead_code)]
 pub async fn add_liquidity(
   serai: &Serai,
-  coin: Coin,
+  coin: ExternalCoin,
   coin_amount: Amount,
   sri_amount: Amount,
   nonce: u32,

--- a/substrate/client/tests/common/validator_sets.rs
+++ b/substrate/client/tests/common/validator_sets.rs
@@ -15,7 +15,7 @@ use schnorrkel::Schnorrkel;
 
 use serai_client::{
   validator_sets::{
-    primitives::{ValidatorSet, KeyPair, musig_context, set_keys_message},
+    primitives::{ExternalValidatorSet, KeyPair, musig_context, set_keys_message},
     ValidatorSetsEvent,
   },
   Amount, Serai, SeraiValidatorSets,
@@ -26,7 +26,7 @@ use crate::common::tx::publish_tx;
 #[allow(dead_code)]
 pub async fn set_keys(
   serai: &Serai,
-  set: ValidatorSet,
+  set: ExternalValidatorSet,
   key_pair: KeyPair,
   pairs: &[Pair],
 ) -> [u8; 32] {
@@ -46,7 +46,8 @@ pub async fn set_keys(
     assert_eq!(Ristretto::generator() * secret_key, pub_keys[i]);
 
     threshold_keys.push(
-      musig::<Ristretto>(&musig_context(set), &Zeroizing::new(secret_key), &pub_keys).unwrap(),
+      musig::<Ristretto>(&musig_context(set.into()), &Zeroizing::new(secret_key), &pub_keys)
+        .unwrap(),
     );
   }
 

--- a/substrate/client/tests/dht.rs
+++ b/substrate/client/tests/dht.rs
@@ -1,4 +1,4 @@
-use serai_client::{primitives::NetworkId, Serai};
+use serai_client::{primitives::ExternalNetworkId, Serai};
 
 #[tokio::test]
 async fn dht() {
@@ -44,7 +44,7 @@ async fn dht() {
       assert!(!Serai::new(serai_rpc.clone())
         .await
         .unwrap()
-        .p2p_validators(NetworkId::Bitcoin)
+        .p2p_validators(ExternalNetworkId::Bitcoin.into())
         .await
         .unwrap()
         .is_empty());

--- a/substrate/coins/pallet/src/lib.rs
+++ b/substrate/coins/pallet/src/lib.rs
@@ -1,13 +1,13 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use serai_primitives::{Coin, SubstrateAmount, Balance};
+use serai_primitives::{Balance, Coin, ExternalBalance, SubstrateAmount};
 
 pub trait AllowMint {
-  fn is_allowed(balance: &Balance) -> bool;
+  fn is_allowed(balance: &ExternalBalance) -> bool;
 }
 
 impl AllowMint for () {
-  fn is_allowed(_: &Balance) -> bool {
+  fn is_allowed(_: &ExternalBalance) -> bool {
     true
   }
 }
@@ -161,7 +161,12 @@ pub mod pallet {
     pub fn mint(to: Public, balance: Balance) -> Result<(), Error<T, I>> {
       // If the coin isn't Serai, which we're always allowed to mint, and the mint isn't explicitly
       // allowed, error
-      if (balance.coin != Coin::Serai) && (!T::AllowMint::is_allowed(&balance)) {
+      if !balance.coin.is_native() &&
+        (!T::AllowMint::is_allowed(&ExternalBalance {
+          coin: balance.coin.try_into().unwrap(),
+          amount: balance.amount,
+        }))
+      {
         Err(Error::<T, I>::MintNotAllowed)?;
       }
 
@@ -230,22 +235,18 @@ pub mod pallet {
     }
 
     /// Burn `balance` with `OutInstructionWithBalance` from the caller.
-    /// Errors if called for SRI or Instance1 instance of this pallet.
     #[pallet::call_index(2)]
     #[pallet::weight((0, DispatchClass::Normal))] // TODO
     pub fn burn_with_instruction(
       origin: OriginFor<T>,
       instruction: OutInstructionWithBalance,
     ) -> DispatchResult {
-      if instruction.balance.coin == Coin::Serai {
-        Err(Error::<T, I>::BurnWithInstructionNotAllowed)?;
-      }
       if TypeId::of::<I>() == TypeId::of::<LiquidityTokensInstance>() {
         Err(Error::<T, I>::BurnWithInstructionNotAllowed)?;
       }
 
       let from = ensure_signed(origin)?;
-      Self::burn_internal(from, instruction.balance)?;
+      Self::burn_internal(from, instruction.balance.into())?;
       Self::deposit_event(Event::BurnWithInstruction { from, instruction });
       Ok(())
     }

--- a/substrate/coins/pallet/src/lib.rs
+++ b/substrate/coins/pallet/src/lib.rs
@@ -161,11 +161,9 @@ pub mod pallet {
     pub fn mint(to: Public, balance: Balance) -> Result<(), Error<T, I>> {
       // If the coin isn't Serai, which we're always allowed to mint, and the mint isn't explicitly
       // allowed, error
-      if !balance.coin.is_native() &&
-        (!T::AllowMint::is_allowed(&ExternalBalance {
-          coin: balance.coin.try_into().unwrap(),
-          amount: balance.amount,
-        }))
+      if !ExternalCoin::try_from(balance.coin)
+        .map(|coin| T::AllowMint::is_allowed(&ExternalBalance { coin, amount: balance.amount }))
+        .unwrap_or(true)
       {
         Err(Error::<T, I>::MintNotAllowed)?;
       }

--- a/substrate/coins/primitives/src/lib.rs
+++ b/substrate/coins/primitives/src/lib.rs
@@ -13,7 +13,7 @@ use serde::{Serialize, Deserialize};
 use scale::{Encode, Decode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
-use serai_primitives::{Balance, SeraiAddress, ExternalAddress, Data, system_address};
+use serai_primitives::{system_address, Data, ExternalAddress, ExternalBalance, SeraiAddress};
 
 pub const FEE_ACCOUNT: SeraiAddress = system_address(b"Coins-fees");
 
@@ -32,7 +32,7 @@ pub struct OutInstruction {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct OutInstructionWithBalance {
   pub instruction: OutInstruction,
-  pub balance: Balance,
+  pub balance: ExternalBalance,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Encode, Decode, MaxEncodedLen, TypeInfo)]

--- a/substrate/dex/pallet/src/benchmarking.rs
+++ b/substrate/dex/pallet/src/benchmarking.rs
@@ -38,7 +38,7 @@ type AccountIdLookupOf<T> = <<T as frame_system::Config>::Lookup as StaticLookup
 
 type LiquidityTokens<T> = coins_pallet::Pallet<T, coins_pallet::Instance1>;
 
-fn create_coin<T: Config>(coin: &Coin) -> (T::AccountId, AccountIdLookupOf<T>) {
+fn create_coin<T: Config>(coin: &ExternalCoin) -> (T::AccountId, AccountIdLookupOf<T>) {
   let caller: T::AccountId = whitelisted_caller();
   let caller_lookup = T::Lookup::unlookup(caller);
   assert_ok!(Coins::<T>::mint(
@@ -47,12 +47,14 @@ fn create_coin<T: Config>(coin: &Coin) -> (T::AccountId, AccountIdLookupOf<T>) {
   ));
   assert_ok!(Coins::<T>::mint(
     caller,
-    Balance { coin: *coin, amount: Amount(INITIAL_COIN_BALANCE) }
+    Balance { coin: (*coin).into(), amount: Amount(INITIAL_COIN_BALANCE) }
   ));
   (caller, caller_lookup)
 }
 
-fn create_coin_and_pool<T: Config>(coin: &Coin) -> (Coin, T::AccountId, AccountIdLookupOf<T>) {
+fn create_coin_and_pool<T: Config>(
+  coin: &ExternalCoin,
+) -> (ExternalCoin, T::AccountId, AccountIdLookupOf<T>) {
   let (caller, caller_lookup) = create_coin::<T>(coin);
   assert_ok!(Dex::<T>::create_pool(*coin));
 
@@ -62,7 +64,7 @@ fn create_coin_and_pool<T: Config>(coin: &Coin) -> (Coin, T::AccountId, AccountI
 benchmarks! {
   add_liquidity {
     let coin1 = Coin::native();
-    let coin2 = Coin::Bitcoin;
+    let coin2 = ExternalCoin::Bitcoin;
     let (lp_token, caller, _) = create_coin_and_pool::<T>(&coin2);
     let add_amount: u64 = 1000;
   }: _(
@@ -75,13 +77,13 @@ benchmarks! {
     caller
   )
   verify {
-    let pool_id = Dex::<T>::get_pool_id(coin1, coin2).unwrap();
+    let pool_id = Dex::<T>::get_pool_id(coin1, coin2.into()).unwrap();
     let lp_minted = Dex::<T>::calc_lp_amount_for_zero_supply(
       add_amount,
       1000u64,
     ).unwrap();
     assert_eq!(
-      LiquidityTokens::<T>::balance(caller, lp_token).0,
+      LiquidityTokens::<T>::balance(caller, lp_token.into()).0,
       lp_minted
     );
     assert_eq!(
@@ -91,7 +93,7 @@ benchmarks! {
     assert_eq!(
       Coins::<T>::balance(
         Dex::<T>::get_pool_account(pool_id),
-        Coin::Bitcoin,
+        ExternalCoin::Bitcoin.into(),
       ).0,
       1000
     );
@@ -99,7 +101,7 @@ benchmarks! {
 
   remove_liquidity {
     let coin1 = Coin::native();
-    let coin2 = Coin::Monero;
+    let coin2 = ExternalCoin::Monero;
     let (lp_token, caller, _) = create_coin_and_pool::<T>(&coin2);
     let add_amount: u64 = 100;
     let lp_minted = Dex::<T>::calc_lp_amount_for_zero_supply(
@@ -117,7 +119,7 @@ benchmarks! {
       0u64,
       caller,
     )?;
-    let total_supply = LiquidityTokens::<T>::supply(lp_token);
+    let total_supply = LiquidityTokens::<T>::supply(Coin::from(lp_token));
   }: _(
     SystemOrigin::Signed(caller),
     coin2,
@@ -127,7 +129,7 @@ benchmarks! {
     caller
   )
   verify {
-    let new_total_supply =  LiquidityTokens::<T>::supply(lp_token);
+    let new_total_supply =  LiquidityTokens::<T>::supply(Coin::from(lp_token));
     assert_eq!(
       new_total_supply,
       total_supply - remove_lp_amount
@@ -136,8 +138,8 @@ benchmarks! {
 
   swap_exact_tokens_for_tokens {
     let native = Coin::native();
-    let coin1 = Coin::Bitcoin;
-    let coin2 = Coin::Ether;
+    let coin1 = ExternalCoin::Bitcoin;
+    let coin2 = ExternalCoin::Ether;
     let (_, caller, _) = create_coin_and_pool::<T>(&coin1);
     let (_, _) = create_coin::<T>(&coin2);
 
@@ -168,21 +170,21 @@ benchmarks! {
       caller,
     )?;
 
-    let path = vec![coin1, native, coin2];
+    let path = vec![Coin::from(coin1), native, Coin::from(coin2)];
     let path = BoundedVec::<_, T::MaxSwapPathLength>::try_from(path).unwrap();
     let native_balance = Coins::<T>::balance(caller, native).0;
-    let coin1_balance = Coins::<T>::balance(caller, Coin::Bitcoin).0;
+    let coin1_balance = Coins::<T>::balance(caller, ExternalCoin::Bitcoin.into()).0;
   }: _(SystemOrigin::Signed(caller), path, swap_amount, 1u64, caller)
   verify {
     let ed_bump = 2u64;
-    let new_coin1_balance = Coins::<T>::balance(caller, Coin::Bitcoin).0;
+    let new_coin1_balance = Coins::<T>::balance(caller, ExternalCoin::Bitcoin.into()).0;
     assert_eq!(new_coin1_balance, coin1_balance - 100u64);
   }
 
   swap_tokens_for_exact_tokens {
     let native = Coin::native();
-    let coin1 = Coin::Bitcoin;
-    let coin2 = Coin::Ether;
+    let coin1 = ExternalCoin::Bitcoin;
+    let coin2 = ExternalCoin::Ether;
     let (_, caller, _) = create_coin_and_pool::<T>(&coin1);
     let (_, _) = create_coin::<T>(&coin2);
 
@@ -208,10 +210,10 @@ benchmarks! {
       0u64,
       caller,
     )?;
-    let path = vec![coin1, native, coin2];
+    let path = vec![Coin::from(coin1), native, Coin::from(coin2)];
 
     let path: BoundedVec<_, T::MaxSwapPathLength> = BoundedVec::try_from(path).unwrap();
-    let coin2_balance = Coins::<T>::balance(caller, Coin::Ether).0;
+    let coin2_balance = Coins::<T>::balance(caller, ExternalCoin::Ether.into()).0;
   }: _(
     SystemOrigin::Signed(caller),
     path.clone(),
@@ -220,7 +222,7 @@ benchmarks! {
     caller
   )
   verify {
-    let new_coin2_balance = Coins::<T>::balance(caller, Coin::Ether).0;
+    let new_coin2_balance = Coins::<T>::balance(caller, ExternalCoin::Ether.into()).0;
     assert_eq!(new_coin2_balance, coin2_balance + 100u64);
   }
 

--- a/substrate/dex/pallet/src/lib.rs
+++ b/substrate/dex/pallet/src/lib.rs
@@ -78,7 +78,7 @@ mod tests;
 #[cfg(test)]
 mod mock;
 
-use frame_support::ensure;
+use frame_support::{ensure, pallet_prelude::*, BoundedBTreeSet};
 use frame_system::{
   pallet_prelude::{BlockNumberFor, OriginFor},
   ensure_signed,
@@ -86,9 +86,12 @@ use frame_system::{
 
 pub use pallet::*;
 
-use sp_runtime::{traits::TrailingZeroInput, DispatchError};
+use sp_runtime::{
+  traits::{TrailingZeroInput, IntegerSquareRoot},
+  DispatchError,
+};
 
-use serai_primitives::{Coin, ExternalCoin, SubstrateAmount};
+use serai_primitives::*;
 
 use sp_std::prelude::*;
 pub use types::*;
@@ -103,14 +106,10 @@ pub use weights::WeightInfo;
 #[frame_support::pallet]
 pub mod pallet {
   use super::*;
-  use frame_support::{pallet_prelude::*, BoundedBTreeSet};
 
   use sp_core::sr25519::Public;
-  use sp_runtime::traits::IntegerSquareRoot;
 
   use coins_pallet::{Pallet as CoinsPallet, Config as CoinsConfig};
-
-  use serai_primitives::{NetworkId, *};
 
   /// Pool ID.
   ///

--- a/substrate/dex/pallet/src/lib.rs
+++ b/substrate/dex/pallet/src/lib.rs
@@ -1002,17 +1002,18 @@ pub mod pallet {
       Ok(amounts)
     }
 
-    /// Used by the RPC service to provide price on coin/SRI pool.
+    /// Used by the RPC service to provide current prices.
     pub fn quote_price_exact_tokens_for_tokens(
-      coin: ExternalCoin,
+      coin1: Coin,
+      coin2: Coin,
       amount: SubstrateAmount,
       include_fee: bool,
     ) -> Option<SubstrateAmount> {
-      let pool_id = Self::get_pool_id(Coin::native(), coin.into()).ok()?;
+      let pool_id = Self::get_pool_id(coin1, coin2).ok()?;
       let pool_account = Self::get_pool_account(pool_id);
 
-      let balance1 = Self::get_balance(&pool_account, Coin::native());
-      let balance2 = Self::get_balance(&pool_account, coin.into());
+      let balance1 = Self::get_balance(&pool_account, coin1);
+      let balance2 = Self::get_balance(&pool_account, coin2);
       if balance1 != 0 {
         if include_fee {
           Self::get_amount_out(amount, balance1, balance2).ok()
@@ -1026,15 +1027,16 @@ pub mod pallet {
 
     /// Used by the RPC service to provide current prices.
     pub fn quote_price_tokens_for_exact_tokens(
-      coin: ExternalCoin,
+      coin1: Coin,
+      coin2: Coin,
       amount: SubstrateAmount,
       include_fee: bool,
     ) -> Option<SubstrateAmount> {
-      let pool_id = Self::get_pool_id(Coin::native(), coin.into()).ok()?;
+      let pool_id = Self::get_pool_id(coin1, coin2).ok()?;
       let pool_account = Self::get_pool_account(pool_id);
 
-      let balance1 = Self::get_balance(&pool_account, Coin::native());
-      let balance2 = Self::get_balance(&pool_account, coin.into());
+      let balance1 = Self::get_balance(&pool_account, coin1);
+      let balance2 = Self::get_balance(&pool_account, coin2);
       if balance1 != 0 {
         if include_fee {
           Self::get_amount_in(amount, balance1, balance2).ok()
@@ -1239,7 +1241,8 @@ sp_api::decl_runtime_apis! {
     /// Note that the price may have changed by the time the transaction is executed.
     /// (Use `amount_in_max` to control slippage.)
     fn quote_price_tokens_for_exact_tokens(
-      coin: ExternalCoin,
+      coin1: Coin,
+      coin2: Coin,
       amount: SubstrateAmount,
       include_fee: bool
     ) -> Option<SubstrateAmount>;
@@ -1249,7 +1252,8 @@ sp_api::decl_runtime_apis! {
     /// Note that the price may have changed by the time the transaction is executed.
     /// (Use `amount_out_min` to control slippage.)
     fn quote_price_exact_tokens_for_tokens(
-      coin: ExternalCoin,
+      coin1: Coin,
+      coin2: Coin,
       amount: SubstrateAmount,
       include_fee: bool
     ) -> Option<SubstrateAmount>;

--- a/substrate/dex/pallet/src/tests.rs
+++ b/substrate/dex/pallet/src/tests.rs
@@ -72,11 +72,13 @@ fn check_pool_accounts_dont_collide() {
   let mut map = HashSet::new();
 
   for coin in coins() {
-    let account = Dex::get_pool_account(coin);
-    if map.contains(&account) {
-      panic!("Collision at {coin:?}");
+    if let Coin::External(c) = coin {
+      let account = Dex::get_pool_account(c);
+      if map.contains(&account) {
+        panic!("Collision at {c:?}");
+      }
+      map.insert(account);
     }
-    map.insert(account);
   }
 }
 
@@ -98,11 +100,11 @@ fn can_create_pool() {
     let coin_account_deposit: u64 = 0;
     let user: PublicKey = system_address(b"user1").into();
     let coin1 = Coin::native();
-    let coin2 = Coin::Monero;
+    let coin2 = Coin::External(ExternalCoin::Monero);
     let pool_id = Dex::get_pool_id(coin1, coin2).unwrap();
 
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin1, amount: Amount(1000) }));
-    assert_ok!(Dex::create_pool(coin2));
+    assert_ok!(Dex::create_pool(coin2.try_into().unwrap()));
 
     assert_eq!(balance(user, coin1), 1000 - coin_account_deposit);
 
@@ -111,15 +113,13 @@ fn can_create_pool() {
       [Event::<Test>::PoolCreated { pool_id, pool_account: Dex::get_pool_account(pool_id) }]
     );
     assert_eq!(pools(), vec![pool_id]);
-
-    assert_noop!(Dex::create_pool(coin1), Error::<Test>::EqualCoins);
   });
 }
 
 #[test]
 fn create_same_pool_twice_should_fail() {
   new_test_ext().execute_with(|| {
-    let coin = Coin::Dai;
+    let coin = ExternalCoin::Dai;
     assert_ok!(Dex::create_pool(coin));
     assert_noop!(Dex::create_pool(coin), Error::<Test>::PoolExists);
   });
@@ -129,13 +129,13 @@ fn create_same_pool_twice_should_fail() {
 fn different_pools_should_have_different_lp_tokens() {
   new_test_ext().execute_with(|| {
     let coin1 = Coin::native();
-    let coin2 = Coin::Bitcoin;
-    let coin3 = Coin::Ether;
+    let coin2 = Coin::External(ExternalCoin::Bitcoin);
+    let coin3 = Coin::External(ExternalCoin::Ether);
     let pool_id_1_2 = Dex::get_pool_id(coin1, coin2).unwrap();
     let pool_id_1_3 = Dex::get_pool_id(coin1, coin3).unwrap();
 
     let lp_token2_1 = coin2;
-    assert_ok!(Dex::create_pool(coin2));
+    assert_ok!(Dex::create_pool(coin2.try_into().unwrap()));
     let lp_token3_1 = coin3;
 
     assert_eq!(
@@ -146,7 +146,7 @@ fn different_pools_should_have_different_lp_tokens() {
       }]
     );
 
-    assert_ok!(Dex::create_pool(coin3));
+    assert_ok!(Dex::create_pool(coin3.try_into().unwrap()));
     assert_eq!(
       events(),
       [Event::<Test>::PoolCreated {
@@ -164,13 +164,13 @@ fn can_add_liquidity() {
   new_test_ext().execute_with(|| {
     let user = system_address(b"user1").into();
     let coin1 = Coin::native();
-    let coin2 = Coin::Dai;
-    let coin3 = Coin::Monero;
+    let coin2 = Coin::External(ExternalCoin::Dai);
+    let coin3 = Coin::External(ExternalCoin::Monero);
 
     let lp_token1 = coin2;
-    assert_ok!(Dex::create_pool(coin2));
+    assert_ok!(Dex::create_pool(coin2.try_into().unwrap()));
     let lp_token2 = coin3;
-    assert_ok!(Dex::create_pool(coin3));
+    assert_ok!(Dex::create_pool(coin3.try_into().unwrap()));
 
     assert_ok!(CoinsPallet::<Test>::mint(
       user,
@@ -179,7 +179,15 @@ fn can_add_liquidity() {
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin2, amount: Amount(1000) }));
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin3, amount: Amount(1000) }));
 
-    assert_ok!(Dex::add_liquidity(RuntimeOrigin::signed(user), coin2, 10, 10000, 10, 10000, user,));
+    assert_ok!(Dex::add_liquidity(
+      RuntimeOrigin::signed(user),
+      coin2.try_into().unwrap(),
+      10,
+      10000,
+      10,
+      10000,
+      user,
+    ));
 
     let pool_id = Dex::get_pool_id(coin1, coin2).unwrap();
     assert!(events().contains(&Event::<Test>::LiquidityAdded {
@@ -198,7 +206,15 @@ fn can_add_liquidity() {
     assert_eq!(pool_balance(user, lp_token1), 216);
 
     // try to pass the non-native - native coins, the result should be the same
-    assert_ok!(Dex::add_liquidity(RuntimeOrigin::signed(user), coin3, 10, 10000, 10, 10000, user,));
+    assert_ok!(Dex::add_liquidity(
+      RuntimeOrigin::signed(user),
+      coin3.try_into().unwrap(),
+      10,
+      10000,
+      10,
+      10000,
+      user,
+    ));
 
     let pool_id = Dex::get_pool_id(coin1, coin3).unwrap();
     assert!(events().contains(&Event::<Test>::LiquidityAdded {
@@ -223,12 +239,15 @@ fn add_tiny_liquidity_leads_to_insufficient_liquidity_minted_error() {
   new_test_ext().execute_with(|| {
     let user = system_address(b"user1").into();
     let coin1 = Coin::native();
-    let coin2 = Coin::Bitcoin;
+    let coin2 = ExternalCoin::Bitcoin;
 
     assert_ok!(Dex::create_pool(coin2));
 
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin1, amount: Amount(1000) }));
-    assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin2, amount: Amount(1000) }));
+    assert_ok!(CoinsPallet::<Test>::mint(
+      user,
+      Balance { coin: coin2.into(), amount: Amount(1000) }
+    ));
 
     assert_noop!(
       Dex::add_liquidity(RuntimeOrigin::signed(user), coin2, 1, 1, 1, 1, user),
@@ -242,11 +261,11 @@ fn add_tiny_liquidity_directly_to_pool_address() {
   new_test_ext().execute_with(|| {
     let user = system_address(b"user1").into();
     let coin1 = Coin::native();
-    let coin2 = Coin::Ether;
-    let coin3 = Coin::Dai;
+    let coin2 = Coin::External(ExternalCoin::Ether);
+    let coin3 = Coin::External(ExternalCoin::Dai);
 
-    assert_ok!(Dex::create_pool(coin2));
-    assert_ok!(Dex::create_pool(coin3));
+    assert_ok!(Dex::create_pool(coin2.try_into().unwrap()));
+    assert_ok!(Dex::create_pool(coin3.try_into().unwrap()));
 
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin1, amount: Amount(10000 * 2) }));
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin2, amount: Amount(10000) }));
@@ -259,7 +278,15 @@ fn add_tiny_liquidity_directly_to_pool_address() {
       Balance { coin: coin1, amount: Amount(1000) }
     ));
 
-    assert_ok!(Dex::add_liquidity(RuntimeOrigin::signed(user), coin2, 10, 10000, 10, 10000, user,));
+    assert_ok!(Dex::add_liquidity(
+      RuntimeOrigin::signed(user),
+      coin2.try_into().unwrap(),
+      10,
+      10000,
+      10,
+      10000,
+      user,
+    ));
 
     // check the same but for coin3 (non-native token)
     let pallet_account = Dex::get_pool_account(Dex::get_pool_id(coin1, coin3).unwrap());
@@ -267,7 +294,15 @@ fn add_tiny_liquidity_directly_to_pool_address() {
       pallet_account,
       Balance { coin: coin2, amount: Amount(1) }
     ));
-    assert_ok!(Dex::add_liquidity(RuntimeOrigin::signed(user), coin3, 10, 10000, 10, 10000, user,));
+    assert_ok!(Dex::add_liquidity(
+      RuntimeOrigin::signed(user),
+      coin3.try_into().unwrap(),
+      10,
+      10000,
+      10,
+      10000,
+      user,
+    ));
   });
 }
 
@@ -276,11 +311,11 @@ fn can_remove_liquidity() {
   new_test_ext().execute_with(|| {
     let user = system_address(b"user1").into();
     let coin1 = Coin::native();
-    let coin2 = Coin::Monero;
+    let coin2 = Coin::External(ExternalCoin::Monero);
     let pool_id = Dex::get_pool_id(coin1, coin2).unwrap();
 
     let lp_token = coin2;
-    assert_ok!(Dex::create_pool(coin2));
+    assert_ok!(Dex::create_pool(coin2.try_into().unwrap()));
 
     assert_ok!(CoinsPallet::<Test>::mint(
       user,
@@ -290,7 +325,7 @@ fn can_remove_liquidity() {
 
     assert_ok!(Dex::add_liquidity(
       RuntimeOrigin::signed(user),
-      coin2,
+      coin2.try_into().unwrap(),
       100000,
       1000000000,
       100000,
@@ -302,7 +337,7 @@ fn can_remove_liquidity() {
 
     assert_ok!(Dex::remove_liquidity(
       RuntimeOrigin::signed(user),
-      coin2,
+      coin2.try_into().unwrap(),
       total_lp_received,
       0,
       0,
@@ -334,15 +369,23 @@ fn can_not_redeem_more_lp_tokens_than_were_minted() {
   new_test_ext().execute_with(|| {
     let user = system_address(b"user1").into();
     let coin1 = Coin::native();
-    let coin2 = Coin::Dai;
+    let coin2 = Coin::External(ExternalCoin::Dai);
     let lp_token = coin2;
 
-    assert_ok!(Dex::create_pool(coin2));
+    assert_ok!(Dex::create_pool(coin2.try_into().unwrap()));
 
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin1, amount: Amount(10000) }));
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin2, amount: Amount(1000) }));
 
-    assert_ok!(Dex::add_liquidity(RuntimeOrigin::signed(user), coin2, 10, 10000, 10, 10000, user,));
+    assert_ok!(Dex::add_liquidity(
+      RuntimeOrigin::signed(user),
+      coin2.try_into().unwrap(),
+      10,
+      10000,
+      10,
+      10000,
+      user,
+    ));
 
     // Only 216 lp_tokens_minted
     assert_eq!(pool_balance(user, lp_token), 216);
@@ -350,7 +393,7 @@ fn can_not_redeem_more_lp_tokens_than_were_minted() {
     assert_noop!(
       Dex::remove_liquidity(
         RuntimeOrigin::signed(user),
-        coin2,
+        coin2.try_into().unwrap(),
         216 + 1, // Try and redeem 10 lp tokens while only 9 minted.
         0,
         0,
@@ -366,81 +409,48 @@ fn can_quote_price() {
   new_test_ext().execute_with(|| {
     let user = system_address(b"user1").into();
     let coin1 = Coin::native();
-    let coin2 = Coin::Ether;
+    let coin2 = ExternalCoin::Ether;
 
     assert_ok!(Dex::create_pool(coin2));
 
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin1, amount: Amount(100000) }));
-    assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin2, amount: Amount(1000) }));
+    assert_ok!(CoinsPallet::<Test>::mint(
+      user,
+      Balance { coin: coin2.into(), amount: Amount(1000) }
+    ));
 
     assert_ok!(Dex::add_liquidity(RuntimeOrigin::signed(user), coin2, 200, 10000, 1, 1, user,));
 
-    assert_eq!(
-      Dex::quote_price_exact_tokens_for_tokens(Coin::native(), coin2, 3000, false,),
-      Some(60)
-    );
+    assert_eq!(Dex::quote_price_exact_tokens_for_tokens(coin2, 3000, false,), Some(60));
     // including fee so should get less out...
-    assert_eq!(
-      Dex::quote_price_exact_tokens_for_tokens(Coin::native(), coin2, 3000, true,),
-      Some(46)
-    );
+    assert_eq!(Dex::quote_price_exact_tokens_for_tokens(coin2, 3000, true,), Some(46));
     // Check it still gives same price:
     // (if the above accidentally exchanged then it would not give same quote as before)
-    assert_eq!(
-      Dex::quote_price_exact_tokens_for_tokens(Coin::native(), coin2, 3000, false,),
-      Some(60)
-    );
+    assert_eq!(Dex::quote_price_exact_tokens_for_tokens(coin2, 3000, false,), Some(60));
     // including fee so should get less out...
-    assert_eq!(
-      Dex::quote_price_exact_tokens_for_tokens(Coin::native(), coin2, 3000, true,),
-      Some(46)
-    );
+    assert_eq!(Dex::quote_price_exact_tokens_for_tokens(coin2, 3000, true,), Some(46));
 
     // Check inverse:
-    assert_eq!(
-      Dex::quote_price_exact_tokens_for_tokens(coin2, Coin::native(), 60, false,),
-      Some(3000)
-    );
+    assert_eq!(Dex::quote_price_exact_tokens_for_tokens(coin2, 60, false,), Some(3000));
     // including fee so should get less out...
-    assert_eq!(
-      Dex::quote_price_exact_tokens_for_tokens(coin2, Coin::native(), 60, true,),
-      Some(2302)
-    );
+    assert_eq!(Dex::quote_price_exact_tokens_for_tokens(coin2, 60, true,), Some(2302));
 
     //
     // same tests as above but for quote_price_tokens_for_exact_tokens:
     //
-    assert_eq!(
-      Dex::quote_price_tokens_for_exact_tokens(Coin::native(), coin2, 60, false,),
-      Some(3000)
-    );
+    assert_eq!(Dex::quote_price_tokens_for_exact_tokens(coin2, 60, false,), Some(3000));
     // including fee so should need to put more in...
-    assert_eq!(
-      Dex::quote_price_tokens_for_exact_tokens(Coin::native(), coin2, 60, true,),
-      Some(4299)
-    );
+    assert_eq!(Dex::quote_price_tokens_for_exact_tokens(coin2, 60, true,), Some(4299));
     // Check it still gives same price:
     // (if the above accidentally exchanged then it would not give same quote as before)
-    assert_eq!(
-      Dex::quote_price_tokens_for_exact_tokens(Coin::native(), coin2, 60, false,),
-      Some(3000)
-    );
+    assert_eq!(Dex::quote_price_tokens_for_exact_tokens(coin2, 60, false,), Some(3000));
     // including fee so should need to put more in...
-    assert_eq!(
-      Dex::quote_price_tokens_for_exact_tokens(Coin::native(), coin2, 60, true,),
-      Some(4299)
-    );
+    assert_eq!(Dex::quote_price_tokens_for_exact_tokens(coin2, 60, true,), Some(4299));
 
     // Check inverse:
-    assert_eq!(
-      Dex::quote_price_tokens_for_exact_tokens(coin2, Coin::native(), 3000, false,),
-      Some(60)
-    );
+    assert_eq!(Dex::quote_price_tokens_for_exact_tokens(coin2, 3000, false,), Some(60));
     // including fee so should need to put more in...
-    assert_eq!(
-      Dex::quote_price_tokens_for_exact_tokens(coin2, Coin::native(), 3000, true,),
-      Some(86)
-    );
+    assert_eq!(Dex::quote_price_tokens_for_exact_tokens(coin2, 3000, true,), Some(86));
 
     //
     // roundtrip: Without fees one should get the original number
@@ -448,28 +458,24 @@ fn can_quote_price() {
     let amount_in = 100;
 
     assert_eq!(
-      Dex::quote_price_exact_tokens_for_tokens(coin2, Coin::native(), amount_in, false,).and_then(
-        |amount| Dex::quote_price_exact_tokens_for_tokens(Coin::native(), coin2, amount, false,)
-      ),
+      Dex::quote_price_exact_tokens_for_tokens(coin2, amount_in, false,)
+        .and_then(|amount| { Dex::quote_price_exact_tokens_for_tokens(coin2, amount, false) }),
       Some(amount_in)
     );
     assert_eq!(
-      Dex::quote_price_exact_tokens_for_tokens(Coin::native(), coin2, amount_in, false,).and_then(
-        |amount| Dex::quote_price_exact_tokens_for_tokens(coin2, Coin::native(), amount, false,)
-      ),
+      Dex::quote_price_exact_tokens_for_tokens(coin2, amount_in, false,)
+        .and_then(|amount| Dex::quote_price_exact_tokens_for_tokens(coin2, amount, false,)),
       Some(amount_in)
     );
 
     assert_eq!(
-      Dex::quote_price_tokens_for_exact_tokens(coin2, Coin::native(), amount_in, false,).and_then(
-        |amount| Dex::quote_price_tokens_for_exact_tokens(Coin::native(), coin2, amount, false,)
-      ),
+      Dex::quote_price_tokens_for_exact_tokens(coin2, amount_in, false,)
+        .and_then(|amount| { Dex::quote_price_tokens_for_exact_tokens(coin2, amount, false) }),
       Some(amount_in)
     );
     assert_eq!(
-      Dex::quote_price_tokens_for_exact_tokens(Coin::native(), coin2, amount_in, false,).and_then(
-        |amount| Dex::quote_price_tokens_for_exact_tokens(coin2, Coin::native(), amount, false,)
-      ),
+      Dex::quote_price_tokens_for_exact_tokens(coin2, amount_in, false,)
+        .and_then(|amount| Dex::quote_price_tokens_for_exact_tokens(coin2, amount, false,)),
       Some(amount_in)
     );
   });
@@ -481,28 +487,31 @@ fn quote_price_exact_tokens_for_tokens_matches_execution() {
     let user = system_address(b"user1").into();
     let user2 = system_address(b"user2").into();
     let coin1 = Coin::native();
-    let coin2 = Coin::Bitcoin;
+    let coin2 = ExternalCoin::Bitcoin;
 
     assert_ok!(Dex::create_pool(coin2));
 
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin1, amount: Amount(100000) }));
-    assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin2, amount: Amount(1000) }));
+    assert_ok!(CoinsPallet::<Test>::mint(
+      user,
+      Balance { coin: coin2.into(), amount: Amount(1000) }
+    ));
 
     assert_ok!(Dex::add_liquidity(RuntimeOrigin::signed(user), coin2, 200, 10000, 1, 1, user,));
 
     let amount = 1;
     let quoted_price = 49;
-    assert_eq!(
-      Dex::quote_price_exact_tokens_for_tokens(coin2, coin1, amount, true,),
-      Some(quoted_price)
-    );
+    assert_eq!(Dex::quote_price_exact_tokens_for_tokens(coin2, amount, true,), Some(quoted_price));
 
-    assert_ok!(CoinsPallet::<Test>::mint(user2, Balance { coin: coin2, amount: Amount(amount) }));
+    assert_ok!(CoinsPallet::<Test>::mint(
+      user2,
+      Balance { coin: coin2.into(), amount: Amount(amount) }
+    ));
     let prior_sri_balance = 0;
     assert_eq!(prior_sri_balance, balance(user2, coin1));
     assert_ok!(Dex::swap_exact_tokens_for_tokens(
       RuntimeOrigin::signed(user2),
-      bvec![coin2, coin1],
+      bvec![coin2.into(), coin1],
       amount,
       1,
       user2,
@@ -518,19 +527,27 @@ fn quote_price_tokens_for_exact_tokens_matches_execution() {
     let user = system_address(b"user1").into();
     let user2 = system_address(b"user2").into();
     let coin1 = Coin::native();
-    let coin2 = Coin::Monero;
+    let coin2 = Coin::External(ExternalCoin::Monero);
 
-    assert_ok!(Dex::create_pool(coin2));
+    assert_ok!(Dex::create_pool(coin2.try_into().unwrap()));
 
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin1, amount: Amount(100000) }));
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin2, amount: Amount(1000) }));
 
-    assert_ok!(Dex::add_liquidity(RuntimeOrigin::signed(user), coin2, 200, 10000, 1, 1, user,));
+    assert_ok!(Dex::add_liquidity(
+      RuntimeOrigin::signed(user),
+      coin2.try_into().unwrap(),
+      200,
+      10000,
+      1,
+      1,
+      user,
+    ));
 
     let amount = 49;
     let quoted_price = 1;
     assert_eq!(
-      Dex::quote_price_tokens_for_exact_tokens(coin2, coin1, amount, true,),
+      Dex::quote_price_tokens_for_exact_tokens(coin2.try_into().unwrap(), amount, true,),
       Some(quoted_price)
     );
 
@@ -557,10 +574,10 @@ fn can_swap_with_native() {
   new_test_ext().execute_with(|| {
     let user = system_address(b"user1").into();
     let coin1 = Coin::native();
-    let coin2 = Coin::Ether;
+    let coin2 = Coin::External(ExternalCoin::Ether);
     let pool_id = Dex::get_pool_id(coin1, coin2).unwrap();
 
-    assert_ok!(Dex::create_pool(coin2));
+    assert_ok!(Dex::create_pool(coin2.try_into().unwrap()));
 
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin1, amount: Amount(10000) }));
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin2, amount: Amount(1000) }));
@@ -570,7 +587,7 @@ fn can_swap_with_native() {
 
     assert_ok!(Dex::add_liquidity(
       RuntimeOrigin::signed(user),
-      coin2,
+      coin2.try_into().unwrap(),
       liquidity2,
       liquidity1,
       1,
@@ -602,8 +619,8 @@ fn can_swap_with_realistic_values() {
   new_test_ext().execute_with(|| {
     let user = system_address(b"user1").into();
     let sri = Coin::native();
-    let dai = Coin::Dai;
-    assert_ok!(Dex::create_pool(dai));
+    let dai = Coin::External(ExternalCoin::Dai);
+    assert_ok!(Dex::create_pool(dai.try_into().unwrap()));
 
     const UNIT: u64 = 1_000_000_000;
 
@@ -620,7 +637,7 @@ fn can_swap_with_realistic_values() {
     let liquidity_dai = 1_000_000 * UNIT;
     assert_ok!(Dex::add_liquidity(
       RuntimeOrigin::signed(user),
-      dai,
+      dai.try_into().unwrap(),
       liquidity_dai,
       liquidity_sri,
       1,
@@ -653,9 +670,9 @@ fn can_not_swap_in_pool_with_no_liquidity_added_yet() {
   new_test_ext().execute_with(|| {
     let user = system_address(b"user1").into();
     let coin1 = Coin::native();
-    let coin2 = Coin::Monero;
+    let coin2 = Coin::External(ExternalCoin::Monero);
 
-    assert_ok!(Dex::create_pool(coin2));
+    assert_ok!(Dex::create_pool(coin2.try_into().unwrap()));
 
     // Check can't swap an empty pool
     assert_noop!(
@@ -676,11 +693,11 @@ fn check_no_panic_when_try_swap_close_to_empty_pool() {
   new_test_ext().execute_with(|| {
     let user = system_address(b"user1").into();
     let coin1 = Coin::native();
-    let coin2 = Coin::Bitcoin;
+    let coin2 = Coin::External(ExternalCoin::Bitcoin);
     let pool_id = Dex::get_pool_id(coin1, coin2).unwrap();
     let lp_token = coin2;
 
-    assert_ok!(Dex::create_pool(coin2));
+    assert_ok!(Dex::create_pool(coin2.try_into().unwrap()));
 
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin1, amount: Amount(10000) }));
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin2, amount: Amount(1000) }));
@@ -690,7 +707,7 @@ fn check_no_panic_when_try_swap_close_to_empty_pool() {
 
     assert_ok!(Dex::add_liquidity(
       RuntimeOrigin::signed(user),
-      coin2,
+      coin2.try_into().unwrap(),
       liquidity2,
       liquidity1,
       1,
@@ -714,7 +731,7 @@ fn check_no_panic_when_try_swap_close_to_empty_pool() {
 
     assert_ok!(Dex::remove_liquidity(
       RuntimeOrigin::signed(user),
-      coin2,
+      coin2.try_into().unwrap(),
       lp_token_minted,
       1,
       1,
@@ -787,9 +804,9 @@ fn swap_should_not_work_if_too_much_slippage() {
   new_test_ext().execute_with(|| {
     let user = system_address(b"user1").into();
     let coin1 = Coin::native();
-    let coin2 = Coin::Ether;
+    let coin2 = Coin::External(ExternalCoin::Ether);
 
-    assert_ok!(Dex::create_pool(coin2));
+    assert_ok!(Dex::create_pool(coin2.try_into().unwrap()));
 
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin1, amount: Amount(10000) }));
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin2, amount: Amount(1000) }));
@@ -799,7 +816,7 @@ fn swap_should_not_work_if_too_much_slippage() {
 
     assert_ok!(Dex::add_liquidity(
       RuntimeOrigin::signed(user),
-      coin2,
+      coin2.try_into().unwrap(),
       liquidity2,
       liquidity1,
       1,
@@ -827,10 +844,10 @@ fn can_swap_tokens_for_exact_tokens() {
   new_test_ext().execute_with(|| {
     let user = system_address(b"user1").into();
     let coin1 = Coin::native();
-    let coin2 = Coin::Dai;
+    let coin2 = Coin::External(ExternalCoin::Dai);
     let pool_id = Dex::get_pool_id(coin1, coin2).unwrap();
 
-    assert_ok!(Dex::create_pool(coin2));
+    assert_ok!(Dex::create_pool(coin2.try_into().unwrap()));
 
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin1, amount: Amount(20000) }));
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin2, amount: Amount(1000) }));
@@ -844,7 +861,7 @@ fn can_swap_tokens_for_exact_tokens() {
 
     assert_ok!(Dex::add_liquidity(
       RuntimeOrigin::signed(user),
-      coin2,
+      coin2.try_into().unwrap(),
       liquidity2,
       liquidity1,
       1,
@@ -882,11 +899,11 @@ fn can_swap_tokens_for_exact_tokens_when_not_liquidity_provider() {
     let user = system_address(b"user1").into();
     let user2 = system_address(b"user2").into();
     let coin1 = Coin::native();
-    let coin2 = Coin::Monero;
+    let coin2 = Coin::External(ExternalCoin::Monero);
     let pool_id = Dex::get_pool_id(coin1, coin2).unwrap();
     let lp_token = coin2;
 
-    assert_ok!(Dex::create_pool(coin2));
+    assert_ok!(Dex::create_pool(coin2.try_into().unwrap()));
 
     let base1 = 10000;
     let base2 = 1000;
@@ -903,7 +920,7 @@ fn can_swap_tokens_for_exact_tokens_when_not_liquidity_provider() {
 
     assert_ok!(Dex::add_liquidity(
       RuntimeOrigin::signed(user2),
-      coin2,
+      coin2.try_into().unwrap(),
       liquidity2,
       liquidity1,
       1,
@@ -947,7 +964,7 @@ fn can_swap_tokens_for_exact_tokens_when_not_liquidity_provider() {
 
     assert_ok!(Dex::remove_liquidity(
       RuntimeOrigin::signed(user2),
-      coin2,
+      coin2.try_into().unwrap(),
       lp_token_minted,
       0,
       0,
@@ -961,9 +978,9 @@ fn swap_tokens_for_exact_tokens_should_not_work_if_too_much_slippage() {
   new_test_ext().execute_with(|| {
     let user = system_address(b"user1").into();
     let coin1 = Coin::native();
-    let coin2 = Coin::Ether;
+    let coin2 = Coin::External(ExternalCoin::Ether);
 
-    assert_ok!(Dex::create_pool(coin2));
+    assert_ok!(Dex::create_pool(coin2.try_into().unwrap()));
 
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin1, amount: Amount(20000) }));
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin2, amount: Amount(1000) }));
@@ -973,7 +990,7 @@ fn swap_tokens_for_exact_tokens_should_not_work_if_too_much_slippage() {
 
     assert_ok!(Dex::add_liquidity(
       RuntimeOrigin::signed(user),
-      coin2,
+      coin2.try_into().unwrap(),
       liquidity2,
       liquidity1,
       1,
@@ -1001,11 +1018,11 @@ fn swap_exact_tokens_for_tokens_in_multi_hops() {
   new_test_ext().execute_with(|| {
     let user = system_address(b"user1").into();
     let coin1 = Coin::native();
-    let coin2 = Coin::Dai;
-    let coin3 = Coin::Monero;
+    let coin2 = Coin::External(ExternalCoin::Dai);
+    let coin3 = Coin::External(ExternalCoin::Monero);
 
-    assert_ok!(Dex::create_pool(coin2));
-    assert_ok!(Dex::create_pool(coin3));
+    assert_ok!(Dex::create_pool(coin2.try_into().unwrap()));
+    assert_ok!(Dex::create_pool(coin3.try_into().unwrap()));
 
     let base1 = 10000;
     let base2 = 10000;
@@ -1019,7 +1036,7 @@ fn swap_exact_tokens_for_tokens_in_multi_hops() {
 
     assert_ok!(Dex::add_liquidity(
       RuntimeOrigin::signed(user),
-      coin2,
+      coin2.try_into().unwrap(),
       liquidity2,
       liquidity1,
       1,
@@ -1028,7 +1045,7 @@ fn swap_exact_tokens_for_tokens_in_multi_hops() {
     ));
     assert_ok!(Dex::add_liquidity(
       RuntimeOrigin::signed(user),
-      coin3,
+      coin3.try_into().unwrap(),
       liquidity3,
       liquidity1,
       1,
@@ -1089,11 +1106,11 @@ fn swap_tokens_for_exact_tokens_in_multi_hops() {
   new_test_ext().execute_with(|| {
     let user = system_address(b"user1").into();
     let coin1 = Coin::native();
-    let coin2 = Coin::Bitcoin;
-    let coin3 = Coin::Ether;
+    let coin2 = Coin::External(ExternalCoin::Bitcoin);
+    let coin3 = Coin::External(ExternalCoin::Ether);
 
-    assert_ok!(Dex::create_pool(coin2));
-    assert_ok!(Dex::create_pool(coin3));
+    assert_ok!(Dex::create_pool(coin2.try_into().unwrap()));
+    assert_ok!(Dex::create_pool(coin3.try_into().unwrap()));
 
     let base1 = 10000;
     let base2 = 10000;
@@ -1107,7 +1124,7 @@ fn swap_tokens_for_exact_tokens_in_multi_hops() {
 
     assert_ok!(Dex::add_liquidity(
       RuntimeOrigin::signed(user),
-      coin2,
+      coin2.try_into().unwrap(),
       liquidity2,
       liquidity1,
       1,
@@ -1116,7 +1133,7 @@ fn swap_tokens_for_exact_tokens_in_multi_hops() {
     ));
     assert_ok!(Dex::add_liquidity(
       RuntimeOrigin::signed(user),
-      coin3,
+      coin3.try_into().unwrap(),
       liquidity3,
       liquidity1,
       1,
@@ -1154,7 +1171,7 @@ fn swap_tokens_for_exact_tokens_in_multi_hops() {
 fn can_not_swap_same_coin() {
   new_test_ext().execute_with(|| {
     let user = system_address(b"user1").into();
-    let coin1 = Coin::Dai;
+    let coin1 = Coin::External(ExternalCoin::Dai);
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin1, amount: Amount(1000) }));
 
     let exchange_amount = 10;
@@ -1188,10 +1205,10 @@ fn validate_pool_id_sorting() {
     // Serai < Bitcoin < Ether < Dai < Monero.
     // coin1 <= coin2 for this test to pass.
     let native = Coin::native();
-    let coin1 = Coin::Bitcoin;
-    let coin2 = Coin::Monero;
-    assert_eq!(Dex::get_pool_id(native, coin2).unwrap(), coin2);
-    assert_eq!(Dex::get_pool_id(coin2, native).unwrap(), coin2);
+    let coin1 = Coin::External(ExternalCoin::Bitcoin);
+    let coin2 = Coin::External(ExternalCoin::Monero);
+    assert_eq!(Dex::get_pool_id(native, coin2).unwrap(), coin2.try_into().unwrap());
+    assert_eq!(Dex::get_pool_id(coin2, native).unwrap(), coin2.try_into().unwrap());
     assert!(matches!(Dex::get_pool_id(native, native), Err(Error::<Test>::EqualCoins)));
     assert!(matches!(Dex::get_pool_id(coin2, coin1), Err(Error::<Test>::PoolNotFound)));
     assert!(coin2 > coin1);
@@ -1216,7 +1233,7 @@ fn cannot_block_pool_creation() {
 
     // The target pool the user wants to create is Native <=> Coin(2)
     let coin1 = Coin::native();
-    let coin2 = Coin::Ether;
+    let coin2 = Coin::External(ExternalCoin::Ether);
 
     // Attacker computes the still non-existing pool account for the target pair
     let pool_account = Dex::get_pool_account(Dex::get_pool_id(coin2, coin1).unwrap());
@@ -1238,7 +1255,7 @@ fn cannot_block_pool_creation() {
     }
 
     // User can still create the pool
-    assert_ok!(Dex::create_pool(coin2));
+    assert_ok!(Dex::create_pool(coin2.try_into().unwrap()));
 
     // User has to transfer one Coin(2) token to the pool account (otherwise add_liquidity will
     // fail with `CoinTwoDepositDidNotMeetMinimum`), also transfer native token for the same error.
@@ -1256,7 +1273,15 @@ fn cannot_block_pool_creation() {
     ));
 
     // add_liquidity shouldn't fail because of the number of consumers
-    assert_ok!(Dex::add_liquidity(RuntimeOrigin::signed(user), coin2, 100, 9900, 10, 9900, user,));
+    assert_ok!(Dex::add_liquidity(
+      RuntimeOrigin::signed(user),
+      coin2.try_into().unwrap(),
+      100,
+      9900,
+      10,
+      9900,
+      user,
+    ));
   });
 }
 
@@ -1281,7 +1306,7 @@ fn test_median_price() {
         prices.push(OsRng.next_u64());
       }
     }
-    let coin = Coin::Bitcoin;
+    let coin = ExternalCoin::Bitcoin;
 
     assert!(prices.len() >= (2 * usize::from(MEDIAN_PRICE_WINDOW_LENGTH)));
     for i in 0 .. prices.len() {

--- a/substrate/dex/pallet/src/tests.rs
+++ b/substrate/dex/pallet/src/tests.rs
@@ -18,7 +18,10 @@
 // It has been forked into a crate distributed under the AGPL 3.0.
 // Please check the current distribution for up-to-date copyright and licensing information.
 
-use crate::{mock::*, *};
+use crate::{
+  mock::{*, MEDIAN_PRICE_WINDOW_LENGTH},
+  *,
+};
 use frame_support::{assert_noop, assert_ok};
 
 pub use coins_pallet as coins;

--- a/substrate/dex/pallet/src/tests.rs
+++ b/substrate/dex/pallet/src/tests.rs
@@ -414,10 +414,7 @@ fn can_quote_price() {
     assert_ok!(Dex::create_pool(coin2.try_into().unwrap()));
 
     assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin1, amount: Amount(100000) }));
-    assert_ok!(CoinsPallet::<Test>::mint(
-      user,
-      Balance { coin: coin2.into(), amount: Amount(1000) }
-    ));
+    assert_ok!(CoinsPallet::<Test>::mint(user, Balance { coin: coin2, amount: Amount(1000) }));
 
     assert_ok!(Dex::add_liquidity(
       RuntimeOrigin::signed(user),

--- a/substrate/economic-security/pallet/src/lib.rs
+++ b/substrate/economic-security/pallet/src/lib.rs
@@ -41,7 +41,8 @@ pub mod pallet {
       // we accept we reached economic security once we can mint smallest amount of a network's coin
       for coin in EXTERNAL_COINS {
         let existing = EconomicSecurityBlock::<T>::get(coin.network());
-        // TODO: we don't need this if is_allowed returns false when there is no coin value
+        // TODO: we don't need to check for oracle value if is_allowed returns false when there is
+        // no coin value
         if existing.is_none() &&
           Dex::<T>::security_oracle_value(coin).is_some() &&
           <T as CoinsConfig>::AllowMint::is_allowed(&ExternalBalance { coin, amount: Amount(1) })

--- a/substrate/genesis-liquidity/pallet/src/lib.rs
+++ b/substrate/genesis-liquidity/pallet/src/lib.rs
@@ -54,9 +54,9 @@ pub mod pallet {
   #[pallet::event]
   #[pallet::generate_deposit(fn deposit_event)]
   pub enum Event<T: Config> {
-    GenesisLiquidityAdded { by: SeraiAddress, balance: Balance },
-    GenesisLiquidityRemoved { by: SeraiAddress, balance: Balance },
-    GenesisLiquidityAddedToPool { coin1: Balance, sri: Amount },
+    GenesisLiquidityAdded { by: SeraiAddress, balance: ExternalBalance },
+    GenesisLiquidityRemoved { by: SeraiAddress, balance: ExternalBalance },
+    GenesisLiquidityAddedToPool { coin: ExternalBalance, sri: Amount },
   }
 
   #[pallet::pallet]
@@ -64,15 +64,23 @@ pub mod pallet {
 
   /// Keeps shares and the amount of coins per account.
   #[pallet::storage]
-  pub(crate) type Liquidity<T: Config> =
-    StorageDoubleMap<_, Identity, Coin, Blake2_128Concat, PublicKey, LiquidityAmount, OptionQuery>;
+  pub(crate) type Liquidity<T: Config> = StorageDoubleMap<
+    _,
+    Identity,
+    ExternalCoin,
+    Blake2_128Concat,
+    PublicKey,
+    LiquidityAmount,
+    OptionQuery,
+  >;
 
   /// Keeps the total shares and the total amount of coins per coin.
   #[pallet::storage]
-  pub(crate) type Supply<T: Config> = StorageMap<_, Identity, Coin, LiquidityAmount, OptionQuery>;
+  pub(crate) type Supply<T: Config> =
+    StorageMap<_, Identity, ExternalCoin, LiquidityAmount, OptionQuery>;
 
   #[pallet::storage]
-  pub(crate) type Oracle<T: Config> = StorageMap<_, Identity, Coin, u64, OptionQuery>;
+  pub(crate) type Oracle<T: Config> = StorageMap<_, Identity, ExternalCoin, u64, OptionQuery>;
 
   #[pallet::storage]
   #[pallet::getter(fn genesis_complete_block)]
@@ -102,11 +110,7 @@ pub mod pallet {
         // get pool & total values
         let mut pool_values = vec![];
         let mut total_value: u128 = 0;
-        for coin in COINS {
-          if coin == Coin::Serai {
-            continue;
-          }
-
+        for coin in EXTERNAL_COINS {
           // initial coin value in terms of btc
           let Some(value) = Oracle::<T>::get(coin) else {
             continue;
@@ -158,7 +162,7 @@ pub mod pallet {
 
           // let everyone know about the event
           Self::deposit_event(Event::GenesisLiquidityAddedToPool {
-            coin1: Balance { coin, amount: Amount(u64::try_from(pool_amount).unwrap()) },
+            coin: ExternalBalance { coin, amount: Amount(u64::try_from(pool_amount).unwrap()) },
             sri: Amount(sri_amount),
           });
         }
@@ -180,7 +184,7 @@ pub mod pallet {
   impl<T: Config> Pallet<T> {
     /// Add genesis liquidity for the given account. All accounts that provide liquidity
     /// will receive the genesis SRI according to their liquidity ratio.
-    pub fn add_coin_liquidity(account: PublicKey, balance: Balance) -> DispatchResult {
+    pub fn add_coin_liquidity(account: PublicKey, balance: ExternalBalance) -> DispatchResult {
       // check we are still in genesis period
       if Self::genesis_ended() {
         Err(Error::<T>::GenesisPeriodEnded)?;
@@ -227,7 +231,7 @@ pub mod pallet {
     /// If networks is yet to be reached that threshold, None is returned.
     fn blocks_since_ec_security() -> Option<u64> {
       let mut min = u64::MAX;
-      for n in NETWORKS {
+      for n in EXTERNAL_NETWORKS {
         let ec_security_block =
           EconomicSecurity::<T>::economic_security_block(n)?.saturated_into::<u64>();
         let current = <frame_system::Pallet<T>>::block_number().saturated_into::<u64>();
@@ -243,11 +247,7 @@ pub mod pallet {
     }
 
     fn oraclization_is_done() -> bool {
-      for c in COINS {
-        if c == Coin::Serai {
-          continue;
-        }
-
+      for c in EXTERNAL_COINS {
         if Oracle::<T>::get(c).is_none() {
           return false;
         }
@@ -276,7 +276,7 @@ pub mod pallet {
     /// Remove the provided genesis liquidity for an account.
     #[pallet::call_index(0)]
     #[pallet::weight((0, DispatchClass::Operational))] // TODO
-    pub fn remove_coin_liquidity(origin: OriginFor<T>, balance: Balance) -> DispatchResult {
+    pub fn remove_coin_liquidity(origin: OriginFor<T>, balance: ExternalBalance) -> DispatchResult {
       let account = ensure_signed(origin)?;
       let origin = RawOrigin::Signed(GENESIS_LIQUIDITY_ACCOUNT.into());
       let supply = Supply::<T>::get(balance.coin).ok_or(Error::<T>::NotEnoughLiquidity)?;
@@ -297,7 +297,7 @@ pub mod pallet {
 
         // remove liquidity from pool
         let prev_sri = Coins::<T>::balance(GENESIS_LIQUIDITY_ACCOUNT.into(), Coin::Serai);
-        let prev_coin = Coins::<T>::balance(GENESIS_LIQUIDITY_ACCOUNT.into(), balance.coin);
+        let prev_coin = Coins::<T>::balance(GENESIS_LIQUIDITY_ACCOUNT.into(), balance.coin.into());
         Dex::<T>::remove_liquidity(
           origin.clone().into(),
           balance.coin,
@@ -307,7 +307,8 @@ pub mod pallet {
           GENESIS_LIQUIDITY_ACCOUNT.into(),
         )?;
         let current_sri = Coins::<T>::balance(GENESIS_LIQUIDITY_ACCOUNT.into(), Coin::Serai);
-        let current_coin = Coins::<T>::balance(GENESIS_LIQUIDITY_ACCOUNT.into(), balance.coin);
+        let current_coin =
+          Coins::<T>::balance(GENESIS_LIQUIDITY_ACCOUNT.into(), balance.coin.into());
 
         // burn the SRI if necessary
         // TODO: take into consideration movement between pools.
@@ -333,7 +334,7 @@ pub mod pallet {
         Coins::<T>::transfer(
           origin.clone().into(),
           account,
-          Balance { coin: balance.coin, amount: Amount(coin_out) },
+          Balance { coin: balance.coin.into(), amount: Amount(coin_out) },
         )?;
         Coins::<T>::transfer(
           origin.into(),
@@ -366,7 +367,7 @@ pub mod pallet {
         Coins::<T>::transfer(
           origin.into(),
           account,
-          Balance { coin: balance.coin, amount: Amount(existing.coins) },
+          Balance { coin: balance.coin.into(), amount: Amount(existing.coins) },
         )?;
 
         (
@@ -404,10 +405,10 @@ pub mod pallet {
       ensure_none(origin)?;
 
       // set their relative values
-      Oracle::<T>::set(Coin::Bitcoin, Some(10u64.pow(Coin::Bitcoin.decimals())));
-      Oracle::<T>::set(Coin::Monero, Some(values.monero));
-      Oracle::<T>::set(Coin::Ether, Some(values.ether));
-      Oracle::<T>::set(Coin::Dai, Some(values.dai));
+      Oracle::<T>::set(ExternalCoin::Bitcoin, Some(10u64.pow(ExternalCoin::Bitcoin.decimals())));
+      Oracle::<T>::set(ExternalCoin::Monero, Some(values.monero));
+      Oracle::<T>::set(ExternalCoin::Ether, Some(values.ether));
+      Oracle::<T>::set(ExternalCoin::Dai, Some(values.dai));
       Ok(())
     }
   }

--- a/substrate/in-instructions/pallet/src/lib.rs
+++ b/substrate/in-instructions/pallet/src/lib.rs
@@ -60,7 +60,7 @@ pub mod pallet {
   pub enum Event<T: Config> {
     Batch { network: ExternalNetworkId, id: u32, block: BlockHash, instructions_hash: [u8; 32] },
     InstructionFailure { network: ExternalNetworkId, id: u32, index: u32 },
-    Halt { network: NetworkId },
+    Halt { network: ExternalNetworkId },
   }
 
   #[pallet::error]
@@ -86,7 +86,7 @@ pub mod pallet {
 
   // Halted networks.
   #[pallet::storage]
-  pub(crate) type Halted<T: Config> = StorageMap<_, Identity, NetworkId, (), OptionQuery>;
+  pub(crate) type Halted<T: Config> = StorageMap<_, Identity, ExternalNetworkId, (), OptionQuery>;
 
   // The latest block a network has acknowledged as finalized
   #[pallet::storage]
@@ -231,8 +231,7 @@ pub mod pallet {
       Ok(())
     }
 
-    pub fn halt(network: NetworkId) -> Result<(), DispatchError> {
-      // TODO: is it possible to halt serai network?
+    pub fn halt(network: ExternalNetworkId) -> Result<(), DispatchError> {
       Halted::<T>::set(network, Some(()));
       Self::deposit_event(Event::Halt { network });
       Ok(())
@@ -325,7 +324,7 @@ pub mod pallet {
         Err(InvalidTransaction::BadProof)?;
       }
 
-      if Halted::<T>::contains_key(NetworkId::from(network)) {
+      if Halted::<T>::contains_key(network) {
         Err(InvalidTransaction::Custom(1))?;
       }
 

--- a/substrate/in-instructions/primitives/src/lib.rs
+++ b/substrate/in-instructions/primitives/src/lib.rs
@@ -2,7 +2,6 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use serai_primitives::ExternalBalance;
 #[cfg(feature = "std")]
 use zeroize::Zeroize;
 
@@ -21,7 +20,7 @@ use sp_std::vec::Vec;
 use sp_runtime::RuntimeDebug;
 
 #[rustfmt::skip]
-use serai_primitives::{BlockHash, Balance, ExternalNetworkId, NetworkId, SeraiAddress, ExternalAddress, system_address};
+use serai_primitives::{BlockHash, Balance, ExternalNetworkId, NetworkId, SeraiAddress, ExternalBalance, ExternalAddress, system_address};
 
 mod shorthand;
 pub use shorthand::*;

--- a/substrate/in-instructions/primitives/src/lib.rs
+++ b/substrate/in-instructions/primitives/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use serai_primitives::ExternalBalance;
 #[cfg(feature = "std")]
 use zeroize::Zeroize;
 
@@ -20,7 +21,7 @@ use sp_std::vec::Vec;
 use sp_runtime::RuntimeDebug;
 
 #[rustfmt::skip]
-use serai_primitives::{BlockHash, Balance, NetworkId, SeraiAddress, ExternalAddress, system_address};
+use serai_primitives::{BlockHash, Balance, ExternalNetworkId, NetworkId, SeraiAddress, ExternalAddress, system_address};
 
 mod shorthand;
 pub use shorthand::*;
@@ -97,7 +98,7 @@ pub struct RefundableInInstruction {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct InInstructionWithBalance {
   pub instruction: InInstruction,
-  pub balance: Balance,
+  pub balance: ExternalBalance,
 }
 
 #[derive(Clone, PartialEq, Eq, Encode, Decode, TypeInfo, RuntimeDebug)]
@@ -105,7 +106,7 @@ pub struct InInstructionWithBalance {
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Batch {
-  pub network: NetworkId,
+  pub network: ExternalNetworkId,
   pub id: u32,
   pub block: BlockHash,
   pub instructions: Vec<InInstructionWithBalance>,

--- a/substrate/in-instructions/primitives/src/shorthand.rs
+++ b/substrate/in-instructions/primitives/src/shorthand.rs
@@ -9,7 +9,7 @@ use serde::{Serialize, Deserialize};
 use scale::{Encode, Decode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
-use serai_primitives::{Coin, Amount, SeraiAddress, ExternalAddress};
+use serai_primitives::{Amount, ExternalAddress, ExternalCoin, SeraiAddress};
 
 use coins_primitives::OutInstruction;
 
@@ -25,7 +25,7 @@ pub enum Shorthand {
   Raw(RefundableInInstruction),
   Swap {
     origin: Option<ExternalAddress>,
-    coin: Coin,
+    coin: ExternalCoin,
     minimum: Amount,
     out: OutInstruction,
   },

--- a/substrate/node/src/chain_spec.rs
+++ b/substrate/node/src/chain_spec.rs
@@ -33,6 +33,22 @@ fn devnet_genesis(
   endowed_accounts: Vec<PublicKey>,
 ) -> RuntimeGenesisConfig {
   let validators = validators.iter().map(|name| account_from_name(name)).collect::<Vec<_>>();
+  let key_shares = NETWORKS
+    .iter()
+    .map(|network| match network {
+      NetworkId::Serai => (NetworkId::Serai, Amount(50_000 * 10_u64.pow(8))),
+      NetworkId::External(ExternalNetworkId::Bitcoin) => {
+        (NetworkId::External(ExternalNetworkId::Bitcoin), Amount(1_000_000 * 10_u64.pow(8)))
+      }
+      NetworkId::External(ExternalNetworkId::Ethereum) => {
+        (NetworkId::External(ExternalNetworkId::Ethereum), Amount(1_000_000 * 10_u64.pow(8)))
+      }
+      NetworkId::External(ExternalNetworkId::Monero) => {
+        (NetworkId::External(ExternalNetworkId::Monero), Amount(100_000 * 10_u64.pow(8)))
+      }
+    })
+    .collect::<Vec<_>>();
+
   RuntimeGenesisConfig {
     system: SystemConfig { code: wasm_binary.to_vec(), _config: PhantomData },
 
@@ -47,29 +63,10 @@ fn devnet_genesis(
     },
 
     validator_sets: ValidatorSetsConfig {
-      networks: serai_runtime::primitives::NETWORKS
-        .iter()
-        .map(|network| match network {
-          NetworkId::Serai => (NetworkId::Serai, Amount(50_000 * 10_u64.pow(8))),
-          NetworkId::Bitcoin => (NetworkId::Bitcoin, Amount(1_000_000 * 10_u64.pow(8))),
-          NetworkId::Ethereum => (NetworkId::Ethereum, Amount(1_000_000 * 10_u64.pow(8))),
-          NetworkId::Monero => (NetworkId::Monero, Amount(100_000 * 10_u64.pow(8))),
-        })
-        .collect(),
+      networks: key_shares.clone(),
       participants: validators.clone(),
     },
-    emissions: EmissionsConfig {
-      networks: serai_runtime::primitives::NETWORKS
-        .iter()
-        .map(|network| match network {
-          NetworkId::Serai => (NetworkId::Serai, Amount(50_000 * 10_u64.pow(8))),
-          NetworkId::Bitcoin => (NetworkId::Bitcoin, Amount(1_000_000 * 10_u64.pow(8))),
-          NetworkId::Ethereum => (NetworkId::Ethereum, Amount(1_000_000 * 10_u64.pow(8))),
-          NetworkId::Monero => (NetworkId::Monero, Amount(100_000 * 10_u64.pow(8))),
-        })
-        .collect(),
-      participants: validators.clone(),
-    },
+    emissions: EmissionsConfig { networks: key_shares, participants: validators.clone() },
     signals: SignalsConfig::default(),
     babe: BabeConfig {
       authorities: validators.iter().map(|validator| ((*validator).into(), 1)).collect(),
@@ -88,6 +85,21 @@ fn testnet_genesis(wasm_binary: &[u8], validators: Vec<&'static str>) -> Runtime
     .into_iter()
     .map(|validator| Public::decode(&mut hex::decode(validator).unwrap().as_slice()).unwrap())
     .collect::<Vec<_>>();
+  let key_shares = NETWORKS
+    .iter()
+    .map(|network| match network {
+      NetworkId::Serai => (NetworkId::Serai, Amount(50_000 * 10_u64.pow(8))),
+      NetworkId::External(ExternalNetworkId::Bitcoin) => {
+        (NetworkId::External(ExternalNetworkId::Bitcoin), Amount(1_000_000 * 10_u64.pow(8)))
+      }
+      NetworkId::External(ExternalNetworkId::Ethereum) => {
+        (NetworkId::External(ExternalNetworkId::Ethereum), Amount(1_000_000 * 10_u64.pow(8)))
+      }
+      NetworkId::External(ExternalNetworkId::Monero) => {
+        (NetworkId::External(ExternalNetworkId::Monero), Amount(100_000 * 10_u64.pow(8)))
+      }
+    })
+    .collect::<Vec<_>>();
 
   assert_eq!(validators.iter().collect::<HashSet<_>>().len(), validators.len());
 
@@ -105,29 +117,10 @@ fn testnet_genesis(wasm_binary: &[u8], validators: Vec<&'static str>) -> Runtime
     },
 
     validator_sets: ValidatorSetsConfig {
-      networks: serai_runtime::primitives::NETWORKS
-        .iter()
-        .map(|network| match network {
-          NetworkId::Serai => (NetworkId::Serai, Amount(50_000 * 10_u64.pow(8))),
-          NetworkId::Bitcoin => (NetworkId::Bitcoin, Amount(1_000_000 * 10_u64.pow(8))),
-          NetworkId::Ethereum => (NetworkId::Ethereum, Amount(1_000_000 * 10_u64.pow(8))),
-          NetworkId::Monero => (NetworkId::Monero, Amount(100_000 * 10_u64.pow(8))),
-        })
-        .collect(),
+      networks: key_shares.clone(),
       participants: validators.clone(),
     },
-    emissions: EmissionsConfig {
-      networks: serai_runtime::primitives::NETWORKS
-        .iter()
-        .map(|network| match network {
-          NetworkId::Serai => (NetworkId::Serai, Amount(50_000 * 10_u64.pow(8))),
-          NetworkId::Bitcoin => (NetworkId::Bitcoin, Amount(1_000_000 * 10_u64.pow(8))),
-          NetworkId::Ethereum => (NetworkId::Ethereum, Amount(1_000_000 * 10_u64.pow(8))),
-          NetworkId::Monero => (NetworkId::Monero, Amount(100_000 * 10_u64.pow(8))),
-        })
-        .collect(),
-      participants: validators.clone(),
-    },
+    emissions: EmissionsConfig { networks: key_shares, participants: validators.clone() },
     signals: SignalsConfig::default(),
     babe: BabeConfig {
       authorities: validators.iter().map(|validator| ((*validator).into(), 1)).collect(),

--- a/substrate/primitives/Cargo.toml
+++ b/substrate/primitives/Cargo.toml
@@ -28,6 +28,7 @@ sp-application-crypto = { git = "https://github.com/serai-dex/substrate", defaul
 sp-core = { git = "https://github.com/serai-dex/substrate", default-features = false }
 sp-runtime = { git = "https://github.com/serai-dex/substrate", default-features = false }
 sp-io = { git = "https://github.com/serai-dex/substrate", default-features = false }
+sp-std = { git = "https://github.com/serai-dex/substrate", default-features = false }
 
 frame-support = { git = "https://github.com/serai-dex/substrate", default-features = false }
 
@@ -35,7 +36,7 @@ frame-support = { git = "https://github.com/serai-dex/substrate", default-featur
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 
 [features]
-std = ["zeroize", "scale/std", "borsh?/std", "serde?/std", "scale-info/std", "sp-core/std", "sp-runtime/std", "frame-support/std"]
+std = ["zeroize", "scale/std", "borsh?/std", "serde?/std", "scale-info/std", "sp-core/std", "sp-runtime/std", "sp-std/std", "frame-support/std"]
 borsh = ["dep:borsh"]
 serde = ["dep:serde"]
 default = ["std"]

--- a/substrate/primitives/src/amount.rs
+++ b/substrate/primitives/src/amount.rs
@@ -29,6 +29,8 @@ pub type SubstrateAmount = u64;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Amount(pub SubstrateAmount);
 
+// TODO: these impl shouldn't panic and return error to be dealt with.
+// Otherwise we might have a panic that stops the network.
 impl Add for Amount {
   type Output = Amount;
   fn add(self, other: Amount) -> Amount {

--- a/substrate/primitives/src/networks.rs
+++ b/substrate/primitives/src/networks.rs
@@ -215,7 +215,6 @@ impl Coin {
 
   pub fn decimals(&self) -> u32 {
     match self {
-      // Ether and DAI have 18 decimals, yet we only track 8 in order to fit them within u64s
       Coin::Serai => 8,
       Coin::External(c) => c.decimals(),
     }

--- a/substrate/primitives/src/networks.rs
+++ b/substrate/primitives/src/networks.rs
@@ -95,7 +95,7 @@ impl Decode for NetworkId {
     let kind = input.read_byte()?;
     match kind {
       0 => Ok(Self::Serai),
-      _ => Ok(ExternalNetworkId::decode(input)?.into()),
+      _ => Ok(ExternalNetworkId::decode(&mut [kind].as_slice())?.into()),
     }
   }
 }
@@ -264,7 +264,7 @@ impl Decode for Coin {
     let kind = input.read_byte()?;
     match kind {
       0 => Ok(Self::Serai),
-      _ => Ok(ExternalCoin::decode(input)?.into()),
+      _ => Ok(ExternalCoin::decode(&mut [kind].as_slice())?.into()),
     }
   }
 }

--- a/substrate/runtime/src/lib.rs
+++ b/substrate/runtime/src/lib.rs
@@ -53,8 +53,9 @@ use sp_runtime::{
 
 #[allow(unused_imports)]
 use primitives::{
-  NetworkId, PublicKey, AccountLookup, SubstrateAmount, Coin, NETWORKS, MEDIAN_PRICE_WINDOW_LENGTH,
-  HOURS, DAYS, MINUTES, TARGET_BLOCK_TIME, BLOCK_SIZE, FAST_EPOCH_DURATION,
+  NetworkId, PublicKey, AccountLookup, SubstrateAmount, Coin, EXTERNAL_NETWORKS,
+  MEDIAN_PRICE_WINDOW_LENGTH, HOURS, DAYS, MINUTES, TARGET_BLOCK_TIME, BLOCK_SIZE,
+  FAST_EPOCH_DURATION,
 };
 
 use support::{
@@ -570,10 +571,7 @@ sp_api::impl_runtime_apis! {
         .map(|(id, _)| id.into_inner().0)
         .collect::<hashbrown::HashSet<_>>();
       let mut all = serai_validators;
-      for network in NETWORKS {
-        if network == NetworkId::Serai {
-          continue;
-        }
+      for network in EXTERNAL_NETWORKS {
         // Returning the latest-decided, not latest and active, means the active set
         // may fail to peer find if there isn't sufficient overlap. If a large amount reboot,
         // forcing some validators to successfully peer find in order for the threshold to become
@@ -581,7 +579,7 @@ sp_api::impl_runtime_apis! {
         //
         // This is assumed not to matter in real life, yet an interesting note.
         let participants =
-          ValidatorSets::participants_for_latest_decided_set(network)
+          ValidatorSets::participants_for_latest_decided_set(NetworkId::from(network))
             .map_or(vec![], BoundedVec::into_inner);
         for (participant, _) in participants {
           all.insert(participant.0);

--- a/substrate/runtime/src/lib.rs
+++ b/substrate/runtime/src/lib.rs
@@ -8,6 +8,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use core::marker::PhantomData;
 
+use serai_primitives::ExternalCoin;
 // Re-export all components
 pub use serai_primitives as primitives;
 pub use primitives::{BlockNumber, Header};
@@ -610,21 +611,19 @@ sp_api::impl_runtime_apis! {
 
   impl dex::DexApi<Block> for Runtime {
     fn quote_price_exact_tokens_for_tokens(
-      asset1: Coin,
-      asset2: Coin,
+      asset: ExternalCoin,
       amount: SubstrateAmount,
       include_fee: bool
     ) -> Option<SubstrateAmount> {
-      Dex::quote_price_exact_tokens_for_tokens(asset1, asset2, amount, include_fee)
+      Dex::quote_price_exact_tokens_for_tokens(asset, amount, include_fee)
     }
 
     fn quote_price_tokens_for_exact_tokens(
-      asset1: Coin,
-      asset2: Coin,
+      asset: ExternalCoin,
       amount: SubstrateAmount,
       include_fee: bool
     ) -> Option<SubstrateAmount> {
-      Dex::quote_price_tokens_for_exact_tokens(asset1, asset2, amount, include_fee)
+      Dex::quote_price_tokens_for_exact_tokens(asset, amount, include_fee)
     }
 
     fn get_reserves(asset1: Coin, asset2: Coin) -> Option<(SubstrateAmount, SubstrateAmount)> {

--- a/substrate/runtime/src/lib.rs
+++ b/substrate/runtime/src/lib.rs
@@ -8,7 +8,6 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use core::marker::PhantomData;
 
-use serai_primitives::ExternalCoin;
 // Re-export all components
 pub use serai_primitives as primitives;
 pub use primitives::{BlockNumber, Header};
@@ -611,23 +610,25 @@ sp_api::impl_runtime_apis! {
 
   impl dex::DexApi<Block> for Runtime {
     fn quote_price_exact_tokens_for_tokens(
-      asset: ExternalCoin,
+      coin1: Coin,
+      coin2: Coin,
       amount: SubstrateAmount,
       include_fee: bool
     ) -> Option<SubstrateAmount> {
-      Dex::quote_price_exact_tokens_for_tokens(asset, amount, include_fee)
+      Dex::quote_price_exact_tokens_for_tokens(coin1, coin2, amount, include_fee)
     }
 
     fn quote_price_tokens_for_exact_tokens(
-      asset: ExternalCoin,
+      coin1: Coin,
+      coin2: Coin,
       amount: SubstrateAmount,
       include_fee: bool
     ) -> Option<SubstrateAmount> {
-      Dex::quote_price_tokens_for_exact_tokens(asset, amount, include_fee)
+      Dex::quote_price_tokens_for_exact_tokens(coin1, coin2, amount, include_fee)
     }
 
-    fn get_reserves(asset1: Coin, asset2: Coin) -> Option<(SubstrateAmount, SubstrateAmount)> {
-      Dex::get_reserves(&asset1, &asset2).ok()
+    fn get_reserves(coin1: Coin, coin2: Coin) -> Option<(SubstrateAmount, SubstrateAmount)> {
+      Dex::get_reserves(&coin1, &coin2).ok()
     }
   }
 }

--- a/substrate/signals/primitives/src/lib.rs
+++ b/substrate/signals/primitives/src/lib.rs
@@ -5,7 +5,7 @@
 use scale::{Encode, Decode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
-use serai_primitives::NetworkId;
+use serai_primitives::ExternalNetworkId;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Encode, Decode, MaxEncodedLen, TypeInfo)]
 #[cfg_attr(feature = "std", derive(zeroize::Zeroize))]
@@ -13,5 +13,5 @@ use serai_primitives::NetworkId;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SignalId {
   Retirement([u8; 32]),
-  Halt(NetworkId),
+  Halt(ExternalNetworkId),
 }

--- a/substrate/validator-sets/pallet/src/lib.rs
+++ b/substrate/validator-sets/pallet/src/lib.rs
@@ -316,11 +316,13 @@ pub mod pallet {
   /// The generated key pair for a given validator set instance.
   #[pallet::storage]
   #[pallet::getter(fn keys)]
-  pub type Keys<T: Config> = StorageMap<_, Twox64Concat, ValidatorSet, KeyPair, OptionQuery>;
+  pub type Keys<T: Config> =
+    StorageMap<_, Twox64Concat, ExternalValidatorSet, KeyPair, OptionQuery>;
 
   /// The key for validator sets which can (and still need to) publish their slash reports.
   #[pallet::storage]
-  pub type PendingSlashReport<T: Config> = StorageMap<_, Identity, NetworkId, Public, OptionQuery>;
+  pub type PendingSlashReport<T: Config> =
+    StorageMap<_, Identity, ExternalNetworkId, Public, OptionQuery>;
 
   /// Disabled validators.
   #[pallet::storage]
@@ -343,7 +345,7 @@ pub mod pallet {
       removed: T::AccountId,
     },
     KeyGen {
-      set: ValidatorSet,
+      set: ExternalValidatorSet,
       key_pair: KeyPair,
     },
     AcceptedHandover {
@@ -600,14 +602,16 @@ pub mod pallet {
       amount: Amount,
     ) -> Result<bool, DispatchError> {
       // Check it's safe to decrease this set's stake by this amount
-      let new_total_staked = Self::total_allocated_stake(network)
-        .unwrap()
-        .0
-        .checked_sub(amount.0)
-        .ok_or(Error::<T>::NotEnoughAllocated)?;
-      let required_stake = Self::required_stake_for_network(network);
-      if new_total_staked < required_stake {
-        Err(Error::<T>::DeallocationWouldRemoveEconomicSecurity)?;
+      if let NetworkId::External(n) = network {
+        let new_total_staked = Self::total_allocated_stake(NetworkId::from(n))
+          .unwrap()
+          .0
+          .checked_sub(amount.0)
+          .ok_or(Error::<T>::NotEnoughAllocated)?;
+        let required_stake = Self::required_stake_for_network(n);
+        if new_total_staked < required_stake {
+          Err(Error::<T>::DeallocationWouldRemoveEconomicSecurity)?;
+        }
       }
 
       let old_allocation =
@@ -690,20 +694,23 @@ pub mod pallet {
         return false;
       }
 
-      // Handover is automatically complete for Serai as it doesn't have a handover protocol
-      if network == NetworkId::Serai {
-        return true;
-      }
+      if let NetworkId::External(n) = network {
+        // The current session must have set keys for its handover to be completed
+        if !Keys::<T>::contains_key(ExternalValidatorSet { network: n, session }) {
+          return false;
+        }
 
-      // The current session must have set keys for its handover to be completed
-      if !Keys::<T>::contains_key(ValidatorSet { network, session }) {
-        return false;
+        // This must be the first session (which has set keys) OR the prior session must have been
+        // retired (signified by its keys no longer being present)
+        (session.0 == 0) ||
+          (!Keys::<T>::contains_key(ExternalValidatorSet {
+            network: n,
+            session: Session(session.0 - 1),
+          }))
+      } else {
+        // Handover is automatically complete for Serai as it doesn't have a handover protocol
+        true
       }
-
-      // This must be the first session (which has set keys) OR the prior session must have been
-      // retired (signified by its keys no longer being present)
-      (session.0 == 0) ||
-        (!Keys::<T>::contains_key(ValidatorSet { network, session: Session(session.0 - 1) }))
     }
 
     fn new_session() {
@@ -733,19 +740,20 @@ pub mod pallet {
     // TODO: This is called retire_set, yet just starts retiring the set
     // Update the nomenclature within this function
     pub fn retire_set(set: ValidatorSet) {
-      // If the prior prior set didn't report, emit they're retired now
-      if PendingSlashReport::<T>::get(set.network).is_some() {
-        Self::deposit_event(Event::SetRetired {
-          set: ValidatorSet { network: set.network, session: Session(set.session.0 - 1) },
-        });
-      }
-
       // Serai doesn't set keys and network slashes are handled by BABE/GRANDPA
-      if set.network != NetworkId::Serai {
+      if let NetworkId::External(n) = set.network {
+        // If the prior prior set didn't report, emit they're retired now
+        if PendingSlashReport::<T>::get(n).is_some() {
+          Self::deposit_event(Event::SetRetired {
+            set: ValidatorSet { network: set.network, session: Session(set.session.0 - 1) },
+          });
+        }
+
         // This overwrites the prior value as the prior to-report set's stake presumably just
         // unlocked, making their report unenforceable
-        let keys = Keys::<T>::take(set).unwrap();
-        PendingSlashReport::<T>::set(set.network, Some(keys.0));
+        let keys =
+          Keys::<T>::take(ExternalValidatorSet { network: n, session: set.session }).unwrap();
+        PendingSlashReport::<T>::set(n, Some(keys.0));
       }
 
       // We're retiring this set because the set after it accepted the handover
@@ -817,7 +825,7 @@ pub mod pallet {
     }
 
     /// Returns the required stake in terms SRI for a given `Balance`.
-    pub fn required_stake(balance: &Balance) -> SubstrateAmount {
+    pub fn required_stake(balance: &ExternalBalance) -> SubstrateAmount {
       use dex_pallet::HigherPrecisionBalance;
 
       // This is inclusive to an increase in accuracy
@@ -840,11 +848,11 @@ pub mod pallet {
     }
 
     /// Returns the current total required stake for a given `network`.
-    pub fn required_stake_for_network(network: NetworkId) -> SubstrateAmount {
+    pub fn required_stake_for_network(network: ExternalNetworkId) -> SubstrateAmount {
       let mut total_required = 0;
       for coin in network.coins() {
-        let supply = Coins::<T>::supply(coin);
-        total_required += Self::required_stake(&Balance { coin: *coin, amount: Amount(supply) });
+        let supply = Coins::<T>::supply(Coin::from(coin));
+        total_required += Self::required_stake(&ExternalBalance { coin, amount: Amount(supply) });
       }
       total_required
     }
@@ -940,7 +948,7 @@ pub mod pallet {
     #[pallet::weight(0)] // TODO
     pub fn set_keys(
       origin: OriginFor<T>,
-      network: NetworkId,
+      network: ExternalNetworkId,
       removed_participants: BoundedVec<Public, ConstU32<{ MAX_KEY_SHARES_PER_SET / 3 }>>,
       key_pair: KeyPair,
       signature: Signature,
@@ -951,8 +959,8 @@ pub mod pallet {
       // (called by pre_dispatch) checks it
       let _ = signature;
 
-      let session = Self::session(network).unwrap();
-      let set = ValidatorSet { network, session };
+      let session = Self::session(NetworkId::from(network)).unwrap();
+      let set = ExternalValidatorSet { network, session };
 
       Keys::<T>::set(set, Some(key_pair.clone()));
 
@@ -960,7 +968,7 @@ pub mod pallet {
       // We generally set TotalAllocatedStake when the prior set retires, and the new set is fully
       // active and liable. Since this is the first set, there is no prior set to wait to retire
       if session == Session(0) {
-        Self::set_total_allocated_stake(network);
+        Self::set_total_allocated_stake(NetworkId::from(network));
       }
 
       // This does not remove from TotalAllocatedStake or InSet in order to:
@@ -970,7 +978,7 @@ pub mod pallet {
       // 2) Not allow parties removed to immediately deallocate, per commentary on deallocation
       //    scheduling (https://github.com/serai-dex/serai/issues/394).
       for removed in removed_participants {
-        Self::deposit_event(Event::ParticipantRemoved { set, removed });
+        Self::deposit_event(Event::ParticipantRemoved { set: set.into(), removed });
       }
       Self::deposit_event(Event::KeyGen { set, key_pair });
 
@@ -981,7 +989,7 @@ pub mod pallet {
     #[pallet::weight(0)] // TODO
     pub fn report_slashes(
       origin: OriginFor<T>,
-      network: NetworkId,
+      network: ExternalNetworkId,
       slashes: BoundedVec<(Public, u32), ConstU32<{ MAX_KEY_SHARES_PER_SET / 3 }>>,
       signature: Signature,
     ) -> DispatchResult {
@@ -996,7 +1004,10 @@ pub mod pallet {
 
       // Emit set retireed
       Pallet::<T>::deposit_event(Event::SetRetired {
-        set: ValidatorSet { network, session: Session(Self::session(network).unwrap().0 - 1) },
+        set: ValidatorSet {
+          network: network.into(),
+          session: Session(Self::session(NetworkId::from(network)).unwrap().0 - 1),
+        },
       });
 
       Ok(())
@@ -1062,17 +1073,12 @@ pub mod pallet {
         Call::set_keys { network, ref removed_participants, ref key_pair, ref signature } => {
           let network = *network;
 
-          // Don't allow the Serai set to set_keys, as they have no reason to do so
-          if network == NetworkId::Serai {
-            Err(InvalidTransaction::Custom(0))?;
-          }
-
           // Confirm this set has a session
-          let Some(current_session) = Self::session(network) else {
+          let Some(current_session) = Self::session(NetworkId::from(network)) else {
             Err(InvalidTransaction::Custom(1))?
           };
 
-          let set = ValidatorSet { network, session: current_session };
+          let set = ExternalValidatorSet { network, session: current_session };
 
           // Confirm it has yet to set keys
           if Keys::<T>::get(set).is_some() {
@@ -1081,7 +1087,7 @@ pub mod pallet {
 
           // This is a needed precondition as this uses storage variables for the latest decided
           // session on this assumption
-          assert_eq!(Pallet::<T>::latest_decided_session(network), Some(current_session));
+          assert_eq!(Pallet::<T>::latest_decided_session(network.into()), Some(current_session));
 
           // This does not slash the removed participants as that'll be done at the end of the
           // set's lifetime
@@ -1094,15 +1100,15 @@ pub mod pallet {
             removed.insert(participant.0);
           }
 
-          let participants =
-            Participants::<T>::get(network).expect("session existed without participants");
+          let participants = Participants::<T>::get(NetworkId::from(network))
+            .expect("session existed without participants");
 
           let mut all_key_shares = 0;
           let mut signers = vec![];
           let mut signing_key_shares = 0;
           for participant in participants {
             let participant = participant.0;
-            let shares = InSet::<T>::get(network, participant)
+            let shares = InSet::<T>::get(NetworkId::from(network), participant)
               .expect("participant from Participants wasn't InSet");
             all_key_shares += shares;
 
@@ -1124,7 +1130,7 @@ pub mod pallet {
           // Verify the signature with the MuSig key of the signers
           // We theoretically don't need set_keys_message to bind to removed_participants, as the
           // key we're signing with effectively already does so, yet there's no reason not to
-          if !musig_key(set, &signers)
+          if !musig_key(set.into(), &signers)
             .verify(&set_keys_message(&set, removed_participants, key_pair), signature)
           {
             Err(InvalidTransaction::BadProof)?;
@@ -1138,17 +1144,16 @@ pub mod pallet {
         }
         Call::report_slashes { network, ref slashes, ref signature } => {
           let network = *network;
-          // Don't allow Serai to publish a slash report as BABE/GRANDPA handles slashes directly
-          if network == NetworkId::Serai {
-            Err(InvalidTransaction::Custom(0))?;
-          }
           let Some(key) = PendingSlashReport::<T>::take(network) else {
             // Assumed already published
             Err(InvalidTransaction::Stale)?
           };
+
           // There must have been a previous session is PendingSlashReport is populated
-          let set =
-            ValidatorSet { network, session: Session(Self::session(network).unwrap().0 - 1) };
+          let set = ExternalValidatorSet {
+            network,
+            session: Session(Self::session(NetworkId::from(network)).unwrap().0 - 1),
+          };
           if !key.verify(&report_slashes_message(&set, slashes), signature) {
             Err(InvalidTransaction::BadProof)?;
           }
@@ -1173,13 +1178,14 @@ pub mod pallet {
   }
 
   impl<T: Config> AllowMint for Pallet<T> {
-    fn is_allowed(balance: &Balance) -> bool {
+    fn is_allowed(balance: &ExternalBalance) -> bool {
       // get the required stake
       let current_required = Self::required_stake_for_network(balance.coin.network());
       let new_required = current_required + Self::required_stake(balance);
 
       // get the total stake for the network & compare.
-      let staked = Self::total_allocated_stake(balance.coin.network()).unwrap_or(Amount(0));
+      let staked =
+        Self::total_allocated_stake(NetworkId::from(balance.coin.network())).unwrap_or(Amount(0));
       staked.0 >= new_required
     }
   }

--- a/tests/coordinator/src/lib.rs
+++ b/tests/coordinator/src/lib.rs
@@ -19,7 +19,7 @@ use ciphersuite::{
   Ciphersuite, Ristretto,
 };
 
-use serai_client::primitives::NetworkId;
+use serai_client::primitives::ExternalNetworkId;
 
 use messages::{
   coordinator::{SubstrateSignableId, SubstrateSignId, cosign_block_msg},
@@ -108,7 +108,7 @@ pub struct Handles {
 }
 
 pub struct Processor {
-  network: NetworkId,
+  network: ExternalNetworkId,
 
   serai_rpc: String,
   #[allow(unused)]
@@ -132,7 +132,7 @@ impl Drop for Processor {
 impl Processor {
   pub async fn new(
     raw_i: u8,
-    network: NetworkId,
+    network: ExternalNetworkId,
     ops: &DockerOperations,
     handles: Handles,
     processor_key: <Ristretto as Ciphersuite>::F,

--- a/tests/coordinator/src/tests/batch.rs
+++ b/tests/coordinator/src/tests/batch.rs
@@ -16,7 +16,7 @@ use dkg::Participant;
 use scale::Encode;
 
 use serai_client::{
-  primitives::{NetworkId, BlockHash, Signature},
+  primitives::{BlockHash, Signature},
   in_instructions::{
     primitives::{Batch, SignedBatch, batch_message},
     InInstructionsEvent,
@@ -274,7 +274,7 @@ async fn batch_test() {
         Session(0),
         &substrate_key,
         Batch {
-          network: NetworkId::Bitcoin,
+          network: ExternalNetworkId::Bitcoin,
           id: 0,
           block: BlockHash([0x22; 32]),
           instructions: vec![],

--- a/tests/coordinator/src/tests/key_gen.rs
+++ b/tests/coordinator/src/tests/key_gen.rs
@@ -13,9 +13,8 @@ use ciphersuite::{
 use dkg::ThresholdParams;
 
 use serai_client::{
-  primitives::NetworkId,
+  validator_sets::primitives::{ExternalValidatorSet, KeyPair, Session},
   Public,
-  validator_sets::primitives::{Session, ValidatorSet, KeyPair},
 };
 use messages::{key_gen::KeyGenId, CoordinatorMessage};
 
@@ -28,7 +27,7 @@ pub async fn key_gen<C: Ciphersuite>(
   let coordinators = processors.len();
   let mut participant_is = vec![];
 
-  let set = ValidatorSet { session, network: NetworkId::Bitcoin };
+  let set = ExternalValidatorSet { session, network: ExternalNetworkId::Bitcoin };
   let id = KeyGenId { session: set.session, attempt: 0 };
 
   for (i, processor) in processors.iter_mut().enumerate() {

--- a/tests/coordinator/src/tests/mod.rs
+++ b/tests/coordinator/src/tests/mod.rs
@@ -104,7 +104,7 @@ pub(crate) async fn new_test(test_body: impl TestBody, fast_epoch: bool) {
       handles.insert(name, handle);
     }
 
-    let processor_key = message_queue_keys[&NetworkId::Bitcoin];
+    let processor_key = message_queue_keys[&ExternalNetworkId::Bitcoin];
 
     coordinators.push((
       Handles {
@@ -198,7 +198,7 @@ pub(crate) async fn new_test(test_body: impl TestBody, fast_epoch: bool) {
         processors.push(
           Processor::new(
             i.try_into().unwrap(),
-            NetworkId::Bitcoin,
+            ExternalNetworkId::Bitcoin,
             &outer_ops,
             handles.clone(),
             *key,

--- a/tests/coordinator/src/tests/rotation.rs
+++ b/tests/coordinator/src/tests/rotation.rs
@@ -132,13 +132,13 @@ async fn set_rotation_test() {
 
       // excluded participant
       let pair5 = insecure_pair_from_name("Eve");
-      let network = NetworkId::Bitcoin;
+      let network = ExternalNetworkId::Bitcoin;
       let amount = Amount(1_000_000 * 10_u64.pow(8));
       let serai = processors[0].serai().await;
 
       // allocate now for the last participant so that it is guaranteed to be included into session
       // 1 set. This doesn't affect the genesis set at all since that is a predetermined set.
-      allocate_stake(&serai, network, amount, &pair5, 0).await;
+      allocate_stake(&serai, network.into(), amount, &pair5, 0).await;
 
       // genesis keygen
       let _ = key_gen::<Secp256k1>(&mut processors, Session(0)).await;
@@ -151,12 +151,14 @@ async fn set_rotation_test() {
       }
 
       // wait until next session to see the effect on coordinator
-      wait_till_session_1(&serai, network).await;
+      wait_till_session_1(&serai, network.into()).await;
 
       // Ensure the new validator was included in the new set
       assert_eq!(
-        most_recent_new_set_event(&serai, network).await,
-        ValidatorSetsEvent::NewSet { set: ValidatorSet { session: Session(1), network } },
+        most_recent_new_set_event(&serai, network.into()).await,
+        ValidatorSetsEvent::NewSet {
+          set: ValidatorSet { session: Session(1), network: network.into() }
+        },
       );
 
       // add the last participant & do the keygen

--- a/tests/full-stack/src/tests/mint_and_burn.rs
+++ b/tests/full-stack/src/tests/mint_and_burn.rs
@@ -9,12 +9,13 @@ use rand_core::{RngCore, OsRng};
 use scale::Encode;
 
 use serai_client::{
-  primitives::{
-    NetworkId, Coin, Amount, Balance, SeraiAddress, ExternalAddress, insecure_pair_from_name,
-  },
-  validator_sets::primitives::{Session, ValidatorSet},
-  in_instructions::primitives::Shorthand,
   coins::primitives::{OutInstruction, OutInstructionWithBalance},
+  in_instructions::primitives::Shorthand,
+  primitives::{
+    insecure_pair_from_name, Amount, Balance, Coin, ExternalAddress, ExternalBalance, ExternalCoin,
+    SeraiAddress,
+  },
+  validator_sets::primitives::{ExternalValidatorSet, Session},
   PairTrait, SeraiCoins,
 };
 
@@ -199,7 +200,7 @@ async fn mint_and_burn_test() {
               .await
               .unwrap()
               .validator_sets()
-              .keys(ValidatorSet { network, session: Session(0) })
+              .keys(ExternalValidatorSet { network, session: Session(0) })
               .await
               .unwrap()
             {
@@ -224,7 +225,10 @@ async fn mint_and_burn_test() {
         }
       };
 
-      (key_pair(false, NetworkId::Bitcoin).await, key_pair(true, NetworkId::Monero).await)
+      (
+        key_pair(false, ExternalNetworkId::Bitcoin).await,
+        key_pair(true, ExternalNetworkId::Monero).await,
+      )
     };
 
     // Because the initial keys only become active when the network's time matches the Serai
@@ -439,8 +443,8 @@ async fn mint_and_burn_test() {
           );
         }
       };
-      wait_for_batch(false, NetworkId::Bitcoin).await;
-      wait_for_batch(true, NetworkId::Monero).await;
+      wait_for_batch(false, ExternalNetworkId::Bitcoin).await;
+      wait_for_batch(true, ExternalNetworkId::Monero).await;
     }
 
     // TODO: Verify the mints
@@ -492,7 +496,7 @@ async fn mint_and_burn_test() {
         let serai_pair = &serai_pair;
         move |nonce, coin, amount, address| async move {
           let out_instruction = OutInstructionWithBalance {
-            balance: Balance { coin, amount: Amount(amount) },
+            balance: ExternalBalance { coin, amount: Amount(amount) },
             instruction: OutInstruction { address, data: None },
           };
 
@@ -511,7 +515,7 @@ async fn mint_and_burn_test() {
       #[allow(clippy::inconsistent_digit_grouping)]
       burn(
         0,
-        Coin::Bitcoin,
+        ExternalCoin::Bitcoin,
         1_000_000_00,
         ExternalAddress::new(
           serai_client::networks::bitcoin::Address::new(bitcoin_addr.clone()).unwrap().into(),
@@ -522,7 +526,7 @@ async fn mint_and_burn_test() {
 
       burn(
         1,
-        Coin::Monero,
+        ExternalCoin::Monero,
         1_000_000_000_000,
         ExternalAddress::new(
           serai_client::networks::monero::Address::new(monero_addr).unwrap().into(),

--- a/tests/full-stack/src/tests/mod.rs
+++ b/tests/full-stack/src/tests/mod.rs
@@ -3,7 +3,7 @@ use std::{sync::OnceLock, collections::HashMap};
 
 use tokio::sync::Mutex;
 
-use serai_client::primitives::NetworkId;
+use serai_client::primitives::ExternalNetworkId;
 
 use dockertest::{
   LogAction, LogPolicy, LogSource, LogOptions, StartPolicy, TestBodySpecification,
@@ -56,15 +56,21 @@ pub(crate) async fn new_test(test_body: impl TestBody) {
 
     let (coord_key, message_queue_keys, message_queue_composition) = message_queue_instance();
 
-    let (bitcoin_composition, bitcoin_port) = network_instance(NetworkId::Bitcoin);
-    let mut bitcoin_processor_composition =
-      processor_instance(NetworkId::Bitcoin, bitcoin_port, message_queue_keys[&NetworkId::Bitcoin]);
+    let (bitcoin_composition, bitcoin_port) = network_instance(ExternalNetworkId::Bitcoin);
+    let mut bitcoin_processor_composition = processor_instance(
+      ExternalNetworkId::Bitcoin,
+      bitcoin_port,
+      message_queue_keys[&ExternalNetworkId::Bitcoin],
+    );
     assert_eq!(bitcoin_processor_composition.len(), 1);
     let bitcoin_processor_composition = bitcoin_processor_composition.swap_remove(0);
 
-    let (monero_composition, monero_port) = network_instance(NetworkId::Monero);
-    let mut monero_processor_composition =
-      processor_instance(NetworkId::Monero, monero_port, message_queue_keys[&NetworkId::Monero]);
+    let (monero_composition, monero_port) = network_instance(ExternalNetworkId::Monero);
+    let mut monero_processor_composition = processor_instance(
+      ExternalNetworkId::Monero,
+      monero_port,
+      message_queue_keys[&ExternalNetworkId::Monero],
+    );
     assert_eq!(monero_processor_composition.len(), 1);
     let monero_processor_composition = monero_processor_composition.swap_remove(0);
 

--- a/tests/processor/src/networks.rs
+++ b/tests/processor/src/networks.rs
@@ -4,9 +4,9 @@ use rand_core::{RngCore, OsRng};
 use scale::Encode;
 
 use serai_client::{
-  primitives::{Amount, NetworkId, Coin, Balance, ExternalAddress},
-  validator_sets::primitives::ExternalKey,
   in_instructions::primitives::{InInstruction, RefundableInInstruction, Shorthand},
+  primitives::{Amount, ExternalAddress, ExternalBalance, ExternalCoin, ExternalNetworkId},
+  validator_sets::primitives::ExternalKey,
 };
 
 use dockertest::{PullPolicy, Image, StartPolicy, TestBodySpecification, DockerOperations};
@@ -52,37 +52,32 @@ pub fn monero_instance() -> (TestBodySpecification, u32) {
   (composition, XMR_PORT)
 }
 
-pub fn network_instance(network: NetworkId) -> (TestBodySpecification, u32) {
+pub fn network_instance(network: ExternalNetworkId) -> (TestBodySpecification, u32) {
   match network {
-    NetworkId::Bitcoin => bitcoin_instance(),
-    NetworkId::Ethereum => ethereum_instance(),
-    NetworkId::Monero => monero_instance(),
-    NetworkId::Serai => {
-      panic!("Serai is not a valid network to spawn an instance of for a processor")
-    }
+    ExternalNetworkId::Bitcoin => bitcoin_instance(),
+    ExternalNetworkId::Ethereum => ethereum_instance(),
+    ExternalNetworkId::Monero => monero_instance(),
   }
 }
 
-pub fn network_rpc(network: NetworkId, ops: &DockerOperations, handle: &str) -> String {
+pub fn network_rpc(network: ExternalNetworkId, ops: &DockerOperations, handle: &str) -> String {
   let (ip, port) = ops
     .handle(handle)
     .host_port(match network {
-      NetworkId::Bitcoin => BTC_PORT,
-      NetworkId::Ethereum => ETH_PORT,
-      NetworkId::Monero => XMR_PORT,
-      NetworkId::Serai => panic!("getting port for external network yet it was Serai"),
+      ExternalNetworkId::Bitcoin => BTC_PORT,
+      ExternalNetworkId::Ethereum => ETH_PORT,
+      ExternalNetworkId::Monero => XMR_PORT,
     })
     .unwrap();
   format!("http://{RPC_USER}:{RPC_PASS}@{ip}:{port}")
 }
 
-pub fn confirmations(network: NetworkId) -> usize {
+pub fn confirmations(network: ExternalNetworkId) -> usize {
   use processor::networks::*;
   match network {
-    NetworkId::Bitcoin => Bitcoin::CONFIRMATIONS,
-    NetworkId::Ethereum => Ethereum::<serai_db::MemDb>::CONFIRMATIONS,
-    NetworkId::Monero => Monero::CONFIRMATIONS,
-    NetworkId::Serai => panic!("getting confirmations required for Serai"),
+    ExternalNetworkId::Bitcoin => Bitcoin::CONFIRMATIONS,
+    ExternalNetworkId::Ethereum => Ethereum::<serai_db::MemDb>::CONFIRMATIONS,
+    ExternalNetworkId::Monero => Monero::CONFIRMATIONS,
   }
 }
 
@@ -108,11 +103,11 @@ pub enum Wallet {
 
 // TODO: Merge these functions with the processor's tests, which offers very similar functionality
 impl Wallet {
-  pub async fn new(network: NetworkId, ops: &DockerOperations, handle: String) -> Wallet {
+  pub async fn new(network: ExternalNetworkId, ops: &DockerOperations, handle: String) -> Wallet {
     let rpc_url = network_rpc(network, ops, &handle);
 
     match network {
-      NetworkId::Bitcoin => {
+      ExternalNetworkId::Bitcoin => {
         use bitcoin_serai::{
           bitcoin::{
             secp256k1::{SECP256K1, SecretKey},
@@ -153,7 +148,7 @@ impl Wallet {
         Wallet::Bitcoin { private_key, public_key, input_tx: funds }
       }
 
-      NetworkId::Ethereum => {
+      ExternalNetworkId::Ethereum => {
         use ciphersuite::{group::ff::Field, Secp256k1};
         use ethereum_serai::alloy::{
           primitives::{U256, Address},
@@ -185,7 +180,7 @@ impl Wallet {
         Wallet::Ethereum { rpc_url: rpc_url.clone(), key, nonce: 0 }
       }
 
-      NetworkId::Monero => {
+      ExternalNetworkId::Monero => {
         use curve25519_dalek::{constants::ED25519_BASEPOINT_POINT, scalar::Scalar};
         use monero_simple_request_rpc::SimpleRequestRpc;
         use monero_wallet::{rpc::Rpc, address::Network, ViewPair};
@@ -210,7 +205,6 @@ impl Wallet {
           last_tx: (height, block.miner_transaction.hash()),
         }
       }
-      NetworkId::Serai => panic!("creating a wallet for for Serai"),
     }
   }
 
@@ -219,7 +213,7 @@ impl Wallet {
     ops: &DockerOperations,
     to: &ExternalKey,
     instruction: Option<InInstruction>,
-  ) -> (Vec<u8>, Balance) {
+  ) -> (Vec<u8>, ExternalBalance) {
     match self {
       Wallet::Bitcoin { private_key, public_key, ref mut input_tx } => {
         use bitcoin_serai::bitcoin::{
@@ -298,7 +292,7 @@ impl Wallet {
         let mut buf = vec![];
         tx.consensus_encode(&mut buf).unwrap();
         *input_tx = tx;
-        (buf, Balance { coin: Coin::Bitcoin, amount: Amount(AMOUNT) })
+        (buf, ExternalBalance { coin: ExternalCoin::Bitcoin, amount: Amount(AMOUNT) })
       }
 
       Wallet::Ethereum { rpc_url, key, ref mut nonce } => {
@@ -400,7 +394,10 @@ impl Wallet {
         // We drop the bottom 10 decimals
         (
           bytes,
-          Balance { coin: Coin::Ether, amount: Amount(u64::try_from(eight_decimals).unwrap()) },
+          ExternalBalance {
+            coin: ExternalCoin::Ether,
+            amount: Amount(u64::try_from(eight_decimals).unwrap()),
+          },
         )
       }
 
@@ -417,7 +414,7 @@ impl Wallet {
         };
         use processor::{additional_key, networks::Monero};
 
-        let rpc_url = network_rpc(NetworkId::Monero, ops, handle);
+        let rpc_url = network_rpc(ExternalNetworkId::Monero, ops, handle);
         let rpc = SimpleRequestRpc::new(rpc_url).await.expect("couldn't connect to the Monero RPC");
 
         // Prepare inputs
@@ -485,7 +482,7 @@ impl Wallet {
         last_tx.0 = current_height;
         last_tx.1 = tx.hash();
 
-        (tx.serialize(), Balance { coin: Coin::Monero, amount: Amount(AMOUNT) })
+        (tx.serialize(), ExternalBalance { coin: ExternalCoin::Monero, amount: Amount(AMOUNT) })
       }
     }
   }

--- a/tests/processor/src/tests/batch.rs
+++ b/tests/processor/src/tests/batch.rs
@@ -13,7 +13,7 @@ use serai_client::{
   },
   primitives::{
     crypto::RuntimePublic, Amount, BlockHash, ExternalBalance, ExternalNetworkId, PublicKey,
-    SeraiAddress,
+    SeraiAddress, EXTERNAL_NETWORKS,
   },
   validator_sets::primitives::Session,
 };
@@ -190,9 +190,7 @@ pub(crate) async fn substrate_block(
 
 #[test]
 fn batch_test() {
-  for network in
-    [ExternalNetworkId::Bitcoin, ExternalNetworkId::Ethereum, ExternalNetworkId::Monero]
-  {
+  for network in EXTERNAL_NETWORKS {
     let (coordinators, test) = new_test(network);
 
     test.run(|ops| async move {

--- a/tests/processor/src/tests/batch.rs
+++ b/tests/processor/src/tests/batch.rs
@@ -8,11 +8,12 @@ use dkg::{Participant, tests::clone_without};
 use messages::{coordinator::*, SubstrateContext};
 
 use serai_client::{
-  primitives::{
-    BlockHash, Amount, Balance, crypto::RuntimePublic, PublicKey, SeraiAddress, NetworkId,
-  },
   in_instructions::primitives::{
-    InInstruction, InInstructionWithBalance, Batch, SignedBatch, batch_message,
+    batch_message, Batch, InInstruction, InInstructionWithBalance, SignedBatch,
+  },
+  primitives::{
+    crypto::RuntimePublic, Amount, BlockHash, ExternalBalance, ExternalNetworkId, PublicKey,
+    SeraiAddress,
   },
   validator_sets::primitives::Session,
 };
@@ -189,7 +190,9 @@ pub(crate) async fn substrate_block(
 
 #[test]
 fn batch_test() {
-  for network in [NetworkId::Bitcoin, NetworkId::Ethereum, NetworkId::Monero] {
+  for network in
+    [ExternalNetworkId::Bitcoin, ExternalNetworkId::Ethereum, ExternalNetworkId::Monero]
+  {
     let (coordinators, test) = new_test(network);
 
     test.run(|ops| async move {
@@ -255,15 +258,14 @@ fn batch_test() {
           instructions: if let Some(instruction) = &instruction {
             vec![InInstructionWithBalance {
               instruction: instruction.clone(),
-              balance: Balance {
+              balance: ExternalBalance {
                 coin: balance_sent.coin,
                 amount: Amount(
                   balance_sent.amount.0 -
                     (2 * match network {
-                      NetworkId::Bitcoin => Bitcoin::COST_TO_AGGREGATE,
-                      NetworkId::Ethereum => Ethereum::<MemDb>::COST_TO_AGGREGATE,
-                      NetworkId::Monero => Monero::COST_TO_AGGREGATE,
-                      NetworkId::Serai => panic!("minted for Serai?"),
+                      ExternalNetworkId::Bitcoin => Bitcoin::COST_TO_AGGREGATE,
+                      ExternalNetworkId::Ethereum => Ethereum::<MemDb>::COST_TO_AGGREGATE,
+                      ExternalNetworkId::Monero => Monero::COST_TO_AGGREGATE,
                     }),
                 ),
               },
@@ -322,7 +324,9 @@ fn batch_test() {
             },
           )
           .await;
-          if instruction.is_some() || (instruction.is_none() && (network == NetworkId::Monero)) {
+          if instruction.is_some() ||
+            (instruction.is_none() && (network == ExternalNetworkId::Monero))
+          {
             assert!(plans.is_empty());
           } else {
             // If no instruction was used, and the processor csn presume the origin, it'd have
@@ -335,7 +339,7 @@ fn batch_test() {
       // With the latter InInstruction not existing, we should've triggered a refund if the origin
       // was detectable
       // Check this is trying to sign a Plan
-      if network != NetworkId::Monero {
+      if network != ExternalNetworkId::Monero {
         let mut refund_id = None;
         for coordinator in &mut coordinators {
           match coordinator.recv_message().await {

--- a/tests/processor/src/tests/key_gen.rs
+++ b/tests/processor/src/tests/key_gen.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, time::SystemTime};
 use dkg::{Participant, ThresholdParams, tests::clone_without};
 
 use serai_client::{
-  primitives::{NetworkId, BlockHash, PublicKey},
-  validator_sets::primitives::{Session, KeyPair},
+  primitives::{BlockHash, PublicKey, EXTERNAL_NETWORKS},
+  validator_sets::primitives::{KeyPair, Session},
 };
 
 use messages::{SubstrateContext, key_gen::KeyGenId, CoordinatorMessage, ProcessorMessage};
@@ -144,7 +144,7 @@ pub(crate) async fn key_gen(coordinators: &mut [Coordinator]) -> KeyPair {
 
 #[test]
 fn key_gen_test() {
-  for network in [NetworkId::Bitcoin, NetworkId::Ethereum, NetworkId::Monero] {
+  for network in EXTERNAL_NETWORKS {
     let (coordinators, test) = new_test(network);
 
     test.run(|ops| async move {

--- a/tests/processor/src/tests/mod.rs
+++ b/tests/processor/src/tests/mod.rs
@@ -1,7 +1,5 @@
 use ciphersuite::{Ciphersuite, Ristretto};
 
-use serai_client::primitives::NetworkId;
-
 use dockertest::DockerTest;
 
 use crate::*;
@@ -17,7 +15,9 @@ mod send;
 pub(crate) const COORDINATORS: usize = 4;
 pub(crate) const THRESHOLD: usize = ((COORDINATORS * 2) / 3) + 1;
 
-fn new_test(network: NetworkId) -> (Vec<(Handles, <Ristretto as Ciphersuite>::F)>, DockerTest) {
+fn new_test(
+  network: ExternalNetworkId,
+) -> (Vec<(Handles, <Ristretto as Ciphersuite>::F)>, DockerTest) {
   let mut coordinators = vec![];
   let mut test = DockerTest::new().with_network(dockertest::Network::Isolated);
   let mut eth_handle = None;
@@ -25,7 +25,7 @@ fn new_test(network: NetworkId) -> (Vec<(Handles, <Ristretto as Ciphersuite>::F)
     let (handles, coord_key, compositions) = processor_stack(network, eth_handle.clone());
     // TODO: Remove this once https://github.com/foundry-rs/foundry/issues/7955
     // This has all processors share an Ethereum node until we can sync controlled nodes
-    if network == NetworkId::Ethereum {
+    if network == ExternalNetworkId::Ethereum {
       eth_handle = eth_handle.or_else(|| Some(handles.0.clone()));
     }
     coordinators.push((handles, coord_key));

--- a/tests/processor/src/tests/send.rs
+++ b/tests/processor/src/tests/send.rs
@@ -8,9 +8,9 @@ use dkg::{Participant, tests::clone_without};
 use messages::{sign::SignId, SubstrateContext};
 
 use serai_client::{
-  primitives::{BlockHash, NetworkId, Amount, Balance, SeraiAddress},
   coins::primitives::{OutInstruction, OutInstructionWithBalance},
-  in_instructions::primitives::{InInstruction, InInstructionWithBalance, Batch},
+  in_instructions::primitives::{Batch, InInstruction, InInstructionWithBalance},
+  primitives::{Amount, BlockHash, ExternalBalance, SeraiAddress, EXTERNAL_NETWORKS},
   validator_sets::primitives::Session,
 };
 
@@ -147,7 +147,7 @@ pub(crate) async fn sign_tx(
 
 #[test]
 fn send_test() {
-  for network in [NetworkId::Bitcoin, NetworkId::Ethereum, NetworkId::Monero] {
+  for network in EXTERNAL_NETWORKS {
     let (coordinators, test) = new_test(network);
 
     test.run(|ops| async move {
@@ -202,10 +202,9 @@ fn send_test() {
       let amount_minted = Amount(
         balance_sent.amount.0 -
           (2 * match network {
-            NetworkId::Bitcoin => Bitcoin::COST_TO_AGGREGATE,
-            NetworkId::Ethereum => Ethereum::<MemDb>::COST_TO_AGGREGATE,
-            NetworkId::Monero => Monero::COST_TO_AGGREGATE,
-            NetworkId::Serai => panic!("minted for Serai?"),
+            ExternalNetworkId::Bitcoin => Bitcoin::COST_TO_AGGREGATE,
+            ExternalNetworkId::Ethereum => Ethereum::<MemDb>::COST_TO_AGGREGATE,
+            ExternalNetworkId::Monero => Monero::COST_TO_AGGREGATE,
           }),
       );
 
@@ -215,7 +214,7 @@ fn send_test() {
         block: BlockHash(block_with_tx.unwrap()),
         instructions: vec![InInstructionWithBalance {
           instruction,
-          balance: Balance { coin: balance_sent.coin, amount: amount_minted },
+          balance: ExternalBalance { coin: balance_sent.coin, amount: amount_minted },
         }],
       };
 
@@ -245,7 +244,7 @@ fn send_test() {
             block: substrate_block_num,
             burns: vec![OutInstructionWithBalance {
               instruction: OutInstruction { address: wallet.address(), data: None },
-              balance: Balance { coin: balance_sent.coin, amount: amount_minted },
+              balance: ExternalBalance { coin: balance_sent.coin, amount: amount_minted },
             }],
             batches: vec![batch.batch.id],
           },


### PR DESCRIPTION
This pr adds new types such as `ExternalNetworkId`, `ExternalCoin` to distinctly identify them and help reduce the bugs. These changes helps code readability and prevent us from constantly checking for native network or coin. 