### PR TITLE
Update contracts re: Prague, Osaka

### DIFF
--- a/.github/actions/build-dependencies/action.yml
+++ b/.github/actions/build-dependencies/action.yml
@@ -53,18 +53,18 @@ runs:
     - name: Install solc
       shell: bash
       run: |
-        cargo +1.95.0 install --locked svm-rs --version =0.5.23
+        cargo +1.95.0 install --locked svm-rs --version =0.5.24
 
         solc_version() {
           # Install the version of `solc` specified in the contracts
           # This also checks the specified version is consistent across contracts
           cat $(find . -name "*.sol") | grep "pragma solidity" | while read -r line; do
-            THIS_SOLC_VERSION=$(printf "%s" "$line" | cut -d'^' -f2 | cut -d';' -f1)
+            THIS_SOLC_VERSION=$(printf "%s" "$line" | cut -d'^' -f2 | cut -d'=' -f2 | cut -d';' -f1)
             if [ "$SOLC_VERSION" = "" ]; then
               SOLC_VERSION="$THIS_SOLC_VERSION"
               echo $SOLC_VERSION
             fi
-            if [ ! "$line" = "pragma solidity ^$SOLC_VERSION;" ]; then
+            if [ ! "$SOLC_VERSION" = "$THIS_SOLC_VERSION" ]; then
               echo "Inconsistent Solidity requirement in \`.sol\` files"
               exit 1
             fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -272,7 +272,7 @@ jobs:
         shell: bash
         run: |
           sudo apt install -y python3-pip
-          python3 -m pip install slither-analyzer==0.11.3
+          python3 -m pip install slither-analyzer==0.11.5
 
           slither ./networks/ethereum/schnorr/contracts/Schnorr.sol
           slither --include-paths ./networks/ethereum/schnorr/contracts ./networks/ethereum/schnorr/contracts/tests/Schnorr.sol

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,13 +30,13 @@ available via your system and the `ROCKSDB_LIB_DIR` environment variable is set
 (optionally along with the `SNAPPY_LIB_DIR` environment variable).
 
 Building the Ethereum smart contracts (and libraries for them) relies on an
-exact version of Solidity, currently `0.8.29`. Our recommended way to install
+exact version of Solidity, currently `0.8.34`. Our recommended way to install
 Solidity is via [`svm-rs`](https://docs.rs/svm-rs) as follows:
 
 ```sh
 cargo install svm-rs
-svm install 0.8.29
-svm use 0.8.29
+svm install 0.8.34
+svm use 0.8.34
 ```
 
 Building the Serai node can be done locally for development purposes. Building

--- a/networks/ethereum/build-contracts/src/lib.rs
+++ b/networks/ethereum/build-contracts/src/lib.rs
@@ -12,7 +12,7 @@ use std::{path::PathBuf, fs, process::Command};
 /// the artifacts within it) are cleaned. If your artifacts are not within your `target` directory,
 /// you should consider any necessary `cargo:rerun-if-changed` directives yourself.
 ///
-/// Requires `solc 0.8.29`.
+/// Requires `solc 0.8.34` and outputs contracts targetting the Osaka network upgrade.
 pub fn build(
   include_paths: &[&str],
   contracts_path: &str,
@@ -42,8 +42,8 @@ pub fn build(
     if let Some(version) = line.strip_prefix("Version: ") {
       let version =
         version.split('+').next().ok_or_else(|| "no value present on line".to_owned())?;
-      if version != "0.8.29" {
-        Err(format!("version was {version}, 0.8.29 required"))?;
+      if version != "0.8.34" {
+        Err(format!("version was {version}, 0.8.34 required"))?;
       }
     }
   }
@@ -51,7 +51,8 @@ pub fn build(
   #[rustfmt::skip]
   let mut args = vec![
     "--base-path", ".",
-    "-o", artifacts_path, "--overwrite",
+    "--output-dir", artifacts_path, "--overwrite",
+    "--evm-version", "osaka",
     "--bin", "--bin-runtime", "--abi",
     "--via-ir", "--optimize",
     "--no-color",

--- a/networks/ethereum/schnorr/contracts/Schnorr.sol
+++ b/networks/ethereum/schnorr/contracts/Schnorr.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.29;
+pragma solidity =0.8.34;
 
 /// @title A library for verifying Schnorr signatures
 /// @author Luke Parker <lukeparker@serai.exchange>

--- a/networks/ethereum/schnorr/contracts/tests/Schnorr.sol
+++ b/networks/ethereum/schnorr/contracts/tests/Schnorr.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.29;
+pragma solidity =0.8.34;
 
 import "../Schnorr.sol";
 

--- a/orchestration/src/processor.rs
+++ b/orchestration/src/processor.rs
@@ -23,8 +23,8 @@ pub fn processor(
       if coin == "ethereum" {
         r#"
 RUN cargo install svm-rs
-RUN svm install 0.8.29
-RUN svm use 0.8.29
+RUN svm install 0.8.34
+RUN svm use 0.8.34
 "#
       } else {
         ""

--- a/processor/ethereum/deployer/contracts/Deployer.sol
+++ b/processor/ethereum/deployer/contracts/Deployer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.29;
+pragma solidity =0.8.34;
 
 /*
   The expected deployment process of Serai's Router is as follows:

--- a/processor/ethereum/deployer/src/lib.rs
+++ b/processor/ethereum/deployer/src/lib.rs
@@ -76,7 +76,7 @@ impl Deployer {
       */
       gas_price: 100_000_000_000u128,
       /*
-        This is twice the cost of deployment as of Ethereum's Cancun upgrade. The wide margin is to
+        This is twice the cost of deployment as of Ethereum's Osaka upgrade. The wide margin is to
         increase the likelihood of surviving changes to the cost of contract deployment (notably
         the gas cost of calldata). While wasteful, this only has to be done once per chain and is
         accepted accordingly.

--- a/processor/ethereum/deployer/src/tests.rs
+++ b/processor/ethereum/deployer/src/tests.rs
@@ -14,10 +14,10 @@ use crate::{
 
 #[tokio::test]
 async fn test_deployer() {
-  const CANCUN: &str = "cancun";
+  const OSAKA: &str = "osaka";
   const LATEST: &str = "latest";
 
-  for network in [CANCUN, LATEST] {
+  for network in [OSAKA, LATEST] {
     let anvil = (if network == LATEST {
       // If this is the latest network, it's inherently defaulted to when `anvil` is spawned
       Anvil::new()
@@ -39,9 +39,9 @@ async fn test_deployer() {
       assert!(receipt.status());
       assert_eq!(receipt.contract_address.unwrap(), Deployer::address());
 
-      if network == CANCUN {
+      if network == OSAKA {
         // Check the gas programmed was twice the gas used
-        // We only check this for cancun as the constant was programmed per cancun's gas pricing
+        // We only check this for Osaka as the constant was programmed per Osaka's gas pricing
         assert_eq!(2 * receipt.gas_used, gas_programmed);
       }
     }

--- a/processor/ethereum/erc20/contracts/IERC20.sol
+++ b/processor/ethereum/erc20/contracts/IERC20.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: CC0
-pragma solidity ^0.8.29;
+// slither-disable-next-line pragma // Checked in CI
+pragma solidity ^0.8.34;
 
 interface IERC20 {
   event Transfer(address indexed from, address indexed to, uint256 value);

--- a/processor/ethereum/router/contracts/IRouter.sol
+++ b/processor/ethereum/router/contracts/IRouter.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.29;
+// slither-disable-next-line pragma // Checked in CI
+pragma solidity ^0.8.34;
 
 /// @title Serai Router (without functions overriden by selector collisions)
 /// @author Luke Parker <lukeparker@serai.exchange>

--- a/processor/ethereum/router/contracts/Router.sol
+++ b/processor/ethereum/router/contracts/Router.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.29;
+pragma solidity =0.8.34;
 
 import "IERC20.sol";
 

--- a/processor/ethereum/router/contracts/tests/CreateAddress.sol
+++ b/processor/ethereum/router/contracts/tests/CreateAddress.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.29;
+pragma solidity =0.8.34;
 
 import "Router.sol";
 

--- a/processor/ethereum/router/contracts/tests/ERC20.sol
+++ b/processor/ethereum/router/contracts/tests/ERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.29;
+pragma solidity =0.8.34;
 
 contract TestERC20 {
   event Transfer(address indexed from, address indexed to, uint256 value);

--- a/processor/ethereum/router/contracts/tests/Reentrancy.sol
+++ b/processor/ethereum/router/contracts/tests/Reentrancy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.29;
+pragma solidity =0.8.34;
 
 import "Router.sol";
 

--- a/processor/ethereum/router/src/gas.rs
+++ b/processor/ethereum/router/src/gas.rs
@@ -33,7 +33,7 @@ use ethereum_schnorr::{PublicKey, Signature};
 use crate::*;
 
 // The specification this uses
-const SPEC_ID: SpecId = SpecId::CANCUN;
+const SPEC_ID: SpecId = SpecId::OSAKA;
 
 // The chain ID used for gas estimation
 const CHAIN_ID: U256 = U256::from_be_slice(&[1]);
@@ -152,7 +152,7 @@ impl Router {
     The gas limits to use for non-Execute transactions.
 
     These don't branch on the success path, allowing constants to be used out-right. These
-    constants target the Cancun network upgrade and are validated by the tests.
+    constants target the Osaka network upgrade and are validated by the tests.
 
     While whoever publishes these transactions may be able to query a gas estimate, it may not be
     reasonable to. If the signing context is a distributed group, as Serai frequently employs, a
@@ -235,7 +235,7 @@ impl Router {
           cfg.chain_id = CHAIN_ID.try_into().unwrap();
         })
         .modify_tx_chained(|tx: &mut TxEnv| {
-          tx.gas_limit = u64::MAX;
+          tx.gas_limit = revm::primitives::eip7825::TX_GAS_LIMIT_CAP;
           tx.kind = self.address.into();
         }),
       WorstCaseCallInspector {
@@ -362,17 +362,18 @@ impl Router {
         0,
         0,
       );
-      assert_eq!(gas.floor_gas, 0);
-      gas.initial_total_gas
+      (gas.initial_total_gas, gas.floor_gas)
     };
-    let mut current_initial_gas = initial_gas(shimmed_fee, abi::Signature::from(&sig));
+    let (mut current_initial_gas, mut floor_gas) =
+      initial_gas(shimmed_fee, abi::Signature::from(&sig));
     // Remove the current initial gas from the transaction's gas
     gas -= current_initial_gas;
     loop {
       // Calculate the would-be fee
-      let fee = fee_per_gas * U256::from(gas + current_initial_gas);
+      let fee = fee_per_gas * U256::from((gas + current_initial_gas).max(floor_gas));
       // Calculate the would-be gas for this fee
-      let new_initial_gas =
+      let new_initial_gas;
+      (new_initial_gas, floor_gas) =
         initial_gas(fee, abi::Signature { c: [0xff; 32].into(), s: [0xff; 32].into() });
       // If the values are equal, or if it went down, return
       /*
@@ -382,7 +383,7 @@ impl Router {
         gas to ensure this algorithm terminates.
       */
       if current_initial_gas >= new_initial_gas {
-        return (gas + new_initial_gas, fee);
+        return ((gas + new_initial_gas).max(floor_gas), fee);
       }
       // Update what the current initial gas is
       current_initial_gas = new_initial_gas;

--- a/processor/ethereum/router/src/tests/create_address.rs
+++ b/processor/ethereum/router/src/tests/create_address.rs
@@ -72,7 +72,7 @@ async fn test_create_address() {
     // Check the function is constant-gas
     let gas_used = test.provider.estimate_gas(call).await.unwrap();
     let initial_gas =
-      calculate_initial_tx_gas(SpecId::CANCUN, &input, false, 0, 0, 0).initial_total_gas;
+      calculate_initial_tx_gas(SpecId::OSAKA, &input, false, 0, 0, 0).initial_total_gas;
     let this_call = gas_used - initial_gas;
     if gas.is_none() {
       gas = Some(this_call);

--- a/processor/ethereum/router/src/tests/mod.rs
+++ b/processor/ethereum/router/src/tests/mod.rs
@@ -78,9 +78,9 @@ impl CalldataAgnosticGas {
       }
     }
     gas_used +
-      (calculate_initial_tx_gas(SpecId::CANCUN, &without_variable_zero_bytes, false, 0, 0, 0)
+      (calculate_initial_tx_gas(SpecId::OSAKA, &without_variable_zero_bytes, false, 0, 0, 0)
         .initial_total_gas -
-        calculate_initial_tx_gas(SpecId::CANCUN, input, false, 0, 0, 0).initial_total_gas)
+        calculate_initial_tx_gas(SpecId::OSAKA, input, false, 0, 0, 0).initial_total_gas)
   }
 }
 
@@ -121,10 +121,10 @@ impl Test {
   }
 
   async fn new() -> Self {
-    // The following is explicitly only evaluated against the cancun network upgrade at this time
+    // The following is explicitly only evaluated against the Osaka network upgrade at this time
     let anvil = Anvil::new()
       .arg("--hardfork")
-      .arg("cancun")
+      .arg("osaka")
       .arg("--tracing")
       .arg("--no-request-size-limit")
       .arg("--disable-block-gas-limit")


### PR DESCRIPTION
The router is updated to handle `floor_gas`, which is the only non-trivial change that affects us.

This adopts `solc 0.8.34`, which is old enough to be considered sufficiently tested, and which includes a bug fix the authors deemed important. The non-interface contracts now explicitly specify this version as required, not allowing compilation with any other version.

`build-solidity-contracts` is updated to specify the EVM it targets.

`slither-analyzer` has its version bumped, as does `svm-rs` which had a release cut but didn't post a release via GitHub, hence why it wasn't updated to earlier.