### PR TITLE
remove mastodon and switch twitter -> X

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ issued at the discretion of the Immunefi program managers.
 
 - [Website](https://serai.exchange/): https://serai.exchange/
 - [Immunefi](https://immunefi.com/bounty/serai/): https://immunefi.com/bounty/serai/
-- [Twitter](https://twitter.com/SeraiDEX): https://twitter.com/SeraiDEX
-- [Mastodon](https://cryptodon.lol/@serai): https://cryptodon.lol/@serai
+- [Twitter](https://twitter.com/SeraiDEX): https://x.com/SeraiDEX
 - [Discord](https://discord.gg/mpEUtJR3vz): https://discord.gg/mpEUtJR3vz
 - [Matrix](https://matrix.to/#/#serai:matrix.org): https://matrix.to/#/#serai:matrix.org
 - [Reddit](https://www.reddit.com/r/SeraiDEX/): https://www.reddit.com/r/SeraiDEX/


### PR DESCRIPTION
mastodon instance https://cryptodon.lol/ have been down for a year and twitter account suspended, better remove immediately as it could turn into a scam.