### PR TITLE
fix build process for M1 MacOS

### DIFF
--- a/orchestration/src/main.rs
+++ b/orchestration/src/main.rs
@@ -304,7 +304,9 @@ fn build_serai_service(
 
     // LLVM's MemTagSanitizer
     #[cfg(target_feature = "mte")]
-    rustflags += " -C target-feature=+mte -Z sanitizer=memtag";
+    {
+      rustflags += " -C target-feature=+mte -Z sanitizer=memtag";
+    }
   }
 
   /*

--- a/substrate/runtime/build.rs
+++ b/substrate/runtime/build.rs
@@ -215,6 +215,21 @@ fn command(bin: &str) -> Command {
   command.env(BUILD_SCRIPT_MARKER, "1");
 
   /*
+    We do propagate the host's `PATH`, as the Rust toolchain requires the host's C compiler, even
+    when using the self-contained linker, in order to drive it and provide the platform-specific
+    libraries.
+
+    While we could build a `PATH` from the Rust toolchain, and then append the value of
+    `RUSTC_LINKER` (to have a `PATH` deterministic to the Rust toolchain with the sole exception of
+    the host's linker), `RUSTC_LINKER` is the linker for the _target_, not the host, when we would
+    want to set the linker for the host specifically. There also isn't a trivial way to query the
+    _resolved_ linker after all the possible configuration methods are taken into consideration.
+  */
+  if let Ok(path) = env::var("PATH") {
+    command.env("PATH", path);
+  }
+
+  /*
     Normalize the locale, in case any tooling attempts to take it into consideration.
 
     This is likely redundant, but could matter if any tooling performed a string sort by deferring
@@ -234,8 +249,18 @@ fn command(bin: &str) -> Command {
     The propagation of the `clippy`-specific environment variables is unfortunately very fragile.
     https://github.com/rust-lang/rust-clippy/blob/0f17b47529fcde29fde44343e8f35e5cd2f21b89
       /src/main.rs#L123-L124
+
+    Also propagate `RUSTUP_HOME` and `RUSTUP_TOOLCHAIN` so that when we create a fresh
+    `CARGO_HOME`, rustup can still resolve the correct toolchain.
   */
-  for key in ["RUSTC_WRAPPER", "RUSTC_WORKSPACE_WRAPPER", "CLIPPY_ARGS", "CLIPPY_TERMINAL_WIDTH"] {
+  for key in [
+    "RUSTC_WRAPPER",
+    "RUSTC_WORKSPACE_WRAPPER",
+    "CLIPPY_ARGS",
+    "CLIPPY_TERMINAL_WIDTH",
+    "RUSTUP_HOME",
+    "RUSTUP_TOOLCHAIN",
+  ] {
     if let Ok(value) = env::var(key) {
       command.env(key, value);
     }
@@ -697,21 +722,6 @@ which will build the WASM as part of its build process, with the necessary confi
     To solve this, we explicitly declare the original workspace for our future calls.
   */
   build_command.env("WORKSPACE_DIR", workspace_dir());
-
-  /*
-    We do propagate the host's `PATH`, as the Rust toolchain requires the host's C compiler, even
-    when using the self-contained linker, in order to drive it and provide the platform-specific
-    libraries.
-
-    While we could build a `PATH` from the Rust toolchain, and then append the value of
-    `RUSTC_LINKER` (to have a `PATH` deterministic to the Rust toolchain with the sole exception of
-    the host's linker), `RUSTC_LINKER` is the linker for the _target_, not the host, when we would
-    want to set the linker for the host specifically. There also isn't a trivial way to query the
-    _resolved_ linker after all the possible configuration methods are taken into consideration.
-  */
-  if let Ok(path) = env::var("PATH") {
-    build_command.env("PATH", path);
-  }
 
   /*
     Install ourselves as the `rustc` wrapper for the reasons described above.

--- a/substrate/runtime/src/std_runtime_api.rs
+++ b/substrate/runtime/src/std_runtime_api.rs
@@ -17,6 +17,7 @@ use super::*;
 
 /// A `struct` representing the runtime as necessary to define the available APIs.
 // This `struct` itself is never instantiated, solely the `RuntimeApi` derived around it.
+#[allow(dead_code)]
 struct Runtime;
 
 sp_api::impl_runtime_apis! {

--- a/substrate/signals/src/benchmarking.rs
+++ b/substrate/signals/src/benchmarking.rs
@@ -71,8 +71,8 @@ mod benchmarks {
           .flat_map(IntoIterator::into_iter)
           .map(|event| borsh::from_slice::<serai_abi::Event>(event.as_slice()).unwrap())
           .filter(|event| matches!(event, serai_abi::Event::Signals(_)))
-          .last() ==
-          Some(serai_abi::Event::Signals(Event::RetirementSignalLockedIn { signal: signal_id }))
+          .last()
+          == Some(serai_abi::Event::Signals(Event::RetirementSignalLockedIn { signal: signal_id }))
         {
           break 'outer;
         }

--- a/substrate/signals/src/benchmarking.rs
+++ b/substrate/signals/src/benchmarking.rs
@@ -71,8 +71,8 @@ mod benchmarks {
           .flat_map(IntoIterator::into_iter)
           .map(|event| borsh::from_slice::<serai_abi::Event>(event.as_slice()).unwrap())
           .filter(|event| matches!(event, serai_abi::Event::Signals(_)))
-          .last()
-          == Some(serai_abi::Event::Signals(Event::RetirementSignalLockedIn { signal: signal_id }))
+          .last() ==
+          Some(serai_abi::Event::Signals(Event::RetirementSignalLockedIn { signal: signal_id }))
         {
           break 'outer;
         }


### PR DESCRIPTION
I was getting bunch of errors when I try to build the `next-polkadot-sdk` branch on M1 macOS Tahoe 26.2 with `cargo build --all-features` command. This PR fixes couple of issues on the runtime  build  script that causes build to fail. This is only tested on said operating system. Its effect on other operating systems yet to be tested.  Here what it fixes;

1. Moved setting the `PATH` env variable directly within `command` function instead of only setting it for `build_command` since other commands also need the `PATH` variable. Specifically, `tree_command` also needed to find the `rustc`.
2. Include  `RUSTUP_HOME` and `RUSTUP_TOOLCHAIN` in the env variables we are setting so that it is still resolved after we create fresh `CARGO_HOME`. 
3. Put `rustflags` command inside a block to properly apply the `cfg` attribute.
4. Import `alloc::vec::Vec` to `signals/benchmarking` 