### PR TITLE
Ensure `start_block` is finalized in `IndexTask::new` and add tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8436,6 +8436,7 @@ dependencies = [
  "dkg-evrf",
  "log",
  "modular-frost",
+ "monero-ed25519",
  "monero-simple-request-rpc",
  "monero-wallet",
  "rand_chacha 0.3.1",
@@ -8753,6 +8754,7 @@ dependencies = [
  "serai-processor-messages",
  "serai-processor-primitives",
  "serai-processor-scheduler-primitives",
+ "tempfile",
  "tokio",
 ]
 

--- a/processor/monero/Cargo.toml
+++ b/processor/monero/Cargo.toml
@@ -50,6 +50,12 @@ signers = { package = "serai-processor-signers", path = "../signers" }
 
 bin = { package = "serai-processor-bin", path = "../bin" }
 
+[dev-dependencies]
+monero-ed25519 = { git = "https://github.com/monero-oxide/monero-oxide", rev = "cae84b7b16051ac8bf92ed151aad49b9e6f4fcae", version = "0.1.0", default-features = false, features = ["std"] }
+zeroize = { version = "^1.5", default-features = false }
+
+scanner = { package = "serai-processor-scanner", path = "../scanner", features = ["tests"] }
+
 [features]
 parity-db = ["bin/parity-db"]
 rocksdb = ["bin/rocksdb"]

--- a/processor/monero/src/rpc.rs
+++ b/processor/monero/src/rpc.rs
@@ -138,3 +138,74 @@ impl TransactionPublisher<Transaction> for Rpc {
     async move { self.rpc.publish_transaction(&tx.0).await }
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use core::future::Future;
+  use scanner::{ScannerFeed, tests};
+
+  use monero_wallet::{address::Network, ViewPair};
+  use monero_ed25519::{CompressedPoint, Scalar};
+  use monero_simple_request_rpc::{SimpleRequestTransport, prelude::*};
+
+  use zeroize::Zeroizing;
+
+  static DAEMON_URL: &'static str = "http://serai:seraidex@127.0.0.1:18081";
+
+  async fn add_block(rpc: &MoneroDaemon<SimpleRequestTransport>, block_count: usize) {
+    rpc
+      .generate_blocks(
+        &ViewPair::new(CompressedPoint::G.decompress().unwrap(), Zeroizing::new(Scalar::ONE))
+          .unwrap()
+          .legacy_address(Network::Mainnet),
+        block_count,
+      )
+      .await
+      .unwrap();
+  }
+
+  async fn reset_chain(rpc: &MoneroDaemon<SimpleRequestTransport>) {
+    let high_block_no = rpc.latest_block_number().await.unwrap();
+    if high_block_no == 0 {
+      return;
+    }
+
+    static DEFAULT_HIGH_RES_LIMIT: usize = 1000;
+
+    let pop_n_blocks = format!(r#"{{"nblocks":{}}}"#, high_block_no);
+    rpc.rpc_call("pop_blocks", Some(pop_n_blocks), DEFAULT_HIGH_RES_LIMIT).await.unwrap();
+    rpc.json_rpc_call("flush_txpool", None, DEFAULT_HIGH_RES_LIMIT).await.unwrap();
+  }
+
+  #[derive(Clone)]
+  struct DaemonHelper {
+    pub(crate) rpc: MoneroDaemon<SimpleRequestTransport>,
+  }
+
+  impl tests::DaemonHelper for DaemonHelper {
+    fn reset_chain(&self) -> impl Send + Future<Output = ()> {
+      async move { reset_chain(&self.rpc).await }
+    }
+
+    fn add_block(&self) -> impl Send + Future<Output = ()> {
+      async move { add_block(&self.rpc, 1).await }
+    }
+
+    /// We consider a Monero block "finalized" once it has 10 confirmations.
+    fn setup_finalized_block(&self) -> impl Send + Future<Output = ()> {
+      async move { add_block(&self.rpc, crate::Rpc::CONFIRMATIONS.try_into().unwrap()).await }
+    }
+  }
+
+  #[tokio::test]
+  async fn test_scanner() {
+    // TODO: initialize a docker monerod instance for this test specifically
+
+    let rpc = SimpleRequestTransport::new(DAEMON_URL.to_string()).await.unwrap();
+    let feed = crate::Rpc { rpc: rpc.clone() };
+
+    let daemon = DaemonHelper { rpc };
+
+    tests::index_task_tests(feed.clone(), daemon).await;
+  }
+}

--- a/processor/scanner/Cargo.toml
+++ b/processor/scanner/Cargo.toml
@@ -38,3 +38,8 @@ serai-primitives = { path = "../../substrate/primitives", default-features = fal
 
 primitives = { package = "serai-processor-primitives", path = "../primitives" }
 scheduler-primitives = { package = "serai-processor-scheduler-primitives", path = "../scheduler/primitives" }
+
+tempfile = { version = "3", optional = true }
+
+[features]
+tests = ["dep:tempfile", "serai-db/rocksdb"]

--- a/processor/scanner/src/index/mod.rs
+++ b/processor/scanner/src/index/mod.rs
@@ -34,15 +34,28 @@ impl<D: Db, S: ScannerFeed> IndexTask<D, S> {
       let block = {
         let mut delay = Self::DELAY_BETWEEN_ITERATIONS;
         loop {
-          match feed.unchecked_block_header_by_number(start_block).await {
-            Ok(block) => break block,
-            Err(e) => {
-              log::warn!("IndexTask couldn't fetch start block {start_block}: {e:?}");
-              tokio::time::sleep(core::time::Duration::from_secs(delay)).await;
-              delay += Self::DELAY_BETWEEN_ITERATIONS;
-              delay = delay.min(Self::MAX_DELAY_BETWEEN_ITERATIONS);
+          // loop until the given start block is finalized
+          match feed.latest_finalized_block_number().await {
+            Ok(latest_finalized) => {
+              if latest_finalized >= start_block {
+                // Get the block from the chain
+                match feed.unchecked_block_header_by_number(start_block).await {
+                  Ok(block) => break block,
+                  Err(e) => {
+                    log::warn!("IndexTask couldn't fetch start block {start_block}: {e:?}");
+                  }
+                };
+              }
+              log::warn!("IndexTask start block {start_block} is not yet finalized");
             }
-          };
+            Err(e) => {
+              log::warn!("IndexTask couldn't fetch latest finalized block number: {e:?}");
+            }
+          }
+
+          tokio::time::sleep(core::time::Duration::from_secs(delay)).await;
+          delay += Self::DELAY_BETWEEN_ITERATIONS;
+          delay = delay.min(Self::MAX_DELAY_BETWEEN_ITERATIONS);
         }
       };
 
@@ -114,5 +127,131 @@ impl<D: Db, S: ScannerFeed> ContinuallyRan for IndexTask<D, S> {
       // Have dependents run if we updated the latest finalized block
       Ok(our_latest_finalized != latest_finalized)
     }
+  }
+}
+
+/// Generic tests for the index task. These should be plug-and-play with an implemented ScannerFeed.
+#[cfg(feature = "tests")]
+pub mod tests {
+  use primitives::task::ContinuallyRan;
+  use serai_db::{new_rocksdb, Db};
+  use tempfile::TempDir;
+
+  use core::future::Future;
+
+  use crate::{
+    ScannerFeed,
+    index::{IndexTask, db::IndexDb},
+  };
+
+  /// A trait that defines fn's a caller should implement for each chain.
+  pub trait DaemonHelper: 'static + Send + Sync + Clone {
+    /// Reset the blockchain state.
+    fn reset_chain(&self) -> impl Send + Future<Output = ()>;
+
+    /// Add 1 block to the chain.
+    fn add_block(&self) -> impl Send + Future<Output = ()>;
+
+    /// There should be at least 1 finalized block in the chain after this executes.
+    fn setup_finalized_block(&self) -> impl Send + Future<Output = ()>;
+  }
+
+  async fn init_task<D: Db, S: ScannerFeed>(db: D, feed: S, start_block: u64) -> IndexTask<D, S> {
+    assert!(IndexDb::latest_finalized_block(&db).is_none());
+    assert!(IndexDb::block_id(&db, start_block).is_none());
+
+    let index_task = IndexTask::new(db.clone(), feed.clone(), start_block).await;
+
+    // Assert expected DB state after new
+    let our_latest_finalized =
+      IndexDb::latest_finalized_block(&db).expect("Expected latest finalized");
+    assert_eq!(our_latest_finalized, start_block);
+    let res = feed.block_by_number(&db, start_block).await;
+    assert!(!res.is_err());
+
+    index_task
+  }
+
+  async fn init_test(
+    feed: impl ScannerFeed,
+  ) -> (TempDir, impl Db, u64, IndexTask<impl Db, impl ScannerFeed>) {
+    let temp_dir = TempDir::new().unwrap();
+    let temp_db = new_rocksdb(temp_dir.path().to_str().unwrap());
+
+    let start_block = feed.latest_finalized_block_number().await.unwrap();
+
+    let index_task = init_task(temp_db.clone(), feed.clone(), start_block).await;
+
+    (temp_dir, temp_db, start_block, index_task)
+  }
+
+  /// Test initializing a new scan task.
+  async fn new_index_task<S: ScannerFeed, D: DaemonHelper>(feed: S, daemon: D) {
+    daemon.reset_chain().await;
+    daemon.add_block().await;
+    init_test(feed).await;
+  }
+
+  /// Test an iteration of the index task without any change to the chain state.
+  async fn no_expected_change<S: ScannerFeed, D: DaemonHelper>(feed: S, daemon: D) {
+    daemon.reset_chain().await;
+    daemon.setup_finalized_block().await;
+
+    let (_temp_dir, _, _, mut index_task) = init_test(feed).await;
+
+    // We should be able to complete an iteration without erroring
+    let res = index_task.run_iteration().await;
+    assert!(!res.is_err());
+
+    // Since the chain did not change since we initialized our IndexTask,
+    // then the latest finalized block shouldn't have changed either
+    let latest_finalized_updated = res.unwrap();
+    assert!(!latest_finalized_updated);
+  }
+
+  /// Test an iteration of the index task after advancing the chain one block.
+  async fn advance_one_block<S: ScannerFeed, D: DaemonHelper>(feed: S, daemon: D) {
+    daemon.reset_chain().await;
+    daemon.setup_finalized_block().await;
+
+    let (_temp_dir, temp_db, start_block, mut index_task) = init_test(feed.clone()).await;
+
+    // Advance the chain 1 block so that the latest finalized advances by 1
+    daemon.add_block().await;
+
+    // We should be able to complete an iteration without erroring
+    let res = index_task.run_iteration().await;
+    assert!(!res.is_err());
+
+    // The latest finalized should have updated
+    let latest_finalized_updated = res.unwrap();
+    assert!(latest_finalized_updated);
+
+    // The latest finalized in the db should be expected
+    let new_latest_finalized = start_block + 1;
+    let our_latest_finalized =
+      IndexDb::latest_finalized_block(&temp_db).expect("Expected new latest finalized");
+    assert_eq!(our_latest_finalized, new_latest_finalized);
+
+    // The block id's should all match up with the chain
+    for b in start_block..=new_latest_finalized {
+      let res = feed.clone().block_by_number(&temp_db, b).await;
+      assert!(!res.is_err());
+    }
+
+    // Next iteration there should be no change
+    let res = index_task.run_iteration().await;
+    assert!(!res.is_err());
+    let latest_finalized_updated = res.unwrap();
+    assert!(!latest_finalized_updated);
+  }
+
+  /// Test the index task manages various circumstances correctly.
+  pub async fn index_task_tests<S: ScannerFeed, D: DaemonHelper>(feed: S, daemon: D) {
+    new_index_task(feed.clone(), daemon.clone()).await;
+    no_expected_change(feed.clone(), daemon.clone()).await;
+    advance_one_block(feed.clone(), daemon.clone()).await;
+
+    // TODO: test the index task can recover from a reorg
   }
 }

--- a/processor/scanner/src/lib.rs
+++ b/processor/scanner/src/lib.rs
@@ -39,6 +39,9 @@ mod substrate;
 /// Check blocks for transactions expected to eventually occur.
 mod eventuality;
 
+#[cfg(feature = "tests")]
+pub use index::tests;
+
 pub(crate) fn sort_outputs<K: GroupEncoding, A: Address, O: ReceivedOutput<K, A>>(
   a: &O,
   b: &O,


### PR DESCRIPTION
As discussed after #732, exposed a generic `index_task_tests` from the index task, and then called the test from the file defining the Monero `ScannerFeed`. This enabled unit testing the index task test in isolation using an already implemented `ScannerFeed`.

I'm sure the daemon impl is still not ideal (I'd like to use a new docker instance rather than expect a running daemon). But if this looks solid directionally, I'll continue writing more tests.