### PR TITLE
fix(spec): svm version mismatch in docs; document foundryup

### DIFF
--- a/spec/Getting Started.md
+++ b/spec/Getting Started.md
@@ -51,7 +51,8 @@ svm use 0.8.25
 ### Install foundry (for tests)
 
 ```
-cargo install --git https://github.com/foundry-rs/foundry --profile local --locked forge cast chisel anvil
+curl -L https://foundry.paradigm.xyz | bash
+foundryup
 ```
 
 ### Clone and Build Serai

--- a/spec/Getting Started.md
+++ b/spec/Getting Started.md
@@ -36,8 +36,8 @@ rustup target add wasm32-unknown-unknown --toolchain nightly
 
 ```
 cargo install svm-rs
-svm install 0.8.25
-svm use 0.8.25
+svm install 0.8.26
+svm use 0.8.26
 ```
 
 ### Install Solidity Compiler Version Manager


### PR DESCRIPTION
I noticed that the svm version in the docs does not match what is used throughout the rest of the codebase.

The documented foundry installation command was not working for me (see [this issue](https://github.com/foundry-rs/foundry/issues/5659))