### PR TITLE
Enable various CIs for `next-polkadot-sdk`

### DIFF
--- a/.github/actions/bitcoin/action.yml
+++ b/.github/actions/bitcoin/action.yml
@@ -14,10 +14,10 @@ runs:
       id: cache-bitcoind
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # 4.2.4
       with:
-        path: bitcoin*
+        path: bitcoin-${{ inputs.version }}
         key: bitcoind-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
 
-    - name: Download the Bitcoin Daemon
+    - name: Download and Extract the Bitcoin Daemon
       if: steps.cache-bitcoind.outputs.cache-hit != 'true'
       shell: bash
       run: |
@@ -46,19 +46,19 @@ runs:
 
         FILE=bitcoin-${{ inputs.version }}-$ARCH$OS.$EXT
 
-        wget https://bitcoincore.org/bin/bitcoin-core-${{ inputs.version }}/$FILE
-        mv $FILE bitcoin.$EXT
+        curl -L https://bitcoincore.org/bin/bitcoin-core-${{ inputs.version }}/$FILE -o $FILE
 
-    - name: Extract the Bitcoin Daemon
-      shell: bash
-      run: |
         if [ "${{ runner.os }}" = "Windows" ]; then
-          unzip bitcoin.zip
+          unzip $FILE
           mv $(find . -name "bitcoind*") .
         else
-          tar -xf bitcoin.tar.gz
+          tar -xf $FILE
           cd bitcoin-${{ inputs.version }}
-          sudo mv bin/* /usr/bin && sudo mv lib/* /usr/lib
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            sudo mv bin/* /usr/local/bin/
+          else
+            sudo mv bin/* /usr/bin/
+          fi
         fi
 
     - name: Bitcoin Regtest Daemon

--- a/.github/actions/bitcoin/action.yml
+++ b/.github/actions/bitcoin/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - name: Bitcoin Daemon Cache
       id: cache-bitcoind
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # 4.2.4
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
       with:
         path: bitcoin-${{ inputs.version }}
         key: bitcoind-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}

--- a/.github/actions/build-dependencies/action.yml
+++ b/.github/actions/build-dependencies/action.yml
@@ -40,7 +40,9 @@ runs:
         if [ "$RUNNER_OS" == "Linux" ]; then
           sudo apt install -y ca-certificates protobuf-compiler libclang-dev
         elif [ "$RUNNER_OS" == "Windows" ]; then
-          choco install protoc
+          # Use `-gnu` to avoid the installation and licensing headaches of `-msvc`
+          rustup set default-host x86_64-pc-windows-gnu
+          choco install llvm protoc
         elif [ "$RUNNER_OS" == "macOS" ]; then
           brew install protobuf llvm
           HOMEBREW_PREFIX=$(brew --prefix)

--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -37,6 +37,15 @@ runs:
           exit 1
         fi
 
+    - name: Get the arguments to start Lima with
+      shell: bash
+      if: runner.os == 'macOS'
+      run: |
+        if [ $(uname -m) = "x86_64" ]; then
+          # On Intel CPUs, where we can use the Virtualization Framework, we do so
+          echo "LIMA_START_ARGS=--vm-type=vz --mount-type=virtiofs" >> "$GITHUB_ENV"
+        fi
+
     - name: Install Docker (macOS)
       uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d # 5.0.0
       if: runner.os == 'macOS'

--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -57,6 +57,15 @@ runs:
       with:
         set-host: true
 
+    - name: Install `buildx`
+      if: runner.os == 'macOS'
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # 4.0.0
+      with:
+        # This is Docker's default, but `setup-buildx-action` defaults to `docker-container`
+        # (for _some_ reason) which means built images won't be loaded into Docker (`--load`) by
+        # default. We want that behavior.
+        driver: docker
+
     - name: Remove preinstalled Docker
       if: runner.os == 'Windows'
       shell: pwsh
@@ -99,20 +108,10 @@ runs:
     # runtime, a WASM blob which should be exactly reproducible, we fix the builder to x86-64
     # accordingly. This requires we be able to run a x86-64 userspace.
     - name: Install x64 Qemu for non-x64 Docker
-      if: runner.arch != 'X64'
+      if: (runner.os != 'Windows') && (runner.arch != 'X64')
       uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # 4.0.0
       with:
         platforms: amd64
-
-    # This isn't strictly required. ARM macOS performs very slowly and `buildx` is notably faster.
-    - name: Install `buildx`
-      if: (runner.os == 'macOS') && (runner.arch == 'ARM64')
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # 4.0.0
-      with:
-        # This is Docker's default, but `setup-buildx-action` defaults to `docker-container`
-        # (for _some_ reason) which means built images won't be loaded into Docker (`--load`) by
-        # default. We want that behavior.
-        driver: docker
 
     # This ensures we have a consistent clean build, there aren't any issues from any version of
     # `docker` we removed before installing our current version, and checks that `docker` was in

--- a/.github/actions/monero/action.yml
+++ b/.github/actions/monero/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - name: Monero Daemon Cache
       id: cache-monerod
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # 4.2.4
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
       with:
         path: monerod*
         key: monerod-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}

--- a/.github/actions/test-dependencies/action.yml
+++ b/.github/actions/test-dependencies/action.yml
@@ -19,9 +19,9 @@ runs:
       uses: ./.github/actions/build-dependencies
 
     - name: Install Foundry
-      uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e # 1.5.0
+      uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # 1.7.0
       with:
-        version: v1.5.0
+        version: v1.5.1
         cache: false
 
     - name: Run a Monero Regtest Node

--- a/.github/workflows/common-tests.yml
+++ b/.github/workflows/common-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - next-polkadot-sdk
     paths:
       - "common/**"
 

--- a/.github/workflows/common-tests.yml
+++ b/.github/workflows/common-tests.yml
@@ -27,12 +27,8 @@ jobs:
         uses: ./.github/actions/build-dependencies
 
       - name: Run Tests
+        shell: bash
         run: |
-          cargo test --all-features \
-            -p std-shims \
-            -p zalloc \
-            -p patchable-async-sleep \
-            -p serai-db \
-            -p serai-env \
-            -p serai-task \
-            -p simple-request
+          find ./common -name "Cargo.toml" | while IFS="\n" read -r manifest; do
+            cargo test --all-features --manifest-path $manifest
+          done

--- a/.github/workflows/common-tests.yml
+++ b/.github/workflows/common-tests.yml
@@ -17,7 +17,7 @@ jobs:
   test-common:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-26-intel, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-26-intel, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/crypto-tests.yml
+++ b/.github/workflows/crypto-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - next-polkadot-sdk
     paths:
       - "common/**"
       - "crypto/**"

--- a/.github/workflows/crypto-tests.yml
+++ b/.github/workflows/crypto-tests.yml
@@ -29,24 +29,8 @@ jobs:
         uses: ./.github/actions/build-dependencies
 
       - name: Run Tests
+        shell: bash
         run: |
-          cargo test --all-features \
-            -p flexible-transcript \
-            -p ff-group-tests \
-            -p dalek-ff-group \
-            -p minimal-ed448 \
-            -p ciphersuite \
-            -p ciphersuite-kp256 \
-            -p multiexp \
-            -p schnorr-signatures \
-            -p prime-field \
-            -p short-weierstrass \
-            -p secq256k1 \
-            -p embedwards25519 \
-            -p dkg \
-            -p dkg-recovery \
-            -p dkg-dealer \
-            -p dkg-musig \
-            -p dkg-evrf \
-            -p modular-frost \
-            -p frost-schnorrkel
+          find ./crypto -name "Cargo.toml" | while IFS="\n" read -r manifest; do
+            cargo test --all-features --manifest-path $manifest
+          done

--- a/.github/workflows/libraries-on-redox.yml
+++ b/.github/workflows/libraries-on-redox.yml
@@ -22,10 +22,13 @@ jobs:
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0
 
+      - name: Install QEMU
+        run: sudo apt update -y && sudo apt upgrade -y && sudo apt install -y qemu-system-x86
+
       - name: Run Tests for Libraries on Redoxer
         run: |
           cargo +1.94.0 install redoxer --version =0.2.62
-          redoxer toolchain
+          TARGET=x86_64-unknown-redox redoxer toolchain
           GITHUB_CI=true RUST_BACKTRACE=1 redoxer test -- --all-features \
             -p std-shims \
             -p zalloc \

--- a/.github/workflows/libraries-on-redox.yml
+++ b/.github/workflows/libraries-on-redox.yml
@@ -26,30 +26,14 @@ jobs:
         run: sudo apt update -y && sudo apt upgrade -y && sudo apt install -y qemu-system-x86
 
       - name: Run Tests for Libraries on Redoxer
+        shell: bash
         run: |
           cargo +1.94.0 install redoxer --version =0.2.62
           TARGET=x86_64-unknown-redox redoxer toolchain
-          GITHUB_CI=true RUST_BACKTRACE=1 redoxer test -- --all-features \
-            -p std-shims \
-            -p zalloc \
-            -p patchable-async-sleep \
-            -p simple-request \
-            -p flexible-transcript \
-            -p ff-group-tests \
-            -p dalek-ff-group \
-            -p minimal-ed448 \
-            -p ciphersuite \
-            -p ciphersuite-kp256 \
-            -p multiexp \
-            -p schnorr-signatures \
-            -p prime-field \
-            -p short-weierstrass \
-            -p secq256k1 \
-            -p embedwards25519 \
-            -p dkg \
-            -p dkg-recovery \
-            -p dkg-dealer \
-            -p dkg-musig \
-            -p dkg-evrf \
-            -p modular-frost \
-            -p frost-schnorrkel
+
+          find ./common ./crypto -name "Cargo.toml" | while IFS="\n" read -r manifest; do
+            if [ "$manifest" = "./common/db/Cargo.toml" ]; then
+              continue
+            fi
+            GITHUB_CI=true RUST_BACKTRACE=1 redoxer test -- --all-features --manifest-path $manifest
+          done

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -159,17 +159,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0
+      - name: Build Dependencies
+        uses: ./.github/actions/build-dependencies
       - name: Verify claimed `rust-version`
         shell: bash
         run: |
           cargo +1.94.0 install cargo-msrv --version =0.19.2
+
+          # Remove `patches/{home, getrandom}` as they force the entire workspace to Rust 1.85(+)
+          echo "$(cat ./Cargo.toml | grep -v 'patches/home' | grep -v 'patches/getrandom')" > ./Cargo.toml
 
           function check_msrv {
             # We `cd` into the directory passed as the first argument, but will return to the
             # directory called from.
             return_to=$(pwd)
             echo "Checking $1"
-            cd $1
+            cd "$1"
+
+            # If this is marked `publish = false`, check it doesn't declare a MSRV
+            if [ $(grep "publish = false" ./Cargo.toml | wc -l || true) -ne 0 ]; then
+              [ "$(grep 'rust-version' ./Cargo.toml || true)" = "" ]
+              cd "$return_to"
+              return
+            fi
 
             # We then find the existing `rust-version` using `grep` (for the right line) and then a
             # regex (to strip to just the major and minor version).
@@ -200,7 +212,7 @@ jobs:
             mv ./Cargo.toml.bak ./Cargo.toml
 
             # Return to the directory called from and return the result.
-            cd $return_to
+            cd "$return_to"
             return $result
           }
 
@@ -218,24 +230,6 @@ jobs:
             members=$(echo "$members" | sed "1s/.*/\[/")
             # Correct the last line, which was malleated to "],"
             members=$(echo "$members" | sed "$(echo "$members" | wc -l)s/\]\,/\]/")
-
-            # Don't check the following
-            # Most of these are binaries, with the exception of the Substrate runtime which has a
-            # bespoke build pipeline
-            members=$(echo "$members" | grep -v "networks/ethereum/relayer\"")
-            members=$(echo "$members" | grep -v "message-queue\"")
-            members=$(echo "$members" | grep -v "processor/bin\"")
-            members=$(echo "$members" | grep -v "processor/bitcoin\"")
-            members=$(echo "$members" | grep -v "processor/ethereum\"")
-            members=$(echo "$members" | grep -v "processor/monero\"")
-            members=$(echo "$members" | grep -v "coordinator\"")
-            members=$(echo "$members" | grep -v "substrate/runtime\"")
-            members=$(echo "$members" | grep -v "substrate/node\"")
-            members=$(echo "$members" | grep -v "orchestration\"")
-
-            # Don't check the tests
-            members=$(echo "$members" | grep -v "mini\"")
-            members=$(echo "$members" | grep -v "tests/")
 
             # Remove the trailing comma by replacing the last line's "," with ""
             members=$(echo "$members" | sed "$(($(echo "$members" | wc -l) - 1))s/\,//")

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,15 +51,18 @@ jobs:
       - name: Verify `pallet::hooks` is unused
         shell: bash
         run: |
-          error=0
-          find ./substrate -iname "*.rs" | while read -r file; do
-            hooks=$(grep -F "pallet::hooks" "$file" | grep -v -F "serai-core-pallet: allow" | wc -l)
-            if [ $hooks -ne 0 ]; then
-              echo "\`pallet::hooks\` (without \`serai-core-pallet: allow\`) found in $file"
-              error=1
-            fi
-          done
-          exit $error
+          FAILURES=$(
+            find ./substrate -name "*.rs" | while IFS="\n" read -r file; do
+              hooks=$(grep -F "pallet::hooks" "$file" | grep -v -F "serai-core-pallet: allow" | wc -l || true)
+              if [ $hooks -ne 0 ]; then
+                echo "\`pallet::hooks\` (without \`serai-core-pallet: allow\`) found in $file"
+              fi
+            done
+          )
+          if [ ! "$FAILURES" = "" ]; then
+            echo "$FAILURES"
+            exit 1
+          fi
 
       # Also verify the lockfile isn't dirty
       # This happens when someone edits a Cargo.toml yet doesn't do anything

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
   clippy:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-26-intel, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-26-intel, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - next-polkadot-sdk
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -129,19 +129,19 @@ jobs:
         run: cargo +${{ steps.nightly.outputs.version }} fmt -- --check
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e # 1.5.0
+        uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # 1.7.0
         with:
-          version: v1.5.0
+          version: v1.5.1
           cache: false
 
       - name: Run forge fmt
         shell: bash
         run: |
-          FOUNDRY_FMT_SORT_INPUTS=false
-          FOUNDRY_FMT_LINE_LENGTH=100
-          FOUNDRY_FMT_TAB_WIDTH=2
-          FOUNDRY_FMT_BRACKET_SPACING=true
-          FOUNDRY_FMT_INT_TYPES=preserve
+          export FOUNDRY_FMT_SORT_INPUTS=false
+          export FOUNDRY_FMT_LINE_LENGTH=100
+          export FOUNDRY_FMT_TAB_WIDTH=2
+          export FOUNDRY_FMT_BRACKET_SPACING=true
+          export FOUNDRY_FMT_INT_TYPES=preserve
 
           forge fmt --check $(find . -name "*.sol")
 
@@ -250,7 +250,7 @@ jobs:
           check_workspace
 
   slither:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0
 
@@ -260,6 +260,7 @@ jobs:
       - name: Slither
         shell: bash
         run: |
+          sudo apt install -y python3-pip
           python3 -m pip install slither-analyzer==0.11.3
 
           slither ./networks/ethereum/schnorr/contracts/Schnorr.sol

--- a/.github/workflows/message-queue-tests.yml
+++ b/.github/workflows/message-queue-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - next-polkadot-sdk
     paths:
       - "common/**"
       - "crypto/**"

--- a/.github/workflows/networks-tests.yml
+++ b/.github/workflows/networks-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - next-polkadot-sdk
     paths:
       - "common/**"
       - "crypto/**"

--- a/.github/workflows/networks-tests.yml
+++ b/.github/workflows/networks-tests.yml
@@ -21,7 +21,7 @@ jobs:
   test-bitcoin:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-26-intel, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-26-intel, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -36,7 +36,7 @@ jobs:
   test-ethereum:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-26-intel, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-26-intel, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/networks-tests.yml
+++ b/.github/workflows/networks-tests.yml
@@ -46,9 +46,8 @@ jobs:
         uses: ./.github/actions/test-dependencies
 
       - name: Run Tests
+        shell: bash
         run: |
-          cargo test --all-features \
-            -p build-solidity-contracts \
-            -p ethereum-schnorr-contract \
-            -p alloy-simple-request-transport \
-            -p serai-ethereum-relayer
+          find ./networks/ethereum -name "Cargo.toml" | while IFS="\n" read -r manifest; do
+            cargo test --all-features --manifest-path $manifest
+          done

--- a/.github/workflows/no-std.yml
+++ b/.github/workflows/no-std.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - next-polkadot-sdk
     paths:
       - "common/**"
       - "crypto/**"

--- a/.github/workflows/no-std.yml
+++ b/.github/workflows/no-std.yml
@@ -29,6 +29,9 @@ jobs:
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0
 
+      - name: Build Dependencies
+        uses: ./.github/actions/build-dependencies
+
       - name: Get nightly version to use
         id: nightly
         shell: bash
@@ -37,12 +40,26 @@ jobs:
       - name: Install RISC-V Toolchain
         shell: bash
         run: |
-          if [ "$RUNNER_OS" == "Linux" ]; then
+          if [ "$RUNNER_OS" = "Linux" ]; then
             sudo apt install -y gcc-riscv64-unknown-elf gcc-multilib
+          elif [ "$RUNNER_OS" = "macOS" ]; then
+            brew tap riscv-software-src/riscv
+            brew install riscv-tools
+          elif [ "$RUNNER_OS" = "Windows" ]; then
+            /C/msys64/usr/bin/pacman.exe -Syu --noconfirm
+            /C/msys64/usr/bin/pacman.exe -S --noconfirm mingw-w64-x86_64-riscv32-unknown-elf-gcc
           fi
 
       - name: Verify no-std builds
         shell: bash
         run: |
-          CFLAGS=-I/usr/include cargo +${{ steps.nightly.outputs.version }} build --target riscv32imac-unknown-none-elf -Z build-std=core -p serai-no-std-tests
-          CFLAGS=-I/usr/include cargo +${{ steps.nightly.outputs.version }} build --target riscv32imac-unknown-none-elf -Z build-std=core,alloc -p serai-no-std-tests --features "alloc"
+          rustup +${{ steps.nightly.outputs.version }} component add rust-src
+
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            export CFLAGS=-I/usr/include
+          elif [ "$RUNNER_OS" = "Windows" ]; then
+            export PATH="$PATH:/C/msys64/mingw64/bin"
+          fi
+
+          cargo +${{ steps.nightly.outputs.version }} build --target riscv32imac-unknown-none-elf -Z build-std=core -p serai-no-std-tests
+          cargo +${{ steps.nightly.outputs.version }} build --target riscv32imac-unknown-none-elf -Z build-std=core,alloc -p serai-no-std-tests --features "alloc"

--- a/.github/workflows/reproducible-runtime.yml
+++ b/.github/workflows/reproducible-runtime.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - next-polkadot-sdk
     paths:
       - "Cargo.lock"
       - "common/**"

--- a/.github/workflows/stack-size.yml
+++ b/.github/workflows/stack-size.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Monero Daemon Cache
         id: cache-monerod
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # 4.2.4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
         with:
           path: monerod
           key: stack-size-monerod
@@ -74,9 +74,9 @@ jobs:
             # macOS also has the benefit of packaging (via MacPorts) `mrsh`,
             # which explicitly attempts to be be exactly POSIX, without any extensions.
             # We first have to install MacPorts, the easiest method being from source.
-            curl -O https://distfiles.macports.org/MacPorts/MacPorts-2.12.3.tar.bz2
-            tar xf MacPorts-2.12.3.tar.bz2
-            cd MacPorts-2.12.3
+            curl -O https://distfiles.macports.org/MacPorts/MacPorts-2.12.4.tar.bz2
+            tar xf MacPorts-2.12.4.tar.bz2
+            cd MacPorts-2.12.4
             ./configure
             make
             sudo make install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - next-polkadot-sdk
     paths:
       - "common/**"
       - "crypto/**"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,23 +80,12 @@ jobs:
         uses: ./.github/actions/build-dependencies
 
       - name: Run Tests
+        shell: bash
         run: |
-          cargo test --all-features \
-            -p serai-primitives \
-            -p serai-abi \
-            -p substrate-median \
-            -p serai-core-pallet \
-            -p serai-coins-pallet \
-            -p serai-validator-sets-pallet \
-            -p serai-signals-pallet \
-            -p serai-dex-pallet \
-            -p serai-genesis-liquidity-pallet \
-            -p serai-economic-security-pallet \
-            -p serai-emissions-pallet \
-            -p serai-in-instructions-pallet \
-            -p serai-runtime \
-            -p serai-node \
-            -p serai-substrate-tests
+          find ./substrate -name "Cargo.toml" ! -path "*client*" | while IFS="\n" read -r manifest; do
+            cargo test --all-features --manifest-path $manifest
+          done
+          cargo test --all-features -p serai-substrate-tests
 
   test-serai-client:
     runs-on: ubuntu-latest
@@ -107,10 +96,8 @@ jobs:
         uses: ./.github/actions/build-dependencies
 
       - name: Run Tests
+        shell: bash
         run: |
-          cargo test --all-features \
-            -p serai-client-serai \
-            -p serai-client-bitcoin \
-            -p serai-client-ethereum \
-            -p serai-client-monero \
-            -p serai-client
+          find ./substrate -name "Cargo.toml" -path "*client*" | while IFS="\n" read -r manifest; do
+            cargo test --all-features --manifest-path $manifest
+          done

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
             -p serai-processor-bin \
             -p serai-bitcoin-processor \
             -p serai-processor-ethereum-primitives \
-            -p serai-processor-ethereum-test-primitives \
+            -p serai-ethereum-test-primitives \
             -p serai-processor-ethereum-deployer \
             -p serai-processor-ethereum-router \
             -p serai-processor-ethereum-erc20 \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,8 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0
 
-      - name: Build Dependencies
-        uses: ./.github/actions/build-dependencies
+      - name: Test Dependencies
+        uses: ./.github/actions/test-dependencies
 
       - name: Run Tests
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,8 @@ should be [submitted via GitHub](https://github.com/serai-dex/serai/issues).
 Serai is currently partially tested with [`podman`](https://podman.io) (aliased
 to `docker`) and a long-term goal is to fully test Serai with both `docker` and
 `podman` (https://github.com/serai-dex/serai/issues/709).
+`docker buildx build` is used by some tests which _require_ being built with
+[BuildKit](https://github.com/moby/buildkit).
 
 When building binaries, or running tests, via OCI containers, the user is
 expected to able to spawn/manage containers (as potentially obvious). This

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,8 @@ to `docker`) and a long-term goal is to fully test Serai with both `docker` and
 `docker buildx build` is used by some tests which _require_ being built with
 [BuildKit](https://github.com/moby/buildkit).
 
-When building binaries, or running tests, via OCI containers, the user is
-expected to able to spawn/manage containers (as potentially obvious). This
+When building binaries, or running tests, via OCI containers, the user account
+is expected to able to spawn/manage containers (as potentially obvious). This
 implies the setup should be rootless
 ([as possible with Docker](https://docs.docker.com/engine/security/rootless/)
 and as inherent to `podman`'s architecture).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9d22005bf31b018f31ef9ecadb5d2c39cf4f6acc8db0456f72c815f3d7f757"
+checksum = "9247f0a399ef71aeb68f497b2b8fb348014f742b50d3b83b1e00dfe1b7d64b3d"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -613,7 +613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -1091,7 +1091,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.37.3",
  "rustc-demangle",
  "windows-link",
 ]
@@ -1374,19 +1374,20 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "borsh-derive",
+ "bytes",
  "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.5.0",
@@ -1836,36 +1837,37 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.129.1"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40630d663279bc855bff805d6f5e8a0b6a1867f9df95b010511ac6dc894e9395"
+checksum = "4f248321c6a7d4de5dcf2939368e96a397ad3f53b6a076e38d0104d1da326d37"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.129.1"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee6aec5ceb55e5fdbcf7ef677d7c7195531360ff181ce39b2b31df11d57305f"
+checksum = "ab6d78ff1f7d9bf8b7e1afbedbf78ba49e38e9da479d4c8a2db094e22f64e2bc"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.129.1"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a92d78cc3f087d7e7073828f08d98c7074a3a062b6b29a1b7783ce74305685e"
+checksum = "6b6005ba640213a5b95382aeaf6b82bf028309581c8d7349778d66f27dc1180b"
 dependencies = [
  "cranelift-entity",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.129.1"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edcc73d756f2e0d7eda6144fe64a2bc69c624de893cb1be51f1442aed77881d2"
+checksum = "81fb5b134a12b559ff0c0f5af0fcd755ad380723b5016c4e0d36f74d39485340"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1874,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.129.1"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d94c2cd0d73b41369b88da1129589bc3a2d99cf49979af1d14751f35b7a1b"
+checksum = "85837de8be7f17a4034a6b08816f05a3144345d2091937b39d415990daca28f4"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1888,7 +1890,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli 0.33.0",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "libm",
  "log",
  "pulley-interpreter",
@@ -1902,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.129.1"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235da0e52ee3a0052d0e944c3470ff025b1f4234f6ec4089d3109f2d2ffa6cbd"
+checksum = "e433faa87d38e5b8ff469e44a26fea4f93e58abd7a7c10bad9810056139700c9"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1915,24 +1917,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.129.1"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c07c6c440bd1bf920ff7597a1e743ede1f68dcd400730bd6d389effa7662af"
+checksum = "5397ba61976e13944ca71230775db13ee1cb62849701ed35b753f4761ed0a9b7"
 
 [[package]]
 name = "cranelift-control"
-version = "0.129.1"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8797c022e02521901e1aee483dea3ed3c67f2bf0a26405c9dd48e8ee7a70944b"
+checksum = "cc81c88765580720eb30f4fc2c1bfdb75fcbf3094f87b3cd69cecca79d77a245"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.129.1"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59d8e72637246edd2cba337939850caa8b201f6315925ec4c156fdd089999699"
+checksum = "463feed5d46cf8763f3ba3045284cf706dd161496e20ec9c14afbb4ba09b9e66"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1942,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.129.1"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c31db0085c3dfa131e739c3b26f9f9c84d69a9459627aac1ac4ef8355e3411b"
+checksum = "a4c5eca7696c1c04ab4c7ed8d18eadbb47d6cc9f14ec86fe0881bf1d7e97e261"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1954,15 +1956,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.129.1"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524d804c1ebd8c542e6f64e71aa36934cec17c5da4a9ae3799796220317f5d23"
+checksum = "f1153844610cc9c6da8cf10ce205e45da1a585b7688ed558aa808bbe2e4e6d77"
 
 [[package]]
 name = "cranelift-native"
-version = "0.129.1"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9598f02540e382e1772416eba18e93c5275b746adbbf06ac1f3cf149415270"
+checksum = "a97b583fe9a60f06b0464cee6be5a17f623fd91b217aaac99b51b339d19911af"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1971,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.129.1"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d953932541249c91e3fa70a75ff1e52adc62979a2a8132145d4b9b3e6d1a9b6a"
+checksum = "8594dc6bb4860fa8292f1814c76459dbfb933e1978d8222de6380efce45c7cee"
 
 [[package]]
 name = "crc32fast"
@@ -2044,9 +2046,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde2467e74147f492aebb834985186b2c74761927b8b9b3bd303bcb2e72199d"
+checksum = "e9b6a7421484856c90cb2e996b91068d608539bb4e6f0a111b16d70678824d09"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -2144,7 +2146,7 @@ name = "dalek-ff-group"
 version = "0.5.99"
 dependencies = [
  "crypto-bigint 0.5.5",
- "crypto-bigint 0.7.1",
+ "crypto-bigint 0.7.2",
  "dalek-ff-group 0.5.0",
  "prime-field",
 ]
@@ -2905,7 +2907,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2932,7 +2934,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "45.0.3"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2955,7 +2957,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "45.0.1"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2971,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "45.1.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "array-bytes",
  "environmental",
@@ -3002,7 +3004,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "36.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3021,7 +3023,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.5.0",
@@ -3033,7 +3035,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3043,7 +3045,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "45.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "cfg-if",
  "frame-support",
@@ -3060,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.51.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3469,7 +3471,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -4012,9 +4013,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -4149,10 +4150,11 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.2.0-rc.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882b69cb15b1f78b51342322a97ccd16f5123d1dc8a3da981a95244f488e8692"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
+ "cfg-if",
  "cpufeatures 0.3.0",
 ]
 
@@ -4912,12 +4914,12 @@ name = "minimal-ed448"
 version = "0.4.2"
 dependencies = [
  "ciphersuite 0.4.2",
- "crypto-bigint 0.7.1",
+ "crypto-bigint 0.7.2",
  "ff-group-tests",
  "hex",
  "prime-field",
  "rand_core 0.6.4",
- "sha3 0.11.0-rc.8",
+ "sha3 0.11.0-rc.9",
  "zeroize",
 ]
 
@@ -4975,9 +4977,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -5542,9 +5544,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -5552,9 +5554,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5581,8 +5583,17 @@ version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
+dependencies = [
  "crc32fast",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "memchr",
 ]
@@ -5636,7 +5647,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "45.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5647,7 +5658,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "45.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5668,7 +5679,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "45.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5688,7 +5699,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "45.1.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5699,7 +5710,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "44.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5968,7 +5979,7 @@ dependencies = [
 name = "prime-field"
 version = "0.1.0"
 dependencies = [
- "crypto-bigint 0.7.1",
+ "crypto-bigint 0.7.2",
  "ctutils",
  "ff",
  "ff-group-tests",
@@ -6198,9 +6209,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc2d61e068654529dc196437f8df0981db93687fdc67dec6a5de92363120b9da"
+checksum = "7975f0975fa2c047bf47d617bdf716689e42ee82b159bd000ead7330d7697a1b"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -6210,9 +6221,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f210c61b6ecfaebbba806b6d9113a222519d4e5cc4ab2d5ecca047bb7927ae"
+checksum = "a210c0386ef0ddedb337ec99b91e560ae9c341415ef75958cb39ddb537bb0c84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6523,9 +6534,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.13.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08effbc1fa53aaebff69521a5c05640523fab037b34a4a2c109506bc938246fa"
+checksum = "952ddbfc6f9f64d006c3efd8c9851a6ba2f2b944ba94730db255d55006e0ffda"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -6958,9 +6969,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -7015,7 +7026,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "35.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "log",
  "sp-core",
@@ -7026,7 +7037,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.55.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "async-trait",
  "futures",
@@ -7056,7 +7067,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.53.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "futures",
  "log",
@@ -7078,7 +7089,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.48.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7093,7 +7104,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "48.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -7114,7 +7125,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.57.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -7150,7 +7161,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "44.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "fnv",
  "futures",
@@ -7176,7 +7187,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.51.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -7203,7 +7214,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.54.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "async-trait",
  "futures",
@@ -7225,7 +7236,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.55.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -7262,7 +7273,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.54.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -7275,7 +7286,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.40.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -7318,7 +7329,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.54.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "async-trait",
  "futures",
@@ -7340,7 +7351,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.47.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
@@ -7360,7 +7371,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.43.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "sc-allocator",
  "sp-wasm-interface",
@@ -7370,7 +7381,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.43.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "log",
  "parking_lot",
@@ -7385,7 +7396,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.54.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "console",
  "futures",
@@ -7401,7 +7412,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "39.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "array-bytes",
  "parking_lot",
@@ -7415,7 +7426,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.55.1"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -7459,7 +7470,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.52.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -7469,7 +7480,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.55.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "ahash",
  "futures",
@@ -7488,7 +7499,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.54.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -7522,7 +7533,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.54.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "array-bytes",
  "futures",
@@ -7541,7 +7552,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.20.1"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "bs58",
  "bytes",
@@ -7562,7 +7573,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -7571,7 +7582,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "50.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -7590,7 +7601,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.54.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7602,7 +7613,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "27.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -7626,7 +7637,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.56.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "async-trait",
  "directories",
@@ -7686,7 +7697,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.41.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7696,7 +7707,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "46.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "derive_more 1.0.0",
  "futures",
@@ -7716,7 +7727,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "30.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "chrono",
  "futures",
@@ -7735,7 +7746,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "44.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "chrono",
  "console",
@@ -7762,7 +7773,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -7773,7 +7784,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "44.1.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "async-trait",
  "futures",
@@ -7804,7 +7815,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "43.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "async-trait",
  "futures",
@@ -7822,7 +7833,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "20.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "async-channel",
  "futures",
@@ -8213,7 +8224,6 @@ dependencies = [
  "borsh",
  "dkg",
  "futures",
- "log",
  "serai-client-serai",
  "serai-cosign",
  "serai-db",
@@ -8382,7 +8392,6 @@ dependencies = [
  "serai-env",
  "serai-primitives",
  "serai-processor-bin",
- "serai-processor-ethereum-erc20",
  "serai-processor-ethereum-primitives",
  "serai-processor-ethereum-router",
  "serai-processor-key-gen",
@@ -8816,10 +8825,8 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "group",
- "log",
  "serai-primitives",
  "serai-task",
- "tokio",
 ]
 
 [[package]]
@@ -9220,12 +9227,12 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.8"
+version = "0.11.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95f78cd62cc39ece5aefbeb6caaa2ea44f70b4815d4b85f7e150ac685ada2bb5"
+checksum = "0b233a7d59d7bfc027208506a33ffc9532b2acb24ddc61fe7e758dc2250db431"
 dependencies = [
  "digest 0.11.2",
- "keccak 0.2.0-rc.2",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -9404,7 +9411,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "40.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "hash-db",
  "log",
@@ -9423,7 +9430,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "26.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -9437,7 +9444,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "44.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9448,7 +9455,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "28.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -9460,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "40.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9470,7 +9477,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "40.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -9480,7 +9487,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "43.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -9499,7 +9506,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.46.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "async-trait",
  "futures",
@@ -9513,7 +9520,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.46.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9530,7 +9537,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "27.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -9546,7 +9553,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.46.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9556,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "39.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "array-bytes",
  "bip39",
@@ -9594,7 +9601,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -9607,7 +9614,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -9617,7 +9624,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.1"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "kvdb",
  "kvdb-rocksdb",
@@ -9627,7 +9634,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9637,7 +9644,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.31.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9647,7 +9654,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.21.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9656,7 +9663,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "40.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -9668,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "44.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "bytes",
  "log",
@@ -9689,7 +9696,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "45.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -9699,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.45.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
@@ -9710,7 +9717,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "backtrace",
  "regex",
@@ -9719,7 +9726,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "37.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -9728,7 +9735,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "45.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "bytes",
  "either",
@@ -9753,7 +9760,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "33.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "bytes",
  "parity-scale-codec",
@@ -9767,7 +9774,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "Inflector",
  "expander",
@@ -9780,7 +9787,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "42.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9792,7 +9799,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "42.1.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -9802,7 +9809,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.49.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "hash-db",
  "log",
@@ -9822,12 +9829,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9839,7 +9846,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9851,7 +9858,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "19.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "parity-scale-codec",
  "regex",
@@ -9863,7 +9870,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "40.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -9872,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "42.0.1"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "ahash",
  "foldhash 0.1.5",
@@ -9895,7 +9902,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "43.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9909,7 +9916,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -9921,7 +9928,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "24.0.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -9932,7 +9939,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "33.2.0"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -10093,7 +10100,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.7"
-source = "git+https://github.com/serai-dex/patch-polkadot-sdk#686343cdb05374b598a34ec0d90d660f81ee263a"
+source = "git+https://github.com/serai-dex/patch-polkadot-sdk#1ca91dd50497050e87564aa30611ef6a21b483e9"
 dependencies = [
  "hyper",
  "log",
@@ -10432,7 +10439,7 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -10446,39 +10453,39 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
 
 [[package]]
 name = "tower"
@@ -10919,9 +10926,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.244.0"
+version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
 dependencies = [
  "leb128fmt",
  "wasmparser",
@@ -10929,12 +10936,12 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.244.0"
+version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
 dependencies = [
  "bitflags 2.11.0",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "semver",
  "serde",
@@ -10942,9 +10949,9 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.244.0"
+version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09390d7b2bd7b938e563e4bff10aa345ef2e27a3bc99135697514ef54495e68f"
+checksum = "5f41517a3716fbb8ccf46daa9c1325f760fcbff5168e75c7392288e410b91ac8"
 dependencies = [
  "anyhow",
  "termcolor",
@@ -10953,9 +10960,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bef52be4fb4c5b47d36f847172e896bc94b35c9c6a6f07117686bd16ed89a7"
+checksum = "54fa9f298901a64ed3eae16b130f0b30c80dbb74a9e7f129a791f4e74649b917"
 dependencies = [
  "addr2line 0.26.0",
  "async-trait",
@@ -10968,7 +10975,7 @@ dependencies = [
  "log",
  "mach2",
  "memfd",
- "object",
+ "object 0.38.1",
  "once_cell",
  "postcard",
  "pulley-interpreter",
@@ -10993,21 +11000,23 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb637d5aa960ac391ca5a4cbf3e45807632e56beceeeb530e14dfa67fdfccc62"
+checksum = "75a3aaaa3a522f443af67a7ed8d4efa20b0c3784e1031980537fbfcb497f70a7"
 dependencies = [
  "anyhow",
+ "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",
  "gimli 0.33.0",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "log",
- "object",
+ "object 0.38.1",
  "postcard",
  "serde",
  "serde_derive",
+ "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
  "wasm-encoder",
@@ -11018,9 +11027,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab6c428c610ae3e7acd25ca2681b4d23672c50d8769240d9dda99b751d4deec"
+checksum = "0454f53d6c91d9a3b30be6d5dbd27e8ff595fddaafe69665df908fc385bbd836"
 dependencies = [
  "base64",
  "directories-next",
@@ -11038,18 +11047,20 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a4a3f055a804a2f3d86e816a9df78a8fa57762212a8506164959224a40cd48"
+checksum = "e671917bb6856ae360cb59d7aaf26f1cfd042c7b924319dd06fd380739fc0b2e"
 dependencies = [
+ "hashbrown 0.16.1",
  "libm",
+ "serde",
 ]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55154a91d22ad51f9551124ce7fb49ddddc6a82c4910813db4c790c97c9ccf32"
+checksum = "f2dfd752e1dcf79eeeadc6f2681e2fb4a9f0b5534d18c5b9b93faccd0de2c80c"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -11060,7 +11071,7 @@ dependencies = [
  "gimli 0.33.0",
  "itertools 0.14.0",
  "log",
- "object",
+ "object 0.38.1",
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
@@ -11074,9 +11085,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05decfad1021ad2efcca5c1be9855acb54b6ee7158ac4467119b30b7481508e3"
+checksum = "d1e9171af643316c11d6ebe52f31f6e2a5d6d1d270de9167a7b7b6f0e3f72982"
 dependencies = [
  "cc",
  "cfg-if",
@@ -11089,9 +11100,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924980c50427885fd4feed2049b88380178e567768aaabf29045b02eb262eaa7"
+checksum = "1fe23134536b9883ffc2afcffae23f7ffbcb1791e2d9fac6d6464a37ea4c8fdd"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -11099,9 +11110,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c57d24e8d1334a0e5a8b600286ffefa1fc4c3e8176b110dff6fbc1f43c4a599b"
+checksum = "9b3112806515fac8495883885eb8dbdde849988ae91fe6beb544c0d7c0f4c9aa"
 dependencies = [
  "cfg-if",
  "libc",
@@ -11111,22 +11122,22 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1a144bd4393593a868ba9df09f34a6a360cb5db6e71815f20d3f649c6e6735"
+checksum = "dafc29c6e538273fda8409335137654751bdf24beab65702b7866b0a85ee108a"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
  "log",
- "object",
+ "object 0.38.1",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a6948b56bb00c62dbd205ea18a4f1ceccbe1e4b8479651fdb0bab2553790f20"
+checksum = "772f2b105b7fdd3dfb2cdf70c297baaeb96fe76a95cdc6fa516f713f04090c73"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11583,6 +11594,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11708,18 +11728,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,9 +1567,7 @@ version = "0.4.2"
 dependencies = [
  "digest 0.11.2",
  "ff",
- "ff-group-tests",
  "group",
- "hex",
  "std-shims 0.1.5",
  "subtle",
  "zeroize",

--- a/common/db/Cargo.toml
+++ b/common/db/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/common/db"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
-rust-version = "1.77"
+rust-version = "1.71"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/common/env/Cargo.toml
+++ b/common/env/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/common/env"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.71"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/common/env/src/lib.rs
+++ b/common/env/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Obtain a variable from the Serai environment/secret store.
 pub fn var(variable: &str) -> Option<String> {

--- a/common/patchable-async-sleep/Cargo.toml
+++ b/common/patchable-async-sleep/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/common/patchable-a
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = ["async", "sleep", "tokio", "smol", "async-std"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.71"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/common/request/Cargo.toml
+++ b/common/request/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/common/request"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = ["http", "https", "async", "request", "ssl"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.81"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/common/std-shims/Cargo.toml
+++ b/common/std-shims/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/common/std-shims"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = ["nostd", "no_std", "alloc", "io"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.71"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/common/task/Cargo.toml
+++ b/common/task/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
 publish = false
-rust-version = "1.75"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/common/zalloc/src/lib.rs
+++ b/common/zalloc/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(all(zalloc_rustc_nightly, feature = "allocator"), feature(allocator_api))]
 
 //! Implementation of a Zeroizing Allocator, enabling zeroizing memory on deallocation.

--- a/coordinator/cosign/Cargo.toml
+++ b/coordinator/cosign/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
 publish = false
-rust-version = "1.91"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/coordinator/cosign/types/Cargo.toml
+++ b/coordinator/cosign/types/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
 publish = false
-rust-version = "1.85"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/coordinator/p2p/Cargo.toml
+++ b/coordinator/p2p/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
 publish = false
-rust-version = "1.91"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/coordinator/p2p/libp2p/Cargo.toml
+++ b/coordinator/p2p/libp2p/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
 publish = false
-rust-version = "1.91"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/coordinator/substrate/Cargo.toml
+++ b/coordinator/substrate/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
 publish = false
-rust-version = "1.91"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/coordinator/substrate/Cargo.toml
+++ b/coordinator/substrate/Cargo.toml
@@ -24,8 +24,6 @@ dkg = { path = "../../crypto/dkg", default-features = false, features = ["std"] 
 
 serai-client-serai = { path = "../../substrate/client/serai", default-features = false }
 
-log = { version = "0.4", default-features = false, features = ["std"] }
-
 futures = { version = "0.3", default-features = false, features = ["std"] }
 
 serai-db = { path = "../../common/db", version = "0.1.1" }

--- a/coordinator/tributary-sdk/Cargo.toml
+++ b/coordinator/tributary-sdk/Cargo.toml
@@ -6,7 +6,7 @@ license = "AGPL-3.0-only"
 repository = "https://github.com/serai-dex/serai/tree/develop/coordinator/tributary-sdk"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.89"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/coordinator/tributary-sdk/tendermint/Cargo.toml
+++ b/coordinator/tributary-sdk/tendermint/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/coordinator/tendermint"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.77"
+rust-version = "1.82"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/coordinator/tributary/Cargo.toml
+++ b/coordinator/tributary/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
 publish = false
-rust-version = "1.91"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crypto/ciphersuite/Cargo.toml
+++ b/crypto/ciphersuite/Cargo.toml
@@ -27,11 +27,6 @@ digest = { version = "0.11", default-features = false }
 ff = { version = "0.13", default-features = false, features = ["bits"] }
 group = { version = "0.13", default-features = false }
 
-[dev-dependencies]
-hex = { version = "0.4", default-features = false, features = ["std"] }
-
-ff-group-tests = { version = "0.13", path = "../ff-group-tests" }
-
 [features]
 alloc = ["zeroize/alloc", "digest/alloc", "ff/alloc"]
 std = [

--- a/crypto/dalek-ff-group/Cargo.toml
+++ b/crypto/dalek-ff-group/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/crypto/dalek-ff-gr
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = ["curve25519", "ed25519", "ristretto", "dalek", "group"]
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.89"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crypto/ed448/Cargo.toml
+++ b/crypto/ed448/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/crypto/ed448"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = ["ed448", "ff", "group"]
 edition = "2021"
-rust-version = "1.86"
+rust-version = "1.89"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crypto/embedwards25519/Cargo.toml
+++ b/crypto/embedwards25519/Cargo.toml
@@ -22,7 +22,7 @@ typenum = { version = "1", default-features = false }
 
 prime-field = { path = "../prime-field", default-features = false }
 short-weierstrass = { path = "../short-weierstrass", default-features = false }
-curve25519-dalek = { version = "4", default-features = false, features = ["legacy_compatibility"] }
+curve25519-dalek = { version = "4", default-features = false, features = ["legacy_compatibility", "zeroize", "group"] }
 
 blake2 = { version = "0.11.0-rc.5", default-features = false }
 ciphersuite = { path = "../ciphersuite", version = "0.4", default-features = false }

--- a/crypto/embedwards25519/Cargo.toml
+++ b/crypto/embedwards25519/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/crypto/embedwards2
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = ["curve25519", "ed25519", "ristretto255", "group"]
 edition = "2021"
-rust-version = "1.86"
+rust-version = "1.89"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crypto/ff-group-tests/Cargo.toml
+++ b/crypto/ff-group-tests/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/crypto/ff-group-te
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = ["ff", "group", "ecc"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.81"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crypto/multiexp/Cargo.toml
+++ b/crypto/multiexp/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/crypto/multiexp"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = ["multiexp", "ff", "group"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.81"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crypto/schnorr/Cargo.toml
+++ b/crypto/schnorr/Cargo.toml
@@ -22,8 +22,8 @@ std-shims = { path = "../../common/std-shims", version = "^0.1.1", default-featu
 rand_core = { version = "0.6", default-features = false }
 
 zeroize = { version = "^1.5", default-features = false, features = ["zeroize_derive"] }
-digest = { version = "0.11", default-features = false, features = ["block-api"] }
 
+digest = { version = "0.11", default-features = false, features = ["block-api"], optional = true }
 transcript = { package = "flexible-transcript", path = "../transcript", version = "^0.3.2", default-features = false, optional = true }
 
 ciphersuite = { path = "../ciphersuite", version = "^0.4.1", default-features = false }
@@ -40,7 +40,7 @@ dalek-ff-group = { path =  "../dalek-ff-group" }
 ciphersuite = { path = "../ciphersuite" }
 
 [features]
-alloc = ["zeroize/alloc", "digest/alloc", "ciphersuite/alloc", "multiexp/alloc", "multiexp/batch"]
-aggregate = ["alloc", "transcript"]
+alloc = ["zeroize/alloc", "digest?/alloc", "ciphersuite/alloc", "multiexp/alloc", "multiexp/batch"]
+aggregate = ["alloc", "digest", "transcript"]
 std = ["alloc", "std-shims/std", "rand_core/std", "zeroize/std", "transcript?/std", "ciphersuite/std", "multiexp/std"]
 default = ["std"]

--- a/crypto/schnorrkel/Cargo.toml
+++ b/crypto/schnorrkel/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/crypto/schnorrkel"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = ["frost", "multisig", "threshold", "schnorrkel"]
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.89"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crypto/secq256k1/Cargo.toml
+++ b/crypto/secq256k1/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/crypto/secq256k1"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = ["secp256k1", "secq256k1", "group"]
 edition = "2021"
-rust-version = "1.86"
+rust-version = "1.89"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crypto/short-weierstrass/Cargo.toml
+++ b/crypto/short-weierstrass/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/crypto/short-weier
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = ["ff", "group", "elliptic-curve", "weierstrass"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.81"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/message-queue/src/main.rs
+++ b/message-queue/src/main.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::std_instead_of_alloc, clippy::std_instead_of_core)]
 
-use core::str::FromStr as _;
 pub(crate) use std::{
   sync::{Arc, RwLock},
   collections::HashMap,
@@ -156,11 +155,9 @@ pub(crate) fn ack_message(from: Service, to: Service, id: u64, sig: SchnorrSigna
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-  env_logger::builder()
-    .filter_level(
-      log::LevelFilter::from_str(&serai_env::var("RUST_LOG").unwrap_or_else(|| "info".to_owned()))
-        .expect("`RUST_LOG` environment variable had an invalid filter"),
-    )
+  // TODO: `env_logger::Env` for `serai-env` and `Builder::from_env`?
+  env_logger::Builder::from_default_env()
+    .parse_filters(&serai_env::var("RUST_LOG").unwrap_or_else(|| "info".to_owned()))
     .init();
   log::info!("Starting message-queue service...");
 

--- a/networks/ethereum/alloy-simple-request-transport/Cargo.toml
+++ b/networks/ethereum/alloy-simple-request-transport/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/networks/ethereum/alloy-simple-request-transport"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.86"
+rust-version = "1.91"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/orchestration/Cargo.toml
+++ b/orchestration/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/orchestration/"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
+publish = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/orchestration/dev/serai/run.sh
+++ b/orchestration/dev/serai/run.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 set -e
 
-${SERAI_NAME:?} # Ensure this is present in the environment
+# Ensure this is present in the environment
+if [ "${SERAI_NAME:?}" = "" ]; then
+  echo "\`SERAI_NAME\` environment variable wasn't set"
+  exit 1
+fi
 serai-node --unsafe-rpc-external --rpc-cors all --chain local --"$SERAI_NAME"

--- a/orchestration/runtime/README.md
+++ b/orchestration/runtime/README.md
@@ -29,8 +29,8 @@ alternative method of production.
 
 ### `bootstrap/`
 
-To completely demonstrate the supply chain and allow full inspection of the
-entire process used to build `serai-runtime`, a bootstrap from a minimal binary
-seed is present in the `bootstrap/` folder. This is again not canonical nor
-endorsed, but it would be if not for the practical issue of it taking several
-hours.
+To be extensively comprehensive to the supply chain and allow near full
+inspection of the entire process used to build `serai-runtime`, a bootstrap
+from a minimal amount of binaries is present in the `bootstrap/` folder. This
+is again not canonical nor endorsed, but it would be if not for the practical
+issue of it taking several hours.

--- a/processor/ethereum/Cargo.toml
+++ b/processor/ethereum/Cargo.toml
@@ -61,7 +61,6 @@ signers = { package = "serai-processor-signers", path = "../signers" }
 ethereum-schnorr = { package = "ethereum-schnorr-contract", path = "../../networks/ethereum/schnorr" }
 ethereum-primitives = { package = "serai-processor-ethereum-primitives", path = "./primitives" }
 ethereum-router = { package = "serai-processor-ethereum-router", path = "./router" }
-ethereum-erc20 = { package = "serai-processor-ethereum-erc20", path = "./erc20" }
 
 bin = { package = "serai-processor-bin", path = "../bin" }
 

--- a/processor/ethereum/deployer/Cargo.toml
+++ b/processor/ethereum/deployer/Cargo.toml
@@ -7,7 +7,6 @@ repository = "https://github.com/serai-dex/serai/tree/develop/processor/ethereum
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
 publish = false
-rust-version = "1.86"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/processor/ethereum/deployer/src/tests.rs
+++ b/processor/ethereum/deployer/src/tests.rs
@@ -18,7 +18,14 @@ async fn test_deployer() {
   const LATEST: &str = "latest";
 
   for network in [CANCUN, LATEST] {
-    let anvil = Anvil::new().arg("--hardfork").arg(network).spawn();
+    let anvil = (if network == LATEST {
+      // If this is the latest network, it's inherently defaulted to when `anvil` is spawned
+      Anvil::new()
+    } else {
+      // Else, we explicitly specify the hardwork
+      Anvil::new().arg("--hardfork").arg(network)
+    })
+    .spawn();
 
     let provider = Arc::new(RootProvider::new(
       ClientBuilder::default().transport(SimpleRequest::new(anvil.endpoint()).unwrap(), true),

--- a/processor/ethereum/erc20/Cargo.toml
+++ b/processor/ethereum/erc20/Cargo.toml
@@ -7,7 +7,6 @@ repository = "https://github.com/serai-dex/serai/tree/develop/processor/ethereum
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
 publish = false
-rust-version = "1.86"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/processor/ethereum/primitives/Cargo.toml
+++ b/processor/ethereum/primitives/Cargo.toml
@@ -7,7 +7,6 @@ repository = "https://github.com/serai-dex/serai/tree/develop/processor/ethereum
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
 publish = false
-rust-version = "1.86"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/processor/ethereum/router/Cargo.toml
+++ b/processor/ethereum/router/Cargo.toml
@@ -7,7 +7,6 @@ repository = "https://github.com/serai-dex/serai/tree/develop/processor/ethereum
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
 publish = false
-rust-version = "1.88"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/processor/ethereum/router/contracts/IRouter.sol
+++ b/processor/ethereum/router/contracts/IRouter.sol
@@ -145,9 +145,9 @@ interface IRouter is IRouterWithoutCollisions {
 
   /// @title A code destination
   /**
-   * @dev If transferring an ERC20 to this destination, it will be transferred to the address the
-   *   code will be deployed to. If transferring ETH, it will be transferred with the deployment of
-   *   the code. `code` is deployed with CREATE (calling its constructor). The entire deployment
+   * @dev If transferring an ERC20 to this destination, an allowance will be created for the address
+   *   the code will be deployed to. If transferring ETH, it will be transferred with the deployment
+   *   of the code. `code` is deployed with CREATE (calling its constructor). The entire deployment
    *   (and associated sandboxing) must consume less than `gasLimit` units of gas or it will revert.
    */
   struct CodeDestination {

--- a/processor/ethereum/router/contracts/Router.sol
+++ b/processor/ethereum/router/contracts/Router.sol
@@ -389,9 +389,9 @@ contract Router is IRouterWithoutCollisions {
       bytes4 selector;
       if (contractDestination) {
         /*
-          If this is an out of DestinationType::Contract, we only grant an approval. We don't
+          If this is an out of `DestinationType::Contract`, we only grant an approval, we don't
           perform a transfer. This allows the contract, or our expectation of the contract as far as
-          our obligation to it, to be borked and for Serai to potentially it accordingly.
+          our obligation to it, to be borked and for Serai to potentially adjust accordingly.
 
           Unfortunately, this isn't a feasible flow for Ether unless we set Ether approvals within
           our contract (for entities to collect later) which is of sufficient complexity to not be

--- a/processor/ethereum/router/contracts/Router.sol
+++ b/processor/ethereum/router/contracts/Router.sol
@@ -36,7 +36,8 @@ contract Router is IRouterWithoutCollisions {
   bytes32 constant ACCOUNT_WITHOUT_CODE_CODEHASH = keccak256("");
 
   /// @dev The address in transient storage used for the reentrancy guard
-  bytes32 constant REENTRANCY_GUARD_SLOT = bytes32(uint256(keccak256("ReentrancyGuard Router")) - 1);
+  bytes32 constant REENTRANCY_GUARD_SLOT =
+    bytes32(uint256(keccak256("ReentrancyGuard Router")) - 1);
 
   /**
    * @dev The amount of gas to use when interacting with ERC20s
@@ -313,9 +314,10 @@ contract Router is IRouterWithoutCollisions {
     if (coin == address(0)) {
       if (amount != msg.value) revert AmountMismatchesMsgValue();
     } else {
-      (bool success, bytes memory res) = address(coin).call(
-        abi.encodeWithSelector(IERC20.transferFrom.selector, msg.sender, address(this), amount)
-      );
+      (bool success, bytes memory res) = address(coin)
+        .call(
+          abi.encodeWithSelector(IERC20.transferFrom.selector, msg.sender, address(this), amount)
+        );
 
       /*
         Require there was nothing returned, which is done by some non-standard tokens, or that the
@@ -370,19 +372,18 @@ contract Router is IRouterWithoutCollisions {
       // This uses assembly to prevent return bombs
       // slither-disable-next-line assembly
       assembly {
-        success :=
-          call(
-            // explicit gas
-            0,
-            to,
-            amount,
-            // calldata
-            0,
-            0,
-            // return data
-            0,
-            0
-          )
+        success := call(
+          // explicit gas
+          0,
+          to,
+          amount,
+          // calldata
+          0,
+          0,
+          // return data
+          0,
+          0
+        )
       }
     } else {
       bytes4 selector;
@@ -476,17 +477,19 @@ contract Router is IRouterWithoutCollisions {
       // slither-disable-next-line divide-before-multiply
       uint256 rlpEncodingLen = 23 + (nonceIsString * bytesNeeded);
 
+      // forgefmt: disable-start
       uint256 rlpEncoding =
-      // The header, which does not include itself in its length, shifted into the first byte
-      ((0xc0 + (rlpEncodingLen - 1)) << 248)
-      // The address header, which is constant
-      | ADDRESS_HEADER
-      // Shift the address from bytes 12 .. 32 to 2 .. 22
-      | (uint256(uint160(address(this))) << 80)
-      // Shift the nonce (one byte) or the nonce's header from byte 31 to byte 22
-      | (((nonceIsNotString * nonce) + (nonceIsString * (0x80 + bytesNeeded))) << 72)
-      // Shift past the unnecessary bytes
-      | (nonce * nonceIsString) << (72 - bitsNeeded);
+        // The header, which does not include itself in its length, shifted into the first byte
+        ((0xc0 + (rlpEncodingLen - 1)) << 248)
+        // The address header, which is constant
+        | ADDRESS_HEADER
+        // Shift the address from bytes 12 .. 32 to 2 .. 22
+        | (uint256(uint160(address(this))) << 80)
+        // Shift the nonce (one byte) or the nonce's header from byte 31 to byte 22
+        | (((nonceIsNotString * nonce) + (nonceIsString * (0x80 + bytesNeeded))) << 72)
+        // Shift past the unnecessary bytes
+        | (nonce * nonceIsString) << (72 - bitsNeeded);
+      // forgefmt: disable-end
 
       // Store this to the scratch space
       bytes memory rlp;

--- a/processor/ethereum/test-primitives/Cargo.toml
+++ b/processor/ethereum/test-primitives/Cargo.toml
@@ -7,7 +7,6 @@ repository = "https://github.com/serai-dex/serai/tree/develop/processor/ethereum
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
 publish = false
-rust-version = "1.86"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/processor/frost-attempt-manager/Cargo.toml
+++ b/processor/frost-attempt-manager/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = ["frost", "multisig", "threshold"]
 edition = "2021"
 publish = false
-rust-version = "1.85"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/processor/key-gen/Cargo.toml
+++ b/processor/key-gen/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
 publish = false
-rust-version = "1.89"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/processor/messages/Cargo.toml
+++ b/processor/messages/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
 publish = false
-rust-version = "1.85"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/processor/primitives/Cargo.toml
+++ b/processor/primitives/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
 publish = false
-rust-version = "1.85"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/processor/primitives/Cargo.toml
+++ b/processor/primitives/Cargo.toml
@@ -24,7 +24,4 @@ serai-primitives = { path = "../../substrate/primitives", default-features = fal
 
 borsh = { version = "1", default-features = false, features = ["std", "derive", "de_strict_order"] }
 
-log = { version = "0.4", default-features = false, features = ["std"] }
-tokio = { version = "1", default-features = false, features = ["macros", "sync", "time"] }
-
 serai-task = { path = "../../common/task", default-features = false }

--- a/processor/scanner/Cargo.toml
+++ b/processor/scanner/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
 publish = false
-rust-version = "1.85"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/processor/scheduler/primitives/Cargo.toml
+++ b/processor/scheduler/primitives/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
 publish = false
-rust-version = "1.85"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/processor/scheduler/smart-contract/Cargo.toml
+++ b/processor/scheduler/smart-contract/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
 publish = false
-rust-version = "1.85"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/processor/scheduler/utxo/primitives/Cargo.toml
+++ b/processor/scheduler/utxo/primitives/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
 publish = false
-rust-version = "1.85"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/processor/scheduler/utxo/standard/Cargo.toml
+++ b/processor/scheduler/utxo/standard/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
 publish = false
-rust-version = "1.85"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/processor/scheduler/utxo/transaction-chaining/Cargo.toml
+++ b/processor/scheduler/utxo/transaction-chaining/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
 publish = false
-rust-version = "1.85"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/processor/signers/Cargo.toml
+++ b/processor/signers/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = []
 edition = "2021"
 publish = false
-rust-version = "1.85"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/processor/signers/src/transaction/mod.rs
+++ b/processor/signers/src/transaction/mod.rs
@@ -215,7 +215,7 @@ impl<D: Db, ST: SignableTransaction, P: TransactionPublisher<TransactionFor<ST>>
 
       // If it's been five minutes since the last publication, republish the transactions for all
       // active signing protocols
-      if Instant::now().duration_since(self.last_publication) > Duration::from_secs(5 * 60) {
+      if Instant::now().duration_since(self.last_publication) >= Duration::from_mins(5) {
         for tx in &self.active_signing_protocols {
           let Some(tx_buf) = SerializedTransactions::get(&self.db, *tx) else { continue };
           let mut tx_buf = tx_buf.as_slice();

--- a/substrate/abi/Cargo.toml
+++ b/substrate/abi/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/substrate/abi"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.91"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/substrate/abi/src/modules/validator_sets.rs
+++ b/substrate/abi/src/modules/validator_sets.rs
@@ -43,8 +43,16 @@ pub enum Slashes {
     /// representing an `EquivocationProof` not with [`SubstrateHeader`] but
     /// `(Header, Digest::new(substrate_header.digest().find(babe)))` which can be of bounded
     /// length even while the digest as a whole remains unbounded (its own sin).
-    #[expect(clippy::as_conversions)]
-    reason: BoundedVec<u8, ConstU32<{ u16::MAX as u32 }>>,
+    reason: BoundedVec<
+      u8,
+      ConstU32<
+        {
+          #[expect(clippy::as_conversions)]
+          const MAX_REASON_LEN: u32 = u16::MAX as u32;
+          MAX_REASON_LEN
+        },
+      >,
+    >,
   },
   /// A [`SlashReport`] from an external network.
   ExternalNetwork {

--- a/substrate/client/Cargo.toml
+++ b/substrate/client/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/substrate/client"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = ["serai"]
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.91"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/substrate/client/bitcoin/Cargo.toml
+++ b/substrate/client/bitcoin/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/substrate/client/b
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = ["serai", "bitcoin"]
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.91"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/substrate/client/ethereum/Cargo.toml
+++ b/substrate/client/ethereum/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/substrate/client/e
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = ["serai", "ethereum"]
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.91"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/substrate/client/monero/Cargo.toml
+++ b/substrate/client/monero/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/substrate/client/m
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = ["serai", "monero"]
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.91"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/substrate/client/serai/Cargo.toml
+++ b/substrate/client/serai/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/substrate/client/s
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = ["serai"]
 edition = "2021"
-rust-version = "1.89"
+rust-version = "1.91"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/substrate/coins/Cargo.toml
+++ b/substrate/coins/Cargo.toml
@@ -6,7 +6,7 @@ license = "AGPL-3.0-only"
 repository = "https://github.com/serai-dex/serai/tree/develop/substrate/coins"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.85"
+publish = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/substrate/core/Cargo.toml
+++ b/substrate/core/Cargo.toml
@@ -6,7 +6,7 @@ license = "AGPL-3.0-only"
 repository = "https://github.com/serai-dex/serai/tree/develop/substrate/core"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.85"
+publish = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/substrate/core/README.md
+++ b/substrate/core/README.md
@@ -162,7 +162,7 @@ The following POSIX shell script is suggested to detect inadvertent usage of
 the `pallet::hooks` attribute:
 
 ```sh
-find ./substrate -iname "*.rs" | while read -r file; do
+find ./substrate -name "*.rs" | while IFS="\n" read -r file; do
   hooks=$(grep -F "pallet::hooks" "$file" | grep -v -F "serai-core-pallet: allow" | wc -l)
   if [ $hooks -ne 0 ]; then
     echo "\`pallet::hooks\` (without \`serai-core-pallet: allow\`) found in $file"

--- a/substrate/dex/Cargo.toml
+++ b/substrate/dex/Cargo.toml
@@ -6,7 +6,7 @@ license = "AGPL-3.0-only"
 repository = "https://github.com/serai-dex/serai/tree/develop/substrate/dex"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.85"
+publish = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/substrate/dex/src/benchmarking.rs
+++ b/substrate/dex/src/benchmarking.rs
@@ -104,6 +104,14 @@ mod benchmarks {
 
   #[benchmark]
   fn swap(r: Linear<1, 2>) {
+    // TODO: Erasing of the _genesis state_ between trials seems like a bug upstream
+    if r == 2 {
+      frame_support::traits::BuildGenesisConfig::build(&crate::GenesisConfig {
+        fees: ExternalCoin::all().map(|coin| (coin, 1)).collect(),
+        _config: core::marker::PhantomData::<T>,
+      });
+    }
+
     let route_len = r;
     serai_core_pallet::Pallet::<T>::start_transaction(0);
     serai_coins_pallet::Pallet::<T, CoinsInstance>::mint(
@@ -154,6 +162,14 @@ mod benchmarks {
 
   #[benchmark]
   fn swap_for(r: Linear<1, 2>) {
+    // TODO: Erasing of the _genesis state_ between trials seems like a bug upstream
+    if r == 2 {
+      frame_support::traits::BuildGenesisConfig::build(&crate::GenesisConfig {
+        fees: ExternalCoin::all().map(|coin| (coin, 1)).collect(),
+        _config: core::marker::PhantomData::<T>,
+      });
+    }
+
     let route_len = r;
     serai_core_pallet::Pallet::<T>::start_transaction(0);
     serai_coins_pallet::Pallet::<T, CoinsInstance>::mint(

--- a/substrate/dex/src/lib.rs
+++ b/substrate/dex/src/lib.rs
@@ -150,7 +150,7 @@ mod pallet {
       }
       assert_eq!(
         set,
-        ExternalCoin::all().collect::<Vec<_>>().len(),
+        ExternalCoin::all().count(),
         "fee parameter for liquidity pool on genesis omitted"
       );
     }

--- a/substrate/economic-security/Cargo.toml
+++ b/substrate/economic-security/Cargo.toml
@@ -6,7 +6,7 @@ license = "AGPL-3.0-only"
 repository = "https://github.com/serai-dex/serai/tree/develop/substrate/economic-security"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.85"
+publish = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/substrate/emissions/Cargo.toml
+++ b/substrate/emissions/Cargo.toml
@@ -6,7 +6,7 @@ license = "AGPL-3.0-only"
 repository = "https://github.com/serai-dex/serai/tree/develop/substrate/emissions"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.85"
+publish = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/substrate/genesis-liquidity/Cargo.toml
+++ b/substrate/genesis-liquidity/Cargo.toml
@@ -6,7 +6,7 @@ license = "AGPL-3.0-only"
 repository = "https://github.com/serai-dex/serai/tree/develop/substrate/genesis-liquidity"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.85"
+publish = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/substrate/in-instructions/Cargo.toml
+++ b/substrate/in-instructions/Cargo.toml
@@ -7,7 +7,6 @@ repository = "https://github.com/serai-dex/serai/tree/develop/substrate/in-instr
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
 publish = false
-rust-version = "1.85"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/substrate/median/Cargo.toml
+++ b/substrate/median/Cargo.toml
@@ -6,7 +6,7 @@ license = "AGPL-3.0-only"
 repository = "https://github.com/serai-dex/serai/tree/develop/substrate/median"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/substrate/primitives/Cargo.toml
+++ b/substrate/primitives/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/serai-dex/serai/tree/develop/substrate/primitives"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.91"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/substrate/primitives/src/constants.rs
+++ b/substrate/primitives/src/constants.rs
@@ -30,6 +30,8 @@ pub const SESSION_LENGTH_IN_SLOTS: u64 = SESSION_LENGTH.as_secs() / TARGET_BLOCK
 pub const RETIREMENT_LOCK_IN_DURATION_IN_SLOTS: u64 =
   WEEK.checked_mul(4).unwrap().as_secs() / TARGET_BLOCK_TIME.as_secs();
 
+#[allow(unknown_lints)] // `clippy::duration_suboptimal_units` was added with 1.95
+#[expect(clippy::duration_suboptimal_units)]
 #[test]
 fn constants() {
   assert_eq!(MINUTE, Duration::from_secs(60));

--- a/substrate/primitives/src/validator_sets/slashes.rs
+++ b/substrate/primitives/src/validator_sets/slashes.rs
@@ -67,8 +67,8 @@ impl Slash {
         // A Serai validator is allowed to be offline for an average of one day every two weeks
         // with no additional penalty. They'll solely not earn rewards for the time they were
         // offline.
-        const GRACE_WINDOW: Duration = Duration::from_secs(2 * 7 * 24 * 60 * 60);
-        const GRACE: Duration = Duration::from_secs(24 * 60 * 60);
+        const GRACE_WINDOW: Duration = crate::constants::WEEK.checked_mul(2).unwrap();
+        const GRACE: Duration = crate::constants::DAY;
 
         // `GRACE / GRACE_WINDOW` is the fraction of the time a validator is allowed to be offline
         // This means we want `SESSION_LENGTH * (GRACE / GRACE_WINDOW)`, but with the parentheses

--- a/substrate/runtime/Cargo.toml
+++ b/substrate/runtime/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/serai-dex/serai/tree/develop/substrate/runtime"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
 build = "build/main.rs"
+publish = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/substrate/signals/Cargo.toml
+++ b/substrate/signals/Cargo.toml
@@ -6,7 +6,7 @@ license = "AGPL-3.0-only"
 repository = "https://github.com/serai-dex/serai/tree/develop/substrate/signals"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.85"
+publish = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/substrate/validator-sets/Cargo.toml
+++ b/substrate/validator-sets/Cargo.toml
@@ -6,7 +6,7 @@ license = "AGPL-3.0-only"
 repository = "https://github.com/serai-dex/serai/tree/develop/substrate/validator-sets"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.85"
+publish = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tests/reproducible-runtime/src/lib.rs
+++ b/tests/reproducible-runtime/src/lib.rs
@@ -56,6 +56,7 @@ pub fn reproducibly_builds() {
       let mut command = Command::new("docker");
       command
         .current_dir(&path)
+        .arg("buildx")
         .arg("build")
         .arg("--no-cache")
         .arg(format!("--file={}", containerfile.display()))


### PR DESCRIPTION
It definitely is time to re-enable these. Some likely will fail out of the box, such as due to bit rot, due to `machete` being having a couple outstanding items, and due to MSRV declarations not having been maintained for months.