### PR TITLE
Ensure start_block is finalized in IndexTask::new and add tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7811,6 +7811,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7870,6 +7879,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sec1"
@@ -8733,6 +8748,7 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "group",
+ "hex",
  "log",
  "serai-primitives",
  "serai-task",
@@ -8748,12 +8764,19 @@ dependencies = [
  "group",
  "hex",
  "log",
+ "monero-ed25519",
+ "monero-simple-request-rpc",
+ "monero-wallet",
  "serai-db",
+ "serai-monero-processor",
  "serai-primitives",
  "serai-processor-messages",
  "serai-processor-primitives",
  "serai-processor-scheduler-primitives",
+ "serial_test",
+ "tempfile",
  "tokio",
+ "zeroize",
 ]
 
 [[package]]
@@ -9071,6 +9094,32 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d0b343e184fc3b7bb44dff0705fffcf4b3756ba6aff420dddd8b24ca145e555"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f50427f258fb77356e4cd4aa0e87e2bd2c66dbcee41dc405282cae2bfc26c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/processor/bin/src/coordinator.rs
+++ b/processor/bin/src/coordinator.rs
@@ -13,7 +13,7 @@ use serai_cosign::SignedCosign;
 
 use serai_db::{Get, DbTxn, Db as _, create_db, db_channel};
 
-use scanner::ScannerFeed;
+use primitives::ScannerFeed;
 
 use message_queue::{Service, Metadata, client::MessageQueue};
 

--- a/processor/bin/src/lib.rs
+++ b/processor/bin/src/lib.rs
@@ -15,10 +15,10 @@ use serai_primitives::validator_sets::Session;
 use serai_env as env;
 use serai_db::{Get, DbTxn, Db as _, create_db, db_channel};
 
-use primitives::EncodableG;
+use primitives::{EncodableG, ScannerFeed};
 use ::key_gen::{Ristretto, KeyGenParams, KeyGen};
 use scheduler::{SignableTransaction, TransactionFor};
-use scanner::{ScannerFeed, Scanner, KeyFor, Scheduler};
+use scanner::{Scanner, KeyFor, Scheduler};
 use signers::{TransactionPublisher, Signers};
 
 mod coordinator;

--- a/processor/bitcoin/src/rpc.rs
+++ b/processor/bitcoin/src/rpc.rs
@@ -5,7 +5,7 @@ use bitcoin_serai::rpc::{RpcError, Rpc as BRpc};
 use serai_primitives::{network_id::ExternalNetworkId, coin::ExternalCoin, balance::Amount};
 
 use serai_db::Db;
-use scanner::ScannerFeed;
+use primitives::ScannerFeed;
 use signers::TransactionPublisher;
 
 use crate::{

--- a/processor/bitcoin/src/txindex.rs
+++ b/processor/bitcoin/src/txindex.rs
@@ -4,8 +4,7 @@ use bitcoin_serai::bitcoin::ScriptBuf;
 
 use serai_db::{Get, DbTxn as _, Db};
 
-use primitives::task::ContinuallyRan;
-use scanner::ScannerFeed as _;
+use primitives::{ScannerFeed as _, task::ContinuallyRan};
 
 use crate::{db, rpc::Rpc, hash_bytes};
 

--- a/processor/ethereum/src/rpc.rs
+++ b/processor/ethereum/src/rpc.rs
@@ -12,7 +12,7 @@ use tokio::task::JoinSet;
 
 use serai_db::Db;
 
-use scanner::ScannerFeed;
+use primitives::{ScannerFeed, Block as _};
 
 use ethereum_schnorr::PublicKey;
 use ethereum_router::{InInstruction as EthereumInInstruction, Executed, Router};

--- a/processor/monero/src/lib.rs
+++ b/processor/monero/src/lib.rs
@@ -1,0 +1,5 @@
+mod rpc;
+pub use rpc::Rpc;
+
+mod primitives;
+pub(crate) use crate::primitives::*;

--- a/processor/monero/src/primitives/block.rs
+++ b/processor/monero/src/primitives/block.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-pub(crate) struct BlockHeader(pub(crate) MBlock);
+pub struct BlockHeader(pub(crate) MBlock);
 impl primitives::BlockHeader for BlockHeader {
   fn id(&self) -> [u8; 32] {
     self.0.hash()
@@ -28,7 +28,7 @@ impl primitives::BlockHeader for BlockHeader {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct Block(pub(crate) MScannableBlock);
+pub struct Block(pub(crate) MScannableBlock);
 
 impl primitives::Block for Block {
   type Header = BlockHeader;

--- a/processor/monero/src/primitives/output.rs
+++ b/processor/monero/src/primitives/output.rs
@@ -21,7 +21,7 @@ use primitives::{OutputType, ReceivedOutput};
 use crate::{EXTERNAL_SUBADDRESS, BRANCH_SUBADDRESS, CHANGE_SUBADDRESS, FORWARDED_SUBADDRESS};
 
 #[derive(Clone, Copy, PartialEq, Eq, Default, Hash, Debug, BorshSerialize, BorshDeserialize)]
-pub(crate) struct OutputId(pub(crate) [u8; 32]);
+pub struct OutputId(pub(crate) [u8; 32]);
 impl AsRef<[u8]> for OutputId {
   fn as_ref(&self) -> &[u8] {
     self.0.as_ref()
@@ -34,7 +34,7 @@ impl AsMut<[u8]> for OutputId {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub(crate) struct Output(pub(crate) WalletOutput);
+pub struct Output(pub(crate) WalletOutput);
 impl ReceivedOutput<<Ed25519 as WrappedGroup>::G, Address> for Output {
   type Id = OutputId;
   type TransactionId = [u8; 32];

--- a/processor/monero/src/primitives/transaction.rs
+++ b/processor/monero/src/primitives/transaction.rs
@@ -80,7 +80,7 @@ impl scheduler::SignableTransaction for SignableTransaction {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub(crate) struct Eventuality {
+pub struct Eventuality {
   pub(crate) id: [u8; 32],
   pub(crate) singular_spent_output: Option<OutputId>,
   pub(crate) eventuality: MEventuality,

--- a/processor/monero/src/rpc.rs
+++ b/processor/monero/src/rpc.rs
@@ -4,7 +4,7 @@ use monero_simple_request_rpc::{prelude::*, SimpleRequestTransport};
 
 use serai_primitives::{network_id::ExternalNetworkId, coin::ExternalCoin, balance::Amount};
 
-use scanner::ScannerFeed;
+use primitives::ScannerFeed;
 use signers::TransactionPublisher;
 
 use crate::{
@@ -13,8 +13,14 @@ use crate::{
 };
 
 #[derive(Clone)]
-pub(crate) struct Rpc {
+pub struct Rpc {
   pub(crate) rpc: MoneroDaemon<SimpleRequestTransport>,
+}
+
+impl Rpc {
+  pub fn new(rpc: MoneroDaemon<SimpleRequestTransport>) -> Self {
+    Rpc { rpc }
+  }
 }
 
 impl ScannerFeed for Rpc {

--- a/processor/primitives/Cargo.toml
+++ b/processor/primitives/Cargo.toml
@@ -23,6 +23,7 @@ group = { version = "0.13", default-features = false }
 serai-primitives = { path = "../../substrate/primitives", default-features = false, features = ["std"] }
 
 borsh = { version = "1", default-features = false, features = ["std", "derive", "de_strict_order"] }
+hex = { version = "0.4", default-features = false, features = ["std"] }
 
 log = { version = "0.4", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false, features = ["macros", "sync", "time"] }

--- a/processor/primitives/src/lib.rs
+++ b/processor/primitives/src/lib.rs
@@ -23,6 +23,9 @@ pub use block::*;
 mod payment;
 pub use payment::*;
 
+mod scanner;
+pub use scanner::*;
+
 /// An ID for an output/transaction/block/etc.
 ///
 /// IDs don't need to implement `Copy`, enabling `[u8; 33]`, `[u8; 64]` to be used. IDs are still

--- a/processor/primitives/src/scanner.rs
+++ b/processor/primitives/src/scanner.rs
@@ -1,0 +1,134 @@
+use core::{future::Future, fmt::Debug};
+
+use serai_primitives::{
+  network_id::ExternalNetworkId, coin::ExternalCoin, balance::Amount,
+};
+
+use crate::Block;
+
+/// A feed usable to scan a blockchain.
+///
+/// This defines the primitive types used, along with various getters necessary for indexing.
+pub trait ScannerFeed: 'static + Send + Sync + Clone {
+  /// The ID of the network being scanned for.
+  const NETWORK: ExternalNetworkId;
+
+  /// The amount of confirmations a block must have to be considered finalized.
+  ///
+  /// This value must be at least `1`.
+  // This is distinct from `WINDOW_LENGTH` as it's only used for determining the lifetime of the
+  // key. The key switches to various stages of its lifetime depending on when user transactions
+  // will hit the Serai network (relative to the time they're made) and when outputs created by
+  // Serai become available again. If we set a long WINDOW_LENGTH, say two hours, that doesn't mean
+  // we expect user transactions made within a few minutes of a new key being declared to only
+  // appear in finalized blocks two hours later.
+  const CONFIRMATIONS: u64;
+
+  /// The amount of blocks to process in parallel.
+  ///
+  /// This must be at least `1`. This value MUST be at least the worst-case latency to publish a
+  /// Batch for a block divided by the expected block time. Setting this value too low will risk a
+  /// backlog forming. Setting this value too high will only delay key rotation and forwarded
+  /// outputs.
+  // The latency to publish a Batch for a block is the latency of a provided transaction
+  // (1 minute), the latency of a signing protocol (1 minute), the latency of Serai to finalize a
+  // block (1 minute), and the latency to cosign such a block (5 minutes for the cosign distance
+  // plus 1 minute). Accordingly, this should be at least ~30 minutes, ideally 60 minutes.
+  const WINDOW_LENGTH: u64;
+
+  /// The amount of blocks which will occur in 10 minutes (approximate).
+  ///
+  /// This value must be at least `1`.
+  const TEN_MINUTES: u64;
+
+  /// The representation of a block for this blockchain.
+  ///
+  /// A block is defined as a consensus event associated with a set of transactions. It is not
+  /// necessary to literally define it as whatever the external network defines as a block. For
+  /// external networks which finalize block(s), this block type should be a representation of all
+  /// transactions within a finalization event.
+  type Block: Block;
+
+  /// An error encountered when fetching data from the blockchain.
+  ///
+  /// This MUST be an ephemeral error. Retrying fetching data from the blockchain MUST eventually
+  /// resolve without manual intervention/changing the arguments.
+  type EphemeralError: Debug;
+
+  /// Fetch the number of the latest finalized block.
+  ///
+  /// The block number is its zero-indexed position within a linear view of the external network's
+  /// consensus. The genesis block accordingly has block number 0.
+  fn latest_finalized_block_number(
+    &self,
+  ) -> impl Send + Future<Output = Result<u64, Self::EphemeralError>>;
+
+  /// Fetch the timestamp of a block (represented in seconds since the epoch).
+  ///
+  /// This must be monotonically incrementing. Two blocks may share a timestamp.
+  fn time_of_block(
+    &self,
+    number: u64,
+  ) -> impl Send + Future<Output = Result<u64, Self::EphemeralError>>;
+
+  /// Fetch a block header by its number.
+  ///
+  /// This does not check the returned BlockHeader is the header for the block we indexed.
+  fn unchecked_block_header_by_number(
+    &self,
+    number: u64,
+  ) -> impl Send + Future<Output = Result<<Self::Block as Block>::Header, Self::EphemeralError>>;
+
+  /// Fetch a block by its number.
+  ///
+  /// This does not check the returned Block is the block we indexed.
+  fn unchecked_block_by_number(
+    &self,
+    number: u64,
+  ) -> impl Send + Future<Output = Result<Self::Block, Self::EphemeralError>>;
+
+  /// Fetch a block by its number.
+  ///
+  /// Panics if the block requested wasn't indexed.
+  fn block_by_number(
+    &self,
+    number: u64,
+    indexed_block_id: &[u8; 32],
+  ) -> impl Send + Future<Output = Result<Self::Block, String>> {
+    async move {
+      let block = match self.unchecked_block_by_number(number).await {
+        Ok(block) => block,
+        Err(e) => Err(format!("couldn't fetch block {number}: {e:?}"))?,
+      };
+
+      // Check the ID of this block is the expected ID
+      {
+        assert_eq!(
+          &block.id(),
+          indexed_block_id,
+          "finalized chain reorganized from {} to {} at {}",
+          hex::encode(indexed_block_id),
+          hex::encode(block.id()),
+          number,
+        );
+      }
+
+      Ok(block)
+    }
+  }
+
+  /// The dust threshold for the specified coin.
+  ///
+  /// This MUST be constant. Serai MUST NOT create internal outputs worth less than this. This
+  /// SHOULD be a value worth handling at a human level.
+  fn dust(coin: ExternalCoin) -> Amount;
+
+  /// The cost to aggregate an input as of the specified block.
+  ///
+  /// This is defined as the transaction fee for a 2-input, 1-output transaction.
+  fn cost_to_aggregate(
+    &self,
+    coin: ExternalCoin,
+    reference_block: &Self::Block,
+  ) -> impl Send + Future<Output = Result<Amount, Self::EphemeralError>>;
+}

--- a/processor/scanner/Cargo.toml
+++ b/processor/scanner/Cargo.toml
@@ -38,3 +38,16 @@ serai-primitives = { path = "../../substrate/primitives", default-features = fal
 
 primitives = { package = "serai-processor-primitives", path = "../primitives" }
 scheduler-primitives = { package = "serai-processor-scheduler-primitives", path = "../scheduler/primitives" }
+
+[dev-dependencies]
+tempfile = "3"
+serai-db = { path = "../../common/db", features = ["rocksdb"] }
+serai-monero-processor = { path = "../monero", features = ["rocksdb"] }
+
+monero-simple-request-rpc = { git = "https://github.com/monero-oxide/monero-oxide", rev = "cae84b7b16051ac8bf92ed151aad49b9e6f4fcae", default-features = false }
+monero-wallet = { git = "https://github.com/monero-oxide/monero-oxide", rev = "cae84b7b16051ac8bf92ed151aad49b9e6f4fcae", default-features = false, features = ["std"] }
+monero-ed25519 = { git = "https://github.com/monero-oxide/monero-oxide", rev = "cae84b7b16051ac8bf92ed151aad49b9e6f4fcae", version = "0.1.0", default-features = false, features = ["std"] }
+
+zeroize = { version = "1", default-features = false, features = ["std"] }
+
+serial_test = "*"

--- a/processor/scanner/src/eventuality/mod.rs
+++ b/processor/scanner/src/eventuality/mod.rs
@@ -160,7 +160,8 @@ impl<D: Db, S: ScannerFeed, Sch: Scheduler<S>> EventualityTask<D, S, Sch> {
       // others the new key
       let (_keys, keys_with_stages) = self.keys_and_keys_with_stages(latest_handled_notable_block);
 
-      let block = self.feed.block_by_number(&self.db, latest_handled_notable_block).await?;
+      let indexed_block_id = crate::index::block_id(&self.db, latest_handled_notable_block);
+      let block = self.feed.block_by_number(latest_handled_notable_block, &indexed_block_id).await?;
 
       let mut txn = self.db.txn();
       // Drain the entire channel
@@ -272,7 +273,8 @@ impl<D: Db, S: ScannerFeed, Sch: Scheduler<S>> ContinuallyRan for EventualityTas
         // Since we're handling this block, we are making progress
         made_progress = true;
 
-        let block = self.feed.block_by_number(&self.db, b).await?;
+        let indexed_block_id = crate::index::block_id(&self.db, b);
+        let block = self.feed.block_by_number(b, &indexed_block_id).await?;
 
         log::debug!("checking eventuality completions in block: {} ({b})", hex::encode(block.id()));
 

--- a/processor/scanner/src/index/mod.rs
+++ b/processor/scanner/src/index/mod.rs
@@ -1,9 +1,7 @@
 use core::future::Future;
 
 use serai_db::{Get, DbTxn as _, Db};
-use primitives::{task::ContinuallyRan, BlockHeader as _};
-
-use crate::ScannerFeed;
+use primitives::{task::ContinuallyRan, BlockHeader as _, ScannerFeed};
 
 mod db;
 use db::IndexDb;
@@ -34,15 +32,28 @@ impl<D: Db, S: ScannerFeed> IndexTask<D, S> {
       let block = {
         let mut delay = Self::DELAY_BETWEEN_ITERATIONS;
         loop {
-          match feed.unchecked_block_header_by_number(start_block).await {
-            Ok(block) => break block,
-            Err(e) => {
-              log::warn!("IndexTask couldn't fetch start block {start_block}: {e:?}");
-              tokio::time::sleep(core::time::Duration::from_secs(delay)).await;
-              delay += Self::DELAY_BETWEEN_ITERATIONS;
-              delay = delay.min(Self::MAX_DELAY_BETWEEN_ITERATIONS);
+          // loop until the given start block is finalized
+          match feed.latest_finalized_block_number().await {
+            Ok(latest_finalized) => {
+              if latest_finalized >= start_block {
+                // Get the block from the chain
+                match feed.unchecked_block_header_by_number(start_block).await {
+                  Ok(block) => break block,
+                  Err(e) => {
+                    log::warn!("IndexTask couldn't fetch start block {start_block}: {e:?}");
+                  }
+                };
+              }
+              log::warn!("IndexTask start block {start_block} is not yet finalized");
             }
-          };
+            Err(e) => {
+              log::warn!("IndexTask couldn't fetch latest finalized block number: {e:?}");
+            }
+          }
+
+          tokio::time::sleep(core::time::Duration::from_secs(delay)).await;
+          delay += Self::DELAY_BETWEEN_ITERATIONS;
+          delay = delay.min(Self::MAX_DELAY_BETWEEN_ITERATIONS);
         }
       };
 
@@ -114,5 +125,142 @@ impl<D: Db, S: ScannerFeed> ContinuallyRan for IndexTask<D, S> {
       // Have dependents run if we updated the latest finalized block
       Ok(our_latest_finalized != latest_finalized)
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use primitives::{ScannerFeed, task::ContinuallyRan};
+  use serai_db::{new_rocksdb, Db};
+  use tempfile::TempDir;
+  use serai_monero_processor::Rpc as MoneroFeed;
+
+  use monero_simple_request_rpc::SimpleRequestTransport;
+  use monero_wallet::{address::Network, ViewPair};
+  use monero_ed25519::{CompressedPoint, Scalar};
+  use zeroize::Zeroizing;
+
+  use serial_test::serial;
+
+  use crate::index::{IndexTask, db::IndexDb};
+
+  static DAEMON_URL: &'static str = "http://serai:seraidex@127.0.0.1:18081";
+
+  async fn add_block(block_count: usize) {
+    let rpc = SimpleRequestTransport::new(DAEMON_URL.to_string()).await.unwrap();
+
+    rpc
+      .generate_blocks(
+        &ViewPair::new(CompressedPoint::G.decompress().unwrap(), Zeroizing::new(Scalar::ONE))
+          .unwrap()
+          .legacy_address(Network::Mainnet),
+        block_count,
+      )
+      .await
+      .unwrap();
+  }
+
+  async fn init_feed() -> impl ScannerFeed {
+    let rpc = SimpleRequestTransport::new(DAEMON_URL.to_string()).await.unwrap();
+    MoneroFeed::new(rpc)
+  }
+
+  async fn init_task<D: Db, S: ScannerFeed>(db: D, feed: S, start_block: u64) -> IndexTask<D, S> {
+    assert!(IndexDb::latest_finalized_block(&db).is_none());
+    assert!(IndexDb::block_id(&db, start_block).is_none());
+
+    let index_task = IndexTask::new(db.clone(), feed.clone(), start_block).await;
+
+    // Assert expected DB state after new
+    let our_latest_finalized =
+      IndexDb::latest_finalized_block(&db).expect("Expected latest finalized");
+    assert_eq!(our_latest_finalized, start_block);
+    let indexed_block_id = IndexDb::block_id(&db, start_block).unwrap();
+    let res = feed.block_by_number(start_block, &indexed_block_id).await;
+    assert!(!res.is_err());
+
+    index_task
+  }
+
+  async fn init_test(
+  ) -> (TempDir, impl Db, impl ScannerFeed, u64, IndexTask<impl Db, impl ScannerFeed>) {
+    let temp_dir = TempDir::new().unwrap();
+    let temp_db = new_rocksdb(temp_dir.path().to_str().unwrap());
+
+    let feed = init_feed().await;
+
+    let start_block = feed.latest_finalized_block_number().await.unwrap();
+
+    let index_task = init_task(temp_db.clone(), feed.clone(), start_block).await;
+
+    (temp_dir, temp_db, feed, start_block, index_task)
+  }
+
+  #[tokio::test]
+  #[serial]
+  async fn new_index_task() {
+    add_block(1).await;
+    init_test().await;
+  }
+
+  #[tokio::test]
+  #[serial]
+  async fn no_expected_change() {
+    // For Monero, we need at least 10 blocks in the chain
+    // until we're certain a block has been finalized
+    let required_confirmations = 10;
+    add_block(required_confirmations).await;
+
+    let (_temp_dir, _, _, _, mut index_task) = init_test().await;
+
+    // We should be able to complete an iteration without erroring
+    let res = index_task.run_iteration().await;
+    assert!(!res.is_err());
+
+    // Since the chain did not change since we initialized our IndexTask,
+    // then the latest finalized block shouldn't have changed either
+    let latest_finalized_updated = res.unwrap();
+    assert!(!latest_finalized_updated);
+  }
+
+  #[tokio::test]
+  #[serial]
+  async fn advance_one_block() {
+    // For Monero, we need at least 10 blocks in the chain
+    // until we're certain a block has been finalized
+    let required_confirmations = 10;
+    add_block(required_confirmations).await;
+
+    let (_temp_dir, temp_db, feed, start_block, mut index_task) = init_test().await;
+
+    // Advance the chain 1 block so that the latest finalized advances by 1
+    add_block(1).await;
+
+    // We should be able to complete an iteration without erroring
+    let res = index_task.run_iteration().await;
+    assert!(!res.is_err());
+
+    // The latest finalized should have updated
+    let latest_finalized_updated = res.unwrap();
+    assert!(latest_finalized_updated);
+
+    // The latest finalized in the db should be expected
+    let new_latest_finalized = start_block + 1;
+    let our_latest_finalized =
+      IndexDb::latest_finalized_block(&temp_db).expect("Expected new latest finalized");
+    assert_eq!(our_latest_finalized, new_latest_finalized);
+
+    // The block id's should all match up with the chain
+    for b in start_block..=new_latest_finalized {
+      let indexed_block_id = IndexDb::block_id(&temp_db, b).unwrap();
+      let res = feed.block_by_number(b, &indexed_block_id).await;
+      assert!(!res.is_err());
+    }
+
+    // Next iteration there should be no change
+    let res = index_task.run_iteration().await;
+    assert!(!res.is_err());
+    let latest_finalized_updated = res.unwrap();
+    assert!(!latest_finalized_updated);
   }
 }

--- a/processor/scanner/src/lib.rs
+++ b/processor/scanner/src/lib.rs
@@ -8,15 +8,12 @@ use std::{io, collections::HashMap};
 use group::GroupEncoding;
 
 use borsh::{BorshSerialize as _, BorshDeserialize as _};
-use serai_db::{Get, DbTxn, Db};
+use serai_db::{DbTxn, Db};
 
-use serai_primitives::{
-  network_id::ExternalNetworkId, coin::ExternalCoin, balance::Amount,
-  instructions::OutInstructionWithBalance,
-};
+use serai_primitives::instructions::OutInstructionWithBalance;
 
 use messages::substrate::ExecutedBatch;
-use primitives::{task::*, Address, ReceivedOutput, Block, Payment};
+use primitives::{task::*, Address, ReceivedOutput, Block, Payment, ScannerFeed};
 
 // Logic for deciding where in its lifetime a multisig is.
 mod lifetime;
@@ -59,134 +56,6 @@ impl<B: Block> BlockExt for B {
     outputs.sort_by(sort_outputs);
     outputs
   }
-}
-
-/// A feed usable to scan a blockchain.
-///
-/// This defines the primitive types used, along with various getters necessary for indexing.
-pub trait ScannerFeed: 'static + Send + Sync + Clone {
-  /// The ID of the network being scanned for.
-  const NETWORK: ExternalNetworkId;
-
-  /// The amount of confirmations a block must have to be considered finalized.
-  ///
-  /// This value must be at least `1`.
-  // This is distinct from `WINDOW_LENGTH` as it's only used for determining the lifetime of the
-  // key. The key switches to various stages of its lifetime depending on when user transactions
-  // will hit the Serai network (relative to the time they're made) and when outputs created by
-  // Serai become available again. If we set a long WINDOW_LENGTH, say two hours, that doesn't mean
-  // we expect user transactions made within a few minutes of a new key being declared to only
-  // appear in finalized blocks two hours later.
-  const CONFIRMATIONS: u64;
-
-  /// The amount of blocks to process in parallel.
-  ///
-  /// This must be at least `1`. This value MUST be at least the worst-case latency to publish a
-  /// Batch for a block divided by the expected block time. Setting this value too low will risk a
-  /// backlog forming. Setting this value too high will only delay key rotation and forwarded
-  /// outputs.
-  // The latency to publish a Batch for a block is the latency of a provided transaction
-  // (1 minute), the latency of a signing protocol (1 minute), the latency of Serai to finalize a
-  // block (1 minute), and the latency to cosign such a block (5 minutes for the cosign distance
-  // plus 1 minute). Accordingly, this should be at least ~30 minutes, ideally 60 minutes.
-  const WINDOW_LENGTH: u64;
-
-  /// The amount of blocks which will occur in 10 minutes (approximate).
-  ///
-  /// This value must be at least `1`.
-  const TEN_MINUTES: u64;
-
-  /// The representation of a block for this blockchain.
-  ///
-  /// A block is defined as a consensus event associated with a set of transactions. It is not
-  /// necessary to literally define it as whatever the external network defines as a block. For
-  /// external networks which finalize block(s), this block type should be a representation of all
-  /// transactions within a finalization event.
-  type Block: Block;
-
-  /// An error encountered when fetching data from the blockchain.
-  ///
-  /// This MUST be an ephemeral error. Retrying fetching data from the blockchain MUST eventually
-  /// resolve without manual intervention/changing the arguments.
-  type EphemeralError: Debug;
-
-  /// Fetch the number of the latest finalized block.
-  ///
-  /// The block number is its zero-indexed position within a linear view of the external network's
-  /// consensus. The genesis block accordingly has block number 0.
-  fn latest_finalized_block_number(
-    &self,
-  ) -> impl Send + Future<Output = Result<u64, Self::EphemeralError>>;
-
-  /// Fetch the timestamp of a block (represented in seconds since the epoch).
-  ///
-  /// This must be monotonically incrementing. Two blocks may share a timestamp.
-  fn time_of_block(
-    &self,
-    number: u64,
-  ) -> impl Send + Future<Output = Result<u64, Self::EphemeralError>>;
-
-  /// Fetch a block header by its number.
-  ///
-  /// This does not check the returned BlockHeader is the header for the block we indexed.
-  fn unchecked_block_header_by_number(
-    &self,
-    number: u64,
-  ) -> impl Send + Future<Output = Result<<Self::Block as Block>::Header, Self::EphemeralError>>;
-
-  /// Fetch a block by its number.
-  ///
-  /// This does not check the returned Block is the block we indexed.
-  fn unchecked_block_by_number(
-    &self,
-    number: u64,
-  ) -> impl Send + Future<Output = Result<Self::Block, Self::EphemeralError>>;
-
-  /// Fetch a block by its number.
-  ///
-  /// Panics if the block requested wasn't indexed.
-  fn block_by_number(
-    &self,
-    getter: &(impl Send + Sync + Get),
-    number: u64,
-  ) -> impl Send + Future<Output = Result<Self::Block, String>> {
-    async move {
-      let block = match self.unchecked_block_by_number(number).await {
-        Ok(block) => block,
-        Err(e) => Err(format!("couldn't fetch block {number}: {e:?}"))?,
-      };
-
-      // Check the ID of this block is the expected ID
-      {
-        let expected = crate::index::block_id(getter, number);
-        assert_eq!(
-          block.id(),
-          expected,
-          "finalized chain reorganized from {} to {} at {}",
-          hex::encode(expected),
-          hex::encode(block.id()),
-          number,
-        );
-      }
-
-      Ok(block)
-    }
-  }
-
-  /// The dust threshold for the specified coin.
-  ///
-  /// This MUST be constant. Serai MUST NOT create internal outputs worth less than this. This
-  /// SHOULD be a value worth handling at a human level.
-  fn dust(coin: ExternalCoin) -> Amount;
-
-  /// The cost to aggregate an input as of the specified block.
-  ///
-  /// This is defined as the transaction fee for a 2-input, 1-output transaction.
-  fn cost_to_aggregate(
-    &self,
-    coin: ExternalCoin,
-    reference_block: &Self::Block,
-  ) -> impl Send + Future<Output = Result<Amount, Self::EphemeralError>>;
 }
 
 /// The key type for this ScannerFeed.

--- a/processor/scanner/src/scan/mod.rs
+++ b/processor/scanner/src/scan/mod.rs
@@ -106,7 +106,8 @@ impl<D: Db, S: ScannerFeed> ContinuallyRan for ScanTask<D, S> {
         .expect("ScanTask run before writing the start block");
 
       for b in next_to_scan ..= latest_scannable {
-        let block = self.feed.block_by_number(&self.db, b).await?;
+        let indexed_block_id = crate::index::block_id(&self.db, b);
+        let block = self.feed.block_by_number(b, &indexed_block_id).await?;
 
         log::info!("scanning block: {} ({b})", hex::encode(block.id()));
 

--- a/processor/scheduler/smart-contract/src/lib.rs
+++ b/processor/scheduler/smart-contract/src/lib.rs
@@ -9,9 +9,9 @@ use group::GroupEncoding as _;
 
 use serai_db::{Get, DbTxn, create_db};
 
-use primitives::{ReceivedOutput as _, Payment};
+use primitives::{ScannerFeed, ReceivedOutput as _, Payment};
 use scanner::{
-  LifetimeStage, ScannerFeed, KeyFor, AddressFor, EventualityFor, BlockFor, SchedulerUpdate,
+  LifetimeStage, KeyFor, AddressFor, EventualityFor, BlockFor, SchedulerUpdate,
   KeyScopedEventualities, Scheduler as SchedulerTrait,
 };
 use scheduler_primitives::*;

--- a/processor/scheduler/utxo/primitives/src/lib.rs
+++ b/processor/scheduler/utxo/primitives/src/lib.rs
@@ -6,8 +6,8 @@ use core::{fmt::Debug, future::Future};
 
 use serai_primitives::balance::Amount;
 
-use primitives::{ReceivedOutput as _, Payment};
-use scanner::{ScannerFeed, KeyFor, AddressFor, OutputFor, EventualityFor, BlockFor};
+use primitives::{ScannerFeed, ReceivedOutput as _, Payment};
+use scanner::{KeyFor, AddressFor, OutputFor, EventualityFor, BlockFor};
 use scheduler_primitives::*;
 
 mod tree;

--- a/processor/scheduler/utxo/primitives/src/tree.rs
+++ b/processor/scheduler/utxo/primitives/src/tree.rs
@@ -5,8 +5,7 @@ use serai_primitives::{
   balance::{Amount, ExternalBalance},
 };
 
-use primitives::{Address, Payment};
-use scanner::ScannerFeed;
+use primitives::{Address, Payment, ScannerFeed};
 
 /// A transaction within a tree to fulfill payments.
 #[derive(Clone, BorshSerialize, BorshDeserialize)]

--- a/processor/scheduler/utxo/standard/src/db.rs
+++ b/processor/scheduler/utxo/standard/src/db.rs
@@ -9,9 +9,9 @@ use serai_primitives::{
 
 use serai_db::{Get, DbTxn, create_db, db_channel};
 
-use primitives::{Payment, ReceivedOutput as _};
+use primitives::{ScannerFeed, Payment, ReceivedOutput as _};
 use utxo_scheduler_primitives::TreeTransaction;
-use scanner::{ScannerFeed, KeyFor, AddressFor, OutputFor};
+use scanner::{KeyFor, AddressFor, OutputFor};
 
 create_db! {
   UtxoScheduler {

--- a/processor/scheduler/utxo/standard/src/lib.rs
+++ b/processor/scheduler/utxo/standard/src/lib.rs
@@ -14,9 +14,9 @@ use serai_primitives::{
 
 use serai_db::DbTxn;
 
-use primitives::{ReceivedOutput as _, Payment};
+use primitives::{ScannerFeed, ReceivedOutput as _, Payment};
 use scanner::{
-  LifetimeStage, ScannerFeed, KeyFor, AddressFor, OutputFor, EventualityFor, BlockFor,
+  LifetimeStage, KeyFor, AddressFor, OutputFor, EventualityFor, BlockFor,
   SchedulerUpdate, KeyScopedEventualities, Scheduler as SchedulerTrait,
 };
 use scheduler_primitives::*;

--- a/processor/scheduler/utxo/transaction-chaining/src/db.rs
+++ b/processor/scheduler/utxo/transaction-chaining/src/db.rs
@@ -6,8 +6,8 @@ use serai_primitives::{coin::ExternalCoin, balance::Amount};
 
 use serai_db::{Get, DbTxn, create_db};
 
-use primitives::{Payment, ReceivedOutput};
-use scanner::{ScannerFeed, KeyFor, AddressFor, OutputFor};
+use primitives::{ScannerFeed, Payment, ReceivedOutput};
+use scanner::{KeyFor, AddressFor, OutputFor};
 
 create_db! {
   TransactionChainingScheduler {

--- a/processor/scheduler/utxo/transaction-chaining/src/lib.rs
+++ b/processor/scheduler/utxo/transaction-chaining/src/lib.rs
@@ -11,9 +11,9 @@ use serai_primitives::{coin::ExternalCoin, balance::Amount};
 
 use serai_db::DbTxn;
 
-use primitives::{OutputType, ReceivedOutput as _, Payment};
+use primitives::{ScannerFeed, OutputType, ReceivedOutput as _, Payment};
 use scanner::{
-  LifetimeStage, ScannerFeed, KeyFor, AddressFor, OutputFor, EventualityFor, BlockFor,
+  LifetimeStage, KeyFor, AddressFor, OutputFor, EventualityFor, BlockFor,
   SchedulerUpdate, KeyScopedEventualities, Scheduler as SchedulerTrait,
 };
 use scheduler_primitives::*;

--- a/processor/signers/src/lib.rs
+++ b/processor/signers/src/lib.rs
@@ -22,9 +22,9 @@ use serai_cosign::{Cosign, SignedCosign};
 
 use messages::sign::{VariantSignId, ProcessorMessage, CoordinatorMessage};
 
-use primitives::task::{Task, TaskHandle, ContinuallyRan as _};
+use primitives::{ScannerFeed, task::{Task, TaskHandle, ContinuallyRan as _}};
 use scheduler::{Transaction, SignableTransaction, TransactionFor};
-use scanner::{ScannerFeed, Scheduler};
+use scanner::Scheduler;
 
 mod wrapped_schnorrkel;
 pub(crate) use wrapped_schnorrkel::WrappedSchnorrkelMachine;

--- a/processor/signers/src/slash_report.rs
+++ b/processor/signers/src/slash_report.rs
@@ -8,8 +8,7 @@ use serai_db::{DbTxn as _, Db};
 
 use messages::sign::VariantSignId;
 
-use primitives::task::{DoesNotError, ContinuallyRan};
-use scanner::ScannerFeed;
+use primitives::{ScannerFeed, task::{DoesNotError, ContinuallyRan}};
 
 use frost_attempt_manager::*;
 


### PR DESCRIPTION
The main implementation change in here is in `IndexTask::new`. Without this change, it may be setting a start_bock that is not actually finalized according to the ScannerFeed logic. This change makes sure the provided start_block is actually finalized in the chain before setting it as "finalized" in the db.

In order to test the IndexTask implementation, I did some restructuring:

1) Moved ScannerFeed into processor primitives.
2) Exposed the Monero ScannerFeed impl in serai-monero-processor.

This enabled me to write a test directly in the IndexTask definition file, which I think is a safe/sane approach to make sure it's behaving as expected. It also improves code structure & organization. E.g. the monero processor now does not depend on scanner, and instead implements the ScannerFeed trait that it gets from the serai-processor-primitives crate. This cleanly separates impl from interface.

______

The new IndexTask tests are very close to chain agnostic, and would be very simple to update for each chain. Their only dependency is that they require a live daemon to be running, which appears to be the case for XMR and BTC CI currently. I figure this is saner than requiring the entire suite of Serai containers to be running in order for these more isolated unit tests to run.

I imagine there may be an alternative desired approach, but this got me off the ground for now.

______

If this approach looks good, I can continue task-by-task in similar fashion, and extend the tests for each chain.