### PR TITLE
Extend runtime RPC

### DIFF
--- a/substrate/client/serai/src/coins.rs
+++ b/substrate/client/serai/src/coins.rs
@@ -1,6 +1,8 @@
 pub use serai_abi::coins::Event;
 
-use crate::Events;
+use serai_abi::primitives::{address::SeraiAddress, balance::Amount, coin::Coin};
+
+use crate::{Events, RpcError, State, rpc_coin};
 
 /// An `Events` scoped to the coins module.
 #[derive(Clone)]
@@ -34,5 +36,26 @@ impl Coins {
   /// The `BurnWithInstruction` events from the coins module.
   pub fn burn_with_instruction_events(&self) -> impl Iterator<Item = &Event> {
     self.events().filter(|event| matches!(event, Event::BurnWithInstruction { .. }))
+  }
+}
+
+impl State<'_> {
+  /// Return balance of a given account for coin.
+  pub async fn balance(&self, of: SeraiAddress, coin: Coin) -> Result<Amount, RpcError> {
+    Ok(Amount(
+      self
+        .call::<u64>(
+          "coins/balance",
+          &format!(r#", "address": "{of}", "coin": {} "#, rpc_coin(coin)),
+        )
+        .await?,
+    ))
+  }
+
+  /// Return supply of a given coin.
+  pub async fn supply(&self, coin: Coin) -> Result<Amount, RpcError> {
+    Ok(Amount(
+      self.call::<u64>("coins/supply", &format!(r#", "coin": {} "#, rpc_coin(coin))).await?,
+    ))
   }
 }

--- a/substrate/client/serai/src/dex.rs
+++ b/substrate/client/serai/src/dex.rs
@@ -1,19 +1,20 @@
-use borsh::BorshDeserialize as _;
-
-use serai_abi::primitives::{coin::ExternalCoin, dex::Reserves};
+use serai_abi::primitives::{balance::Amount, coin::ExternalCoin, dex::Reserves};
 
 use crate::{RpcError, State, rpc_coin};
 
 impl State<'_> {
   /// Returns reserves for a given pool.
   pub async fn pool_reserves(&self, coin: ExternalCoin) -> Result<Reserves, RpcError> {
-    let result = self
-      .call::<String>("dex/pool-reserves", &format!(r#", "coin": {} "#, rpc_coin(coin)))
+    #[derive(Default, core_json_derive::JsonDeserialize)]
+    struct ReservesJson {
+      sri: u64,
+      external_coin: u64,
+    }
+
+    let reserves = self
+      .call::<ReservesJson>("dex/pool-reserves", &format!(r#", "coin": {} "#, rpc_coin(coin)))
       .await?;
-    let bytes = hex::decode(result)
-      .map_err(|_| RpcError::ErrorInResponse("node sent invalid hex string".to_owned()))?;
-    let reserves = Reserves::try_from_reader(&mut bytes.as_slice())
-      .map_err(|_| RpcError::ErrorInResponse("node sent invalid reserves response".to_owned()))?;
-    Ok(reserves)
+
+    Ok(Reserves { sri: Amount(reserves.sri), external_coin: Amount(reserves.external_coin) })
   }
 }

--- a/substrate/client/serai/src/dex.rs
+++ b/substrate/client/serai/src/dex.rs
@@ -1,0 +1,19 @@
+use borsh::BorshDeserialize as _;
+
+use serai_abi::primitives::{coin::ExternalCoin, dex::Reserves};
+
+use crate::{RpcError, State, rpc_coin};
+
+impl State<'_> {
+  /// Returns reserves for a given pool.
+  pub async fn pool_reserves(&self, coin: ExternalCoin) -> Result<Reserves, RpcError> {
+    let result = self
+      .call::<String>("dex/pool-reserves", &format!(r#", "coin": {} "#, rpc_coin(coin)))
+      .await?;
+    let bytes = hex::decode(result)
+      .map_err(|_| RpcError::ErrorInResponse("node sent invalid hex string".to_owned()))?;
+    let reserves = Reserves::try_from_reader(&mut bytes.as_slice())
+      .map_err(|_| RpcError::ErrorInResponse("node sent invalid reserves response".to_owned()))?;
+    Ok(reserves)
+  }
+}

--- a/substrate/client/serai/src/genesis_liquidity.rs
+++ b/substrate/client/serai/src/genesis_liquidity.rs
@@ -1,0 +1,35 @@
+use serai_abi::primitives::{balance::Amount, address::SeraiAddress, coin::ExternalCoin};
+
+use crate::{RpcError, State, rpc_coin};
+
+impl State<'_> {
+  /// Returns genesis liquidity balance of a given account for coin.
+  pub async fn genesis_liquidity_balance(
+    &self,
+    of: SeraiAddress,
+    coin: ExternalCoin,
+  ) -> Result<Amount, RpcError> {
+    Ok(Amount(
+      self
+        .call::<u64>(
+          "genesis-liquidity/balance",
+          &format!(r#", "address": "{of}", "coin": {} "#, rpc_coin(coin)),
+        )
+        .await?,
+    ))
+  }
+
+  /// Returns genesis liquidly supply of a given coin.
+  pub async fn genesis_liquidity_supply(&self, coin: ExternalCoin) -> Result<Amount, RpcError> {
+    Ok(Amount(
+      self
+        .call::<u64>("genesis-liquidity/supply", &format!(r#", "coin": {} "#, rpc_coin(coin)))
+        .await?,
+    ))
+  }
+
+  /// Returns `true` if the genesis period is completed, `false` otherwise.
+  pub async fn genesis_completed(&self) -> Result<bool, RpcError> {
+    self.call::<bool>("genesis-liquidity/completed", "").await
+  }
+}

--- a/substrate/client/serai/src/lib.rs
+++ b/substrate/client/serai/src/lib.rs
@@ -36,13 +36,13 @@ pub use validator_sets::ValidatorSets;
 mod in_instructions;
 pub use in_instructions::InInstructions;
 
-pub(crate) fn rpc_coin(network: impl Into<Coin>) -> &'static str {
-  match network.into() {
+pub(crate) fn rpc_coin(coin: impl Into<Coin>) -> &'static str {
+  match coin.into() {
     Coin::Serai => r#""SRI""#,
-    Coin::External(ExternalCoin::Bitcoin) => r#""BTC""#,
-    Coin::External(ExternalCoin::Ether) => r#""ETH""#,
-    Coin::External(ExternalCoin::Dai) => r#""DAI""#,
-    Coin::External(ExternalCoin::Monero) => r#""XMR""#,
+    Coin::External(ExternalCoin::Bitcoin) => r#""sriBTC""#,
+    Coin::External(ExternalCoin::Ether) => r#""sriETH""#,
+    Coin::External(ExternalCoin::Dai) => r#""sriDAI""#,
+    Coin::External(ExternalCoin::Monero) => r#""sriXMR""#,
   }
 }
 

--- a/substrate/client/serai/src/lib.rs
+++ b/substrate/client/serai/src/lib.rs
@@ -18,6 +18,7 @@ use abi::{
     BlockHash,
     network_id::ExternalNetworkId,
     coin::{Coin, ExternalCoin},
+    address::SeraiAddress,
   },
   Transaction, Block, Event,
 };
@@ -278,5 +279,10 @@ impl State<'_> {
     params: &str,
   ) -> Result<ResponseValue, RpcError> {
     self.serai.call(method, &format!(r#"{{ "block": "{}" {params} }}"#, self.block)).await
+  }
+
+  /// Returns the next nonce to be used for this account.
+  pub async fn account_nonce(&self, of: &SeraiAddress) -> Result<u32, RpcError> {
+    self.call::<u32>("system/next-nonce", &format!(r#", "address": "{of}" "#)).await
   }
 }

--- a/substrate/client/serai/src/lib.rs
+++ b/substrate/client/serai/src/lib.rs
@@ -14,18 +14,36 @@ use simple_request::{hyper, TokioClient};
 use borsh::BorshDeserialize as _;
 pub use serai_abi as abi;
 use abi::{
-  primitives::{BlockHash, network_id::ExternalNetworkId},
+  primitives::{
+    BlockHash,
+    network_id::ExternalNetworkId,
+    coin::{Coin, ExternalCoin},
+  },
   Transaction, Block, Event,
 };
 
 mod coins;
 pub use coins::Coins;
 
+mod dex;
+mod liquidity_tokens;
+mod genesis_liquidity;
+
 mod validator_sets;
 pub use validator_sets::ValidatorSets;
 
 mod in_instructions;
 pub use in_instructions::InInstructions;
+
+pub(crate) fn rpc_coin(network: impl Into<Coin>) -> &'static str {
+  match network.into() {
+    Coin::Serai => r#""SRI""#,
+    Coin::External(ExternalCoin::Bitcoin) => r#""BTC""#,
+    Coin::External(ExternalCoin::Ether) => r#""ETH""#,
+    Coin::External(ExternalCoin::Dai) => r#""DAI""#,
+    Coin::External(ExternalCoin::Monero) => r#""XMR""#,
+  }
+}
 
 /// An error from the RPC.
 #[derive(Debug, Error)]

--- a/substrate/client/serai/src/lib.rs
+++ b/substrate/client/serai/src/lib.rs
@@ -283,6 +283,6 @@ impl State<'_> {
 
   /// Returns the next nonce to be used for this account.
   pub async fn account_nonce(&self, of: &SeraiAddress) -> Result<u32, RpcError> {
-    self.call::<u32>("system/next-nonce", &format!(r#", "address": "{of}" "#)).await
+    self.call::<u32>("core/next-nonce", &format!(r#", "address": "{of}" "#)).await
   }
 }

--- a/substrate/client/serai/src/liquidity_tokens.rs
+++ b/substrate/client/serai/src/liquidity_tokens.rs
@@ -1,0 +1,30 @@
+use serai_abi::primitives::{balance::Amount, address::SeraiAddress, coin::ExternalCoin};
+
+use crate::{RpcError, State, rpc_coin};
+
+impl State<'_> {
+  /// Return liquidity balance of a given account for coin.
+  pub async fn liquidity_balance(
+    &self,
+    of: SeraiAddress,
+    coin: ExternalCoin,
+  ) -> Result<Amount, RpcError> {
+    Ok(Amount(
+      self
+        .call::<u64>(
+          "liquidity-tokens/balance",
+          &format!(r#", "address": "{of}", "coin": {} "#, rpc_coin(coin)),
+        )
+        .await?,
+    ))
+  }
+
+  /// Return liquidity supply of a given coin.
+  pub async fn liquidity_supply(&self, coin: ExternalCoin) -> Result<Amount, RpcError> {
+    Ok(Amount(
+      self
+        .call::<u64>("liquidity-tokens/supply", &format!(r#", "coin": {} "#, rpc_coin(coin)))
+        .await?,
+    ))
+  }
+}

--- a/substrate/genesis-liquidity/src/lib.rs
+++ b/substrate/genesis-liquidity/src/lib.rs
@@ -271,6 +271,11 @@ mod pallet {
 
       Ok(())
     }
+
+    /// Returns `true` if the genesis period is completed or `false` otherwise.
+    pub fn completed() -> bool {
+      Oraclized::<T>::get().is_some()
+    }
   }
 
   #[pallet::call]

--- a/substrate/node/src/rpc/coins.rs
+++ b/substrate/node/src/rpc/coins.rs
@@ -1,0 +1,41 @@
+use super::*;
+
+pub(crate) fn module(
+  client: Arc<FullClient>,
+) -> Result<RpcModule<impl 'static + Send + Sync>, Box<dyn std::error::Error + Send + Sync>> {
+  let mut module = RpcModule::new(client);
+
+  module.register_method("coins/balance", |params, client, _ext| -> Result<_, Error> {
+    let Some(block_hash) = block_hash(client, &params)? else { Err(Error::InvalidStateReference)? };
+
+    #[derive(sp_core::serde::Deserialize)]
+    #[serde(crate = "sp_core::serde")]
+    struct Address {
+      address: String,
+    }
+    let Ok(address) = params.parse::<Address>() else {
+      Err(Error::InvalidRequest(r#"missing `string` "address" field"#))?
+    };
+    let Ok(address) = SeraiAddress::from_str(&address.address) else {
+      Err(Error::InvalidRequest(r#"invalid serai address"#))?
+    };
+
+    let coin = coin(&params)?;
+    let Ok(amount) = client.runtime_api().balance(block_hash, address, coin) else {
+      Err(Error::Internal("couldn't fetch balance for the address"))?
+    };
+    Ok(amount.0)
+  })?;
+
+  module.register_method("coins/supply", |params, client, _ext| -> Result<_, Error> {
+    let Some(block_hash) = block_hash(client, &params)? else { Err(Error::InvalidStateReference)? };
+
+    let coin = coin(&params)?;
+    let Ok(amount) = client.runtime_api().supply(block_hash, coin) else {
+      Err(Error::Internal("couldn't fetch the supply for the coin"))?
+    };
+    Ok(amount.0)
+  })?;
+
+  Ok(module)
+}

--- a/substrate/node/src/rpc/core.rs
+++ b/substrate/node/src/rpc/core.rs
@@ -5,7 +5,7 @@ pub(crate) fn module(
 ) -> Result<RpcModule<impl 'static + Send + Sync>, Box<dyn std::error::Error + Send + Sync>> {
   let mut module = RpcModule::new(client);
 
-  module.register_method("system/next-nonce", |params, client, _ext| -> Result<_, Error> {
+  module.register_method("core/next-nonce", |params, client, _ext| -> Result<_, Error> {
     let Some(block_hash) = block_hash(client, &params)? else { Err(Error::InvalidStateReference)? };
 
     #[derive(sp_core::serde::Deserialize)]

--- a/substrate/node/src/rpc/dex.rs
+++ b/substrate/node/src/rpc/dex.rs
@@ -1,0 +1,22 @@
+use super::*;
+
+pub(crate) fn module(
+  client: Arc<FullClient>,
+) -> Result<RpcModule<impl 'static + Send + Sync>, Box<dyn std::error::Error + Send + Sync>> {
+  let mut module = RpcModule::new(client);
+
+  module.register_method("dex/pool-reserves", |params, client, _ext| -> Result<_, Error> {
+    let Some(block_hash) = block_hash(client, &params)? else { Err(Error::InvalidStateReference)? };
+
+    let coin = coin(&params)?;
+    let external_coin: ExternalCoin =
+      coin.try_into().map_err(|()| Error::InvalidRequest("coin is not external coin"))?;
+
+    let Ok(reserves) = client.runtime_api().pool_reserves(block_hash, external_coin) else {
+      Err(Error::Internal("couldn't fetch the reserves for the coin"))?
+    };
+    Ok(hex::encode(borsh::to_vec(&reserves).unwrap()))
+  })?;
+
+  Ok(module)
+}

--- a/substrate/node/src/rpc/dex.rs
+++ b/substrate/node/src/rpc/dex.rs
@@ -12,10 +12,24 @@ pub(crate) fn module(
     let external_coin: ExternalCoin =
       coin.try_into().map_err(|()| Error::InvalidRequest("coin is not external coin"))?;
 
-    let Ok(reserves) = client.runtime_api().pool_reserves(block_hash, external_coin) else {
-      Err(Error::Internal("couldn't fetch the reserves for the coin"))?
+    let address = serai_abi::dex::address(external_coin);
+    let Ok(sri_balance) = client.runtime_api().balance(block_hash, address, Coin::Serai) else {
+      Err(Error::Internal("couldn't fetch the sri balance of the pool"))?
     };
-    Ok(hex::encode(borsh::to_vec(&reserves).unwrap()))
+    let Ok(external_coin_balance) =
+      client.runtime_api().balance(block_hash, address, external_coin.into())
+    else {
+      Err(Error::Internal("couldn't fetch the external coin balance of the pool"))?
+    };
+
+    #[derive(Clone, sp_core::serde::Serialize)]
+    #[serde(crate = "sp_core::serde")]
+    struct Reserves {
+      sri: u64,
+      external_coin: u64,
+    }
+
+    Ok(Reserves { sri: sri_balance.0, external_coin: external_coin_balance.0 })
   })?;
 
   Ok(module)

--- a/substrate/node/src/rpc/genesis_liquidity.rs
+++ b/substrate/node/src/rpc/genesis_liquidity.rs
@@ -1,0 +1,76 @@
+use serai_abi::primitives::coin::ExternalCoin;
+
+use super::*;
+
+pub(crate) fn module(
+  client: Arc<FullClient>,
+) -> Result<RpcModule<impl 'static + Send + Sync>, Box<dyn std::error::Error + Send + Sync>> {
+  let mut module = RpcModule::new(client);
+
+  module.register_method(
+    "genesis-liquidity/balance",
+    |params, client, _ext| -> Result<_, Error> {
+      let Some(block_hash) = block_hash(client, &params)? else {
+        Err(Error::InvalidStateReference)?
+      };
+
+      #[derive(sp_core::serde::Deserialize)]
+      #[serde(crate = "sp_core::serde")]
+      struct Address {
+        address: String,
+      }
+      let Ok(address) = params.parse::<Address>() else {
+        Err(Error::InvalidRequest(r#"missing `string` "address" field"#))?
+      };
+      let Ok(address) = SeraiAddress::from_str(&address.address) else {
+        Err(Error::InvalidRequest(r#"invalid serai address"#))?
+      };
+
+      let coin = coin(&params)?;
+      let external_coin: ExternalCoin =
+        coin.try_into().map_err(|()| Error::InvalidRequest("coin is not external coin"))?;
+
+      let Ok(amount) =
+        client.runtime_api().genesis_liquidity_balance(block_hash, address, external_coin)
+      else {
+        Err(Error::Internal("couldn't fetch genesis liquidity balance for the address"))?
+      };
+      Ok(amount.0)
+    },
+  )?;
+
+  module.register_method(
+    "genesis-liquidity/supply",
+    |params, client, _ext| -> Result<_, Error> {
+      let Some(block_hash) = block_hash(client, &params)? else {
+        Err(Error::InvalidStateReference)?
+      };
+
+      let coin = coin(&params)?;
+      let external_coin: ExternalCoin =
+        coin.try_into().map_err(|()| Error::InvalidRequest("coin is not external coin"))?;
+
+      let Ok(amount) = client.runtime_api().genesis_liquidity_supply(block_hash, external_coin)
+      else {
+        Err(Error::Internal("couldn't fetch genesis liquidity supply for the coin"))?
+      };
+      Ok(amount.0)
+    },
+  )?;
+
+  module.register_method(
+    "genesis-liquidity/completed",
+    |params, client, _ext| -> Result<_, Error> {
+      let Some(block_hash) = block_hash(client, &params)? else {
+        Err(Error::InvalidStateReference)?
+      };
+
+      let Ok(completed) = client.runtime_api().genesis_completed(block_hash) else {
+        Err(Error::Internal("couldn't fetch genesis period status"))?
+      };
+      Ok(completed)
+    },
+  )?;
+
+  Ok(module)
+}

--- a/substrate/node/src/rpc/liquidity_tokens.rs
+++ b/substrate/node/src/rpc/liquidity_tokens.rs
@@ -1,0 +1,60 @@
+use serai_abi::primitives::coin::ExternalCoin;
+
+use super::*;
+
+pub(crate) fn module(
+  client: Arc<FullClient>,
+) -> Result<RpcModule<impl 'static + Send + Sync>, Box<dyn std::error::Error + Send + Sync>> {
+  let mut module = RpcModule::new(client);
+
+  module.register_method(
+    "liquidity-tokens/balance",
+    |params, client, _ext| -> Result<_, Error> {
+      let Some(block_hash) = block_hash(client, &params)? else {
+        Err(Error::InvalidStateReference)?
+      };
+
+      #[derive(sp_core::serde::Deserialize)]
+      #[serde(crate = "sp_core::serde")]
+      struct Address {
+        address: String,
+      }
+      let Ok(address) = params.parse::<Address>() else {
+        Err(Error::InvalidRequest(r#"missing `string` "address" field"#))?
+      };
+      let Ok(address) = SeraiAddress::from_str(&address.address) else {
+        Err(Error::InvalidRequest(r#"invalid serai address"#))?
+      };
+
+      let coin = coin(&params)?;
+      let external_coin: ExternalCoin =
+        coin.try_into().map_err(|()| Error::InvalidRequest("coin is not external coin"))?;
+
+      let Ok(amount) = client.runtime_api().liquidity_balance(block_hash, address, external_coin)
+      else {
+        Err(Error::Internal("couldn't fetch liquidity balance for the address"))?
+      };
+      Ok(amount.0)
+    },
+  )?;
+
+  module.register_method(
+    "liquidity-tokens/supply",
+    |params, client, _ext| -> Result<_, Error> {
+      let Some(block_hash) = block_hash(client, &params)? else {
+        Err(Error::InvalidStateReference)?
+      };
+
+      let coin = coin(&params)?;
+      let external_coin: ExternalCoin =
+        coin.try_into().map_err(|()| Error::InvalidRequest("coin is not external coin"))?;
+
+      let Ok(amount) = client.runtime_api().liquidity_supply(block_hash, external_coin) else {
+        Err(Error::Internal("couldn't fetch liquidity supply for the coin"))?
+      };
+      Ok(amount.0)
+    },
+  )?;
+
+  Ok(module)
+}

--- a/substrate/node/src/rpc/mod.rs
+++ b/substrate/node/src/rpc/mod.rs
@@ -8,7 +8,7 @@ use sp_consensus::BlockStatus;
 use sp_api::ProvideRuntimeApi as _;
 
 use serai_abi::{
-  primitives::{address::*, network_id::*, validator_sets::*},
+  primitives::{address::*, network_id::*, validator_sets::*, coin::*},
   Transaction, SubstrateBlock as Block,
 };
 use serai_runtime::SeraiApi as _;
@@ -22,8 +22,12 @@ use sc_network::config::MultiaddrWithPeerId;
 mod utils;
 use utils::*;
 
+mod dex;
+mod coins;
 mod blockchain;
 mod validator_sets;
+mod liquidity_tokens;
+mod genesis_liquidity;
 mod p2p_validators;
 
 use crate::FullClient;
@@ -43,6 +47,10 @@ pub(crate) fn create_full<P: 'static + TransactionPool<Block = Block>>(
   let mut root = RpcModule::new(());
   root.merge(blockchain::module(client.clone(), pool)?)?;
   root.merge(validator_sets::module(client.clone())?)?;
+  root.merge(coins::module(client.clone())?)?;
+  root.merge(liquidity_tokens::module(client.clone())?)?;
+  root.merge(genesis_liquidity::module(client.clone())?)?;
+  root.merge(dex::module(client.clone())?)?;
   if let Some(authority_discovery) = authority_discovery {
     root.merge(p2p_validators::module(&bootnodes, client, authority_discovery)?)?;
   }

--- a/substrate/node/src/rpc/mod.rs
+++ b/substrate/node/src/rpc/mod.rs
@@ -23,6 +23,7 @@ mod utils;
 use utils::*;
 
 mod dex;
+mod system;
 mod coins;
 mod blockchain;
 mod validator_sets;
@@ -51,6 +52,7 @@ pub(crate) fn create_full<P: 'static + TransactionPool<Block = Block>>(
   root.merge(liquidity_tokens::module(client.clone())?)?;
   root.merge(genesis_liquidity::module(client.clone())?)?;
   root.merge(dex::module(client.clone())?)?;
+  root.merge(system::module(client.clone())?)?;
   if let Some(authority_discovery) = authority_discovery {
     root.merge(p2p_validators::module(&bootnodes, client, authority_discovery)?)?;
   }

--- a/substrate/node/src/rpc/mod.rs
+++ b/substrate/node/src/rpc/mod.rs
@@ -1,4 +1,4 @@
-use core::str::FromStr as _;
+use ::core::str::FromStr as _;
 use std::{sync::Arc, collections::HashSet};
 
 use rand_core::{RngCore as _, OsRng};
@@ -23,8 +23,8 @@ mod utils;
 use utils::*;
 
 mod dex;
-mod system;
 mod coins;
+mod core;
 mod blockchain;
 mod validator_sets;
 mod liquidity_tokens;
@@ -52,7 +52,7 @@ pub(crate) fn create_full<P: 'static + TransactionPool<Block = Block>>(
   root.merge(liquidity_tokens::module(client.clone())?)?;
   root.merge(genesis_liquidity::module(client.clone())?)?;
   root.merge(dex::module(client.clone())?)?;
-  root.merge(system::module(client.clone())?)?;
+  root.merge(core::module(client.clone())?)?;
   if let Some(authority_discovery) = authority_discovery {
     root.merge(p2p_validators::module(&bootnodes, client, authority_discovery)?)?;
   }

--- a/substrate/node/src/rpc/p2p_validators.rs
+++ b/substrate/node/src/rpc/p2p_validators.rs
@@ -4,7 +4,7 @@ pub(crate) fn module(
   bootnodes: &[MultiaddrWithPeerId],
   client: Arc<FullClient>,
   authority_discovery: sc_authority_discovery::Service,
-) -> Result<RpcModule<impl 'static + Send + Sync>, Box<dyn core::error::Error + Send + Sync>> {
+) -> Result<RpcModule<impl 'static + Send + Sync>, Box<dyn std::error::Error + Send + Sync>> {
   let bootnodes = bootnodes.iter().map(ToString::to_string).collect::<Vec<_>>();
   let mut module =
     RpcModule::new((bootnodes, client, tokio::sync::RwLock::new(authority_discovery)));

--- a/substrate/node/src/rpc/system.rs
+++ b/substrate/node/src/rpc/system.rs
@@ -1,0 +1,30 @@
+use super::*;
+
+pub(crate) fn module(
+  client: Arc<FullClient>,
+) -> Result<RpcModule<impl 'static + Send + Sync>, Box<dyn std::error::Error + Send + Sync>> {
+  let mut module = RpcModule::new(client);
+
+  module.register_method("system/next-nonce", |params, client, _ext| -> Result<_, Error> {
+    let Some(block_hash) = block_hash(client, &params)? else { Err(Error::InvalidStateReference)? };
+
+    #[derive(sp_core::serde::Deserialize)]
+    #[serde(crate = "sp_core::serde")]
+    struct Address {
+      address: String,
+    }
+    let Ok(address) = params.parse::<Address>() else {
+      Err(Error::InvalidRequest(r#"missing `string` "address" field"#))?
+    };
+    let Ok(address) = SeraiAddress::from_str(&address.address) else {
+      Err(Error::InvalidRequest(r#"invalid serai address"#))?
+    };
+
+    let Ok(nonce) = client.runtime_api().account_nonce(block_hash, address) else {
+      Err(Error::Internal("couldn't fetch the nonce for the address"))?
+    };
+    Ok(nonce)
+  })?;
+
+  Ok(module)
+}

--- a/substrate/node/src/rpc/utils.rs
+++ b/substrate/node/src/rpc/utils.rs
@@ -88,12 +88,12 @@ pub(super) fn network(params: &Params) -> Result<NetworkId, Error> {
 }
 
 pub(super) fn coin_from_str(coin: impl AsRef<str>) -> Result<Coin, Error> {
-  Ok(match coin.as_ref().to_uppercase().as_str() {
+  Ok(match coin.as_ref() {
     "SRI" => Coin::Serai,
-    "BTC" => Coin::External(ExternalCoin::Bitcoin),
-    "ETH" => Coin::External(ExternalCoin::Ether),
-    "DAI" => Coin::External(ExternalCoin::Dai),
-    "XMR" => Coin::External(ExternalCoin::Monero),
+    "sriBTC" => Coin::External(ExternalCoin::Bitcoin),
+    "sriETH" => Coin::External(ExternalCoin::Ether),
+    "sriDAI" => Coin::External(ExternalCoin::Dai),
+    "sriXMR" => Coin::External(ExternalCoin::Monero),
     _ => Err(Error::InvalidRequest("unrecognized external coin requested"))?,
   })
 }

--- a/substrate/node/src/rpc/utils.rs
+++ b/substrate/node/src/rpc/utils.rs
@@ -87,6 +87,31 @@ pub(super) fn network(params: &Params) -> Result<NetworkId, Error> {
   network_from_str(network.network)
 }
 
+pub(super) fn coin_from_str(coin: impl AsRef<str>) -> Result<Coin, Error> {
+  Ok(match coin.as_ref().to_uppercase().as_str() {
+    "SRI" => Coin::Serai,
+    "BTC" => Coin::External(ExternalCoin::Bitcoin),
+    "ETH" => Coin::External(ExternalCoin::Ether),
+    "DAI" => Coin::External(ExternalCoin::Dai),
+    "XMR" => Coin::External(ExternalCoin::Monero),
+    _ => Err(Error::InvalidRequest("unrecognized external coin requested"))?,
+  })
+}
+
+pub(super) fn coin(params: &Params) -> Result<Coin, Error> {
+  #[derive(sp_core::serde::Deserialize)]
+  #[serde(crate = "sp_core::serde")]
+  struct Coin {
+    coin: String,
+  }
+
+  let Ok(coin) = params.parse::<Coin>() else {
+    Err(Error::InvalidRequest(r#"missing `string` "coin" field"#))?
+  };
+
+  coin_from_str(coin.coin)
+}
+
 pub(super) fn set(params: &Params) -> Result<ValidatorSet, Error> {
   #[derive(sp_core::serde::Deserialize)]
   #[serde(crate = "sp_core::serde")]

--- a/substrate/primitives/src/dex/mod.rs
+++ b/substrate/primitives/src/dex/mod.rs
@@ -1,3 +1,5 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
 use crate::{
   coin::{ExternalCoin, Coin},
   balance::Amount,
@@ -59,13 +61,15 @@ impl Premise {
 }
 
 /// The reserves for a liquidity pool.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, BorshSerialize, BorshDeserialize)]
 pub struct Reserves {
   /// The amount of SRI already present.
   pub sri: Amount,
   /// The amount of the external coin already present.
   pub external_coin: Amount,
 }
+#[cfg(feature = "scale")]
+crate::borsh_as_scale!(Reserves);
 
 impl Reserves {
   /// The product of two amounts.

--- a/substrate/runtime/src/common.rs
+++ b/substrate/runtime/src/common.rs
@@ -4,7 +4,6 @@ use serai_abi::primitives::{
   network_id::NetworkId,
   validator_sets::{Session, ExternalValidatorSet},
   coin::{Coin, ExternalCoin},
-  dex::Reserves,
   balance::{Amount, Balance},
   address::SeraiAddress,
 };
@@ -79,9 +78,6 @@ sp_api::decl_runtime_apis! {
 
     /// Returns `true` if genesis period is completed, `false` otherwise.
     fn genesis_completed() -> bool;
-
-    /// Total pool reserves for a given coin.
-    fn pool_reserves(coin: ExternalCoin) -> Reserves;
 
     /// Next nonce to be used for this account.
     fn account_nonce(of: SeraiAddress) -> u32;

--- a/substrate/runtime/src/common.rs
+++ b/substrate/runtime/src/common.rs
@@ -82,5 +82,8 @@ sp_api::decl_runtime_apis! {
 
     /// Total pool reserves for a given coin.
     fn pool_reserves(coin: ExternalCoin) -> Reserves;
+
+    /// Next nonce to be used for this account.
+    fn account_nonce(of: SeraiAddress) -> u32;
   }
 }

--- a/substrate/runtime/src/common.rs
+++ b/substrate/runtime/src/common.rs
@@ -3,7 +3,8 @@ use serai_abi::primitives::{
   crypto::{EmbeddedEllipticCurveKeys, SignedEmbeddedEllipticCurveKeys, KeyPair},
   network_id::NetworkId,
   validator_sets::{Session, ExternalValidatorSet},
-  coin::ExternalCoin,
+  coin::{Coin, ExternalCoin},
+  dex::Reserves,
   balance::{Amount, Balance},
   address::SeraiAddress,
 };
@@ -61,5 +62,25 @@ sp_api::decl_runtime_apis! {
       validator: SeraiAddress,
       network: NetworkId,
     ) -> Option<EmbeddedEllipticCurveKeys>;
+
+    /// Coin balance of a given serai account.
+    fn balance(of: SeraiAddress, coin: Coin) -> Amount;
+    /// Liquidity tokens balance of a given serai account for a given coin.
+    fn liquidity_balance(of: SeraiAddress, coin: ExternalCoin) -> Amount;
+    /// Genesis liquidity coin balance of a given serai account.
+    fn genesis_liquidity_balance(of: SeraiAddress, coin: ExternalCoin) -> Amount;
+
+    /// Supply of a coin,
+    fn supply(coin: Coin) -> Amount;
+    /// Liquidity supply of a coin.
+    fn liquidity_supply(coin: ExternalCoin) -> Amount;
+    /// Genesis liquidity supply of a coin.
+    fn genesis_liquidity_supply(coin: ExternalCoin) -> Amount;
+
+    /// Returns `true` if genesis period is completed, `false` otherwise.
+    fn genesis_completed() -> bool;
+
+    /// Total pool reserves for a given coin.
+    fn pool_reserves(coin: ExternalCoin) -> Reserves;
   }
 }

--- a/substrate/runtime/src/std_runtime_api.rs
+++ b/substrate/runtime/src/std_runtime_api.rs
@@ -8,7 +8,6 @@ use serai_abi::{
     network_id::NetworkId,
     validator_sets::{Session, ExternalValidatorSet},
     coin::{Coin, ExternalCoin},
-    dex::Reserves,
     balance::Amount,
     address::SeraiAddress,
   },
@@ -196,10 +195,6 @@ sp_api::impl_runtime_apis! {
     }
 
     fn genesis_completed() -> bool {
-      unimplemented!("runtime is only implemented when WASM")
-    }
-
-    fn pool_reserves(coin:ExternalCoin) -> Reserves {
       unimplemented!("runtime is only implemented when WASM")
     }
 

--- a/substrate/runtime/src/std_runtime_api.rs
+++ b/substrate/runtime/src/std_runtime_api.rs
@@ -7,6 +7,8 @@ use serai_abi::{
     crypto::{KeyPair, EmbeddedEllipticCurveKeys},
     network_id::NetworkId,
     validator_sets::{Session, ExternalValidatorSet},
+    coin::{Coin, ExternalCoin},
+    dex::Reserves,
     balance::Amount,
     address::SeraiAddress,
   },
@@ -170,6 +172,34 @@ sp_api::impl_runtime_apis! {
       validator: SeraiAddress,
       network: NetworkId,
     ) -> Option<EmbeddedEllipticCurveKeys> {
+      unimplemented!("runtime is only implemented when WASM")
+    }
+
+    fn balance(of: SeraiAddress, coin: Coin) -> Amount {
+      unimplemented!("runtime is only implemented when WASM")
+    }
+    fn liquidity_balance(of: SeraiAddress, coin: ExternalCoin) -> Amount {
+      unimplemented!("runtime is only implemented when WASM")
+    }
+    fn genesis_liquidity_balance(of: SeraiAddress, coin: ExternalCoin) -> Amount {
+      unimplemented!("runtime is only implemented when WASM")
+    }
+
+    fn supply(coin: Coin) -> Amount {
+      unimplemented!("runtime is only implemented when WASM")
+    }
+    fn liquidity_supply(coin: ExternalCoin) -> Amount {
+      unimplemented!("runtime is only implemented when WASM")
+    }
+    fn genesis_liquidity_supply(coin: ExternalCoin) -> Amount {
+      unimplemented!("runtime is only implemented when WASM")
+    }
+
+    fn genesis_completed() -> bool {
+      unimplemented!("runtime is only implemented when WASM")
+    }
+
+    fn pool_reserves(coin:ExternalCoin) -> Reserves {
       unimplemented!("runtime is only implemented when WASM")
     }
   }

--- a/substrate/runtime/src/std_runtime_api.rs
+++ b/substrate/runtime/src/std_runtime_api.rs
@@ -202,5 +202,9 @@ sp_api::impl_runtime_apis! {
     fn pool_reserves(coin:ExternalCoin) -> Reserves {
       unimplemented!("runtime is only implemented when WASM")
     }
+
+    fn account_nonce(of: SeraiAddress) -> u32 {
+      unimplemented!("runtime is only implemented when WASM")
+    }
   }
 }

--- a/substrate/runtime/src/wasm/mod.rs
+++ b/substrate/runtime/src/wasm/mod.rs
@@ -22,7 +22,8 @@ use serai_abi::{
     validator_sets::{Session, ExternalValidatorSet, ValidatorSet},
     address::SeraiAddress,
   },
-  SubstrateHeader as Header, SubstrateBlock as Block, LazySubstrateBlock as LazyBlock,
+  TransactionContext as _, SubstrateHeader as Header, SubstrateBlock as Block,
+  LazySubstrateBlock as LazyBlock,
 };
 
 use serai_coins_pallet::{CoinsInstance, LiquidityTokensInstance, GenesisLiquidityTokensInstance};
@@ -538,6 +539,10 @@ sp_api::impl_runtime_apis! {
         sri: Coins::balance(pool, Coin::Serai),
         external_coin: Coins::balance(pool, coin),
       }
+    }
+
+    fn account_nonce(of: SeraiAddress) -> u32 {
+      Core::next_nonce(&of)
     }
   }
 }

--- a/substrate/runtime/src/wasm/mod.rs
+++ b/substrate/runtime/src/wasm/mod.rs
@@ -16,8 +16,9 @@ use serai_abi::{
     constants::*,
     crypto::{Public, EmbeddedEllipticCurveKeys},
     network_id::{ExternalNetworkId, NetworkId},
-    coin::Coin,
+    coin::{Coin, ExternalCoin},
     balance::{Amount, Balance},
+    dex::Reserves,
     validator_sets::{Session, ExternalValidatorSet, ValidatorSet},
     address::SeraiAddress,
   },
@@ -505,6 +506,38 @@ sp_api::impl_runtime_apis! {
       network: NetworkId,
     ) -> Option<EmbeddedEllipticCurveKeys> {
       ValidatorSets::auxiliary_keys(validator, network)
+    }
+
+    fn balance(of: SeraiAddress, coin: Coin) -> Amount {
+      Coins::balance(of, coin)
+    }
+    fn liquidity_balance(of: SeraiAddress, coin: ExternalCoin) -> Amount {
+      LiquidityTokens::balance(of, coin)
+    }
+    fn genesis_liquidity_balance(of: SeraiAddress, coin: ExternalCoin) -> Amount {
+      GenesisLiquidityTokens::balance(of, coin)
+    }
+
+    fn supply(coin: Coin) -> Amount {
+      Coins::supply(coin)
+    }
+    fn liquidity_supply(coin: ExternalCoin) -> Amount {
+      LiquidityTokens::supply(coin)
+    }
+    fn genesis_liquidity_supply(coin: ExternalCoin) -> Amount {
+      GenesisLiquidityTokens::supply(coin)
+    }
+
+    fn genesis_completed() -> bool {
+      GenesisLiquidity::completed()
+    }
+
+    fn pool_reserves(coin: ExternalCoin) -> Reserves {
+      let pool = serai_abi::dex::address(coin);
+      Reserves {
+        sri: Coins::balance(pool, Coin::Serai),
+        external_coin: Coins::balance(pool, coin),
+      }
     }
   }
 }

--- a/substrate/runtime/src/wasm/mod.rs
+++ b/substrate/runtime/src/wasm/mod.rs
@@ -18,7 +18,6 @@ use serai_abi::{
     network_id::{ExternalNetworkId, NetworkId},
     coin::{Coin, ExternalCoin},
     balance::{Amount, Balance},
-    dex::Reserves,
     validator_sets::{Session, ExternalValidatorSet, ValidatorSet},
     address::SeraiAddress,
   },
@@ -531,14 +530,6 @@ sp_api::impl_runtime_apis! {
 
     fn genesis_completed() -> bool {
       GenesisLiquidity::completed()
-    }
-
-    fn pool_reserves(coin: ExternalCoin) -> Reserves {
-      let pool = serai_abi::dex::address(coin);
-      Reserves {
-        sri: Coins::balance(pool, Coin::Serai),
-        external_coin: Coins::balance(pool, coin),
-      }
     }
 
     fn account_nonce(of: SeraiAddress) -> u32 {


### PR DESCRIPTION
This PR adds various RPC endpoints to serai node and support for them to  serai client. Tried to follow existing RPC design but happy to update endpoint, function and/or parameter names as well as the documentation for the said functions as well.


-----------

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

No output from a Large Language Model (LLM) was included within any of the
contribution.

-----------