### PR TITLE
fix: remove duplicate docsrs cfg_attr lines

### DIFF
--- a/common/env/src/lib.rs
+++ b/common/env/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Obtain a variable from the Serai environment/secret store.
 pub fn var(variable: &str) -> Option<String> {

--- a/substrate/in-instructions/pallet/src/lib.rs
+++ b/substrate/in-instructions/pallet/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use sp_io::hashing::blake2_256;


### PR DESCRIPTION
Removes duplicate `#![cfg_attr(docsrs, feature(doc_cfg))]` lines in:
- `common/env/src/lib.rs`
- `substrate/in-instructions/pallet/src/lib.rs`

These appear to be copy-paste errors. The duplicate attribute has no effect but is unnecessary.