### PR TITLE
Monero: expose merkle root function

### DIFF
--- a/networks/monero/src/block.rs
+++ b/networks/monero/src/block.rs
@@ -126,7 +126,10 @@ impl Block {
     transactions.push(self.miner_transaction.hash());
     transactions.extend_from_slice(&self.transactions);
 
-    blob.extend_from_slice(&merkle_root(transactions));
+    blob.extend_from_slice(
+      &merkle_root(transactions)
+        .expect("the tree will not be empty, the miner tx is always present"),
+    );
     write_varint(&(1 + self.transactions.len()), &mut blob).unwrap();
     blob
   }

--- a/networks/monero/src/block.rs
+++ b/networks/monero/src/block.rs
@@ -126,7 +126,7 @@ impl Block {
     transactions.push(self.miner_transaction.hash());
     transactions.extend_from_slice(&self.transactions);
 
-    blob.extend_from_slice(&merkle_root(&transactions));
+    blob.extend_from_slice(&merkle_root(transactions));
     write_varint(&(1 + self.transactions.len()), &mut blob).unwrap();
     blob
   }

--- a/networks/monero/src/lib.rs
+++ b/networks/monero/src/lib.rs
@@ -7,7 +7,7 @@ pub use monero_io as io;
 pub use monero_generators as generators;
 pub use monero_primitives as primitives;
 
-/// Merkel tree functionality.
+/// Merkle tree functionality.
 pub mod merkle;
 
 /// Ring Signature structs and functionality.

--- a/networks/monero/src/lib.rs
+++ b/networks/monero/src/lib.rs
@@ -7,7 +7,8 @@ pub use monero_io as io;
 pub use monero_generators as generators;
 pub use monero_primitives as primitives;
 
-mod merkle;
+/// Merkel tree functionality.
+pub mod merkle;
 
 /// Ring Signature structs and functionality.
 pub mod ring_signatures;

--- a/networks/monero/src/merkle.rs
+++ b/networks/monero/src/merkle.rs
@@ -2,14 +2,13 @@ use std_shims::vec::Vec;
 
 use crate::primitives::keccak256;
 
-pub(crate) fn merkle_root(root: [u8; 32], leafs: &[[u8; 32]]) -> [u8; 32] {
+/// Calculates the merkel root of the given tree. Equivalent to `tree_hash` in monero-core.
+pub fn merkle_root(leafs: &[[u8; 32]]) -> [u8; 32] {
   match leafs.len() {
-    0 => root,
-    1 => keccak256([root, leafs[0]].concat()),
+    1 => leafs[0],
+    2 => keccak256([leafs[0], leafs[1]].concat()),
     _ => {
-      let mut hashes = Vec::with_capacity(1 + leafs.len());
-      hashes.push(root);
-      hashes.extend(leafs);
+      let mut hashes = leafs.to_vec();
 
       // Monero preprocess this so the length is a power of 2
       let mut high_pow_2 = 4; // 4 is the lowest value this can be

--- a/networks/monero/src/merkle.rs
+++ b/networks/monero/src/merkle.rs
@@ -2,25 +2,29 @@ use std_shims::vec::Vec;
 
 use crate::primitives::keccak256;
 
-/// Calculates the merkel root of the given tree. Equivalent to `tree_hash` in monero-core.
-pub fn merkle_root(leafs: &[[u8; 32]]) -> [u8; 32] {
+/// Calculates the Merkle root of the given tree. Equivalent to `tree_hash` in monero-core:
+/// https://github.com/monero-project/monero/blob/893916ad091a92e765ce3241b94e706ad012b62a
+///   /src/crypto/tree-hash.c#L62
+///
+/// # Panics
+/// This function will panic if the tree is empty.
+pub fn merkle_root(mut leafs: Vec<[u8; 32]>) -> [u8; 32] {
   match leafs.len() {
+    0 => panic!("Can't compute Merkle root for empty tree"),
     1 => leafs[0],
     2 => keccak256([leafs[0], leafs[1]].concat()),
     _ => {
-      let mut hashes = leafs.to_vec();
-
       // Monero preprocess this so the length is a power of 2
       let mut high_pow_2 = 4; // 4 is the lowest value this can be
-      while high_pow_2 < hashes.len() {
+      while high_pow_2 < leafs.len() {
         high_pow_2 *= 2;
       }
       let low_pow_2 = high_pow_2 / 2;
 
       // Merge right-most hashes until we're at the low_pow_2
       {
-        let overage = hashes.len() - low_pow_2;
-        let mut rightmost = hashes.drain((low_pow_2 - overage) ..);
+        let overage = leafs.len() - low_pow_2;
+        let mut rightmost = leafs.drain((low_pow_2 - overage) ..);
         // This is true since we took overage from beneath and above low_pow_2, taking twice as
         // many elements as overage
         debug_assert_eq!(rightmost.len() % 2, 0);
@@ -32,23 +36,23 @@ pub fn merkle_root(leafs: &[[u8; 32]]) -> [u8; 32] {
         }
         drop(rightmost);
 
-        hashes.extend(paired_hashes);
-        assert_eq!(hashes.len(), low_pow_2);
+        leafs.extend(paired_hashes);
+        assert_eq!(leafs.len(), low_pow_2);
       }
 
       // Do a traditional pairing off
-      let mut new_hashes = Vec::with_capacity(hashes.len() / 2);
-      while hashes.len() > 1 {
+      let mut new_hashes = Vec::with_capacity(leafs.len() / 2);
+      while leafs.len() > 1 {
         let mut i = 0;
-        while i < hashes.len() {
-          new_hashes.push(keccak256([hashes[i], hashes[i + 1]].concat()));
+        while i < leafs.len() {
+          new_hashes.push(keccak256([leafs[i], leafs[i + 1]].concat()));
           i += 2;
         }
 
-        hashes = new_hashes;
-        new_hashes = Vec::with_capacity(hashes.len() / 2);
+        leafs = new_hashes;
+        new_hashes = Vec::with_capacity(leafs.len() / 2);
       }
-      hashes[0]
+      leafs[0]
     }
   }
 }

--- a/networks/monero/src/merkle.rs
+++ b/networks/monero/src/merkle.rs
@@ -6,13 +6,12 @@ use crate::primitives::keccak256;
 /// https://github.com/monero-project/monero/blob/893916ad091a92e765ce3241b94e706ad012b62a
 ///   /src/crypto/tree-hash.c#L62
 ///
-/// # Panics
-/// This function will panic if the tree is empty.
-pub fn merkle_root(mut leafs: Vec<[u8; 32]>) -> [u8; 32] {
+/// This function returns [`None`] if the tree is empty.
+pub fn merkle_root(mut leafs: Vec<[u8; 32]>) -> Option<[u8; 32]> {
   match leafs.len() {
-    0 => panic!("Can't compute Merkle root for empty tree"),
-    1 => leafs[0],
-    2 => keccak256([leafs[0], leafs[1]].concat()),
+    0 => None,
+    1 => Some(leafs[0]),
+    2 => Some(keccak256([leafs[0], leafs[1]].concat())),
     _ => {
       // Monero preprocess this so the length is a power of 2
       let mut high_pow_2 = 4; // 4 is the lowest value this can be
@@ -52,7 +51,7 @@ pub fn merkle_root(mut leafs: Vec<[u8; 32]>) -> [u8; 32] {
         leafs = new_hashes;
         new_hashes = Vec::with_capacity(leafs.len() / 2);
       }
-      leafs[0]
+      Some(leafs[0])
     }
   }
 }


### PR DESCRIPTION
This function is needed in the RPC: https://github.com/monero-project/monero/blob/893916ad091a92e765ce3241b94e706ad012b62a/src/rpc/core_rpc_server.cpp#L2172

I also made a small change to the function signature, taking all leafs in one arg,