### PR TITLE
fix(bitcoin-serai): include OP_RETURN output in weight calculation

### DIFF
--- a/networks/bitcoin/src/wallet/send.rs
+++ b/networks/bitcoin/src/wallet/send.rs
@@ -63,6 +63,7 @@ impl SignableTransaction {
     inputs: usize,
     payments: &[(ScriptBuf, u64)],
     change: Option<&ScriptBuf>,
+    data: Option<&[u8]>,
   ) -> (u64, u64) {
     // Expand this a full transaction in order to use the bitcoin library's weight function
     let mut tx = Transaction {
@@ -96,6 +97,16 @@ impl SignableTransaction {
       // Use a 0 value since we're currently unsure what the change amount will be, and since
       // the value is fixed size (so any value could be used here)
       tx.output.push(TxOut { value: Amount::ZERO, script_pubkey: change.clone() });
+    }
+    // Include the OP_RETURN output in weight calculation if data is present
+    if let Some(data) = data {
+      tx.output.push(TxOut {
+        value: Amount::ZERO,
+        script_pubkey: ScriptBuf::new_op_return(
+          PushBytesBuf::try_from(data.to_vec())
+            .expect("data didn't fit into PushBytes despite being checked"),
+        ),
+      });
     }
 
     let weight = tx.weight();
@@ -190,18 +201,10 @@ impl SignableTransaction {
       .map(|payment| TxOut { value: Amount::from_sat(payment.1), script_pubkey: payment.0.clone() })
       .collect::<Vec<_>>();
 
-    // Add the OP_RETURN output
-    if let Some(data) = data {
-      tx_outs.push(TxOut {
-        value: Amount::ZERO,
-        script_pubkey: ScriptBuf::new_op_return(
-          PushBytesBuf::try_from(data)
-            .expect("data didn't fit into PushBytes depsite being checked"),
-        ),
-      })
-    }
-
-    let (mut weight, vbytes) = Self::calculate_weight_vbytes(tx_ins.len(), payments, None);
+    // Calculate weight including OP_RETURN output if data is present
+    let data_ref = data.as_deref();
+    let (mut weight, vbytes) =
+      Self::calculate_weight_vbytes(tx_ins.len(), payments, None, data_ref);
 
     let mut needed_fee = fee_per_vbyte * vbytes;
     // Technically, if there isn't change, this TX may still pay enough of a fee to pass the
@@ -223,7 +226,7 @@ impl SignableTransaction {
     // If there's a change address, check if there's change to give it
     if let Some(change) = change {
       let (weight_with_change, vbytes_with_change) =
-        Self::calculate_weight_vbytes(tx_ins.len(), payments, Some(&change));
+        Self::calculate_weight_vbytes(tx_ins.len(), payments, Some(&change), data_ref);
       let fee_with_change = fee_per_vbyte * vbytes_with_change;
       if let Some(value) = input_sat.checked_sub(payment_sat + fee_with_change) {
         if value >= DUST {
@@ -232,6 +235,17 @@ impl SignableTransaction {
           needed_fee = fee_with_change;
         }
       }
+    }
+
+    // Add the OP_RETURN output after weight calculation
+    if let Some(data) = data {
+      tx_outs.push(TxOut {
+        value: Amount::ZERO,
+        script_pubkey: ScriptBuf::new_op_return(
+          PushBytesBuf::try_from(data)
+            .expect("data didn't fit into PushBytes despite being checked"),
+        ),
+      })
     }
 
     if tx_outs.is_empty() {

--- a/networks/bitcoin/tests/wallet.rs
+++ b/networks/bitcoin/tests/wallet.rs
@@ -323,4 +323,56 @@ async_sequential! {
     check(tx.output[0].script_pubkey.instructions());
     check(tx.output[0].script_pubkey.instructions_minimal());
   }
+
+  // Test that weight calculation correctly includes OP_RETURN output
+  // This is a regression test for issue #691
+  async fn test_op_return_weight_calculation() {
+    let (keys, key) = keys();
+
+    let rpc = rpc().await;
+    let scanner = Scanner::new(key).unwrap();
+
+    let output = send_and_get_output(&rpc, &scanner, key).await;
+    assert_eq!(output.offset(), Scalar::ZERO);
+
+    // Create transaction with OP_RETURN data
+    let data = vec![0u8; 80]; // Maximum OP_RETURN data size
+    let signable_tx = SignableTransaction::new(
+      vec![output.clone()],
+      &[],
+      Some(p2tr_script_buf(key).unwrap()),
+      Some(data),
+      FEE
+    ).unwrap();
+
+    let needed_fee = signable_tx.needed_fee();
+    let tx = sign(&keys, &signable_tx);
+
+    // Verify the fee accounts for the OP_RETURN output
+    // The actual vsize should match the fee calculation
+    let actual_vsize = u64::try_from(tx.vsize()).unwrap();
+    let expected_fee = actual_vsize * FEE;
+
+    // The needed_fee should be >= expected_fee (it may be slightly higher due to ceiling)
+    assert!(
+      needed_fee >= expected_fee,
+      "Fee calculation did not account for OP_RETURN output. \
+       needed_fee ({}) should be >= actual_vsize ({}) * FEE ({})",
+      needed_fee, actual_vsize, FEE
+    );
+
+    // The fee should not be significantly more than expected (within 1 vbyte tolerance)
+    assert!(
+      needed_fee <= expected_fee + FEE,
+      "Fee calculation is too high. \
+       needed_fee ({}) should be <= (actual_vsize ({}) + 1) * FEE ({})",
+      needed_fee, actual_vsize, FEE
+    );
+
+    // Verify the weight is within the policy limit
+    assert!(
+      tx.weight().to_wu() <= u64::from(bitcoin_serai::bitcoin::policy::MAX_STANDARD_TX_WEIGHT),
+      "Transaction weight exceeds MAX_STANDARD_TX_WEIGHT"
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- Fixes weight calculation in `bitcoin-serai` to include OP_RETURN outputs when computing transaction weight/vbytes
- Previously, the `calculate_weight_vbytes` function did not account for OP_RETURN data, causing underestimation of transaction weight
- This could lead to transactions exceeding `MAX_STANDARD_TX_WEIGHT` when OP_RETURN data was present

## Changes
- Modified `calculate_weight_vbytes` to accept an optional `data` parameter
- Added the OP_RETURN output to the weight calculation transaction when data is present
- Restructured the code to calculate weight before consuming the data ownership
- Added regression test `test_op_return_weight_calculation` to verify correct fee calculation with OP_RETURN

## Test plan
- [x] Code compiles with `cargo check`
- [x] Added `test_op_return_weight_calculation` test that verifies:
  - Fee calculation accounts for OP_RETURN output
  - Transaction weight stays within policy limits
- [ ] Run full test suite with `cargo test` (requires bitcoind for integration tests)

Closes #691

---
Generated with [Claude Code](https://claude.ai/code)